### PR TITLE
fix: sync package-lock.json versions and add missing blockchain type

### DIFF
--- a/packages/gatekeeper/src/types.ts
+++ b/packages/gatekeeper/src/types.ts
@@ -71,6 +71,7 @@ export interface GatekeeperEvent {
     did?: string;
     opid?: string;
     registration?: DidRegistration;
+    blockchain?: DidRegistration;
 }
 
 export interface GatekeeperDb {

--- a/services/explorer/package-lock.json
+++ b/services/explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "mdip-explorer",
-  "version": "1.3.0",
+  "name": "archon-explorer",
+  "version": "1.4.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mdip-explorer",
-      "version": "1.3.0",
+      "name": "archon-explorer",
+      "version": "1.4.0-beta.5",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/services/gatekeeper/client/package-lock.json
+++ b/services/gatekeeper/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatekeeper-client",
-  "version": "1.1.1",
+  "version": "1.4.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatekeeper-client",
-      "version": "1.1.1",
+      "version": "1.4.0-beta.5",
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",

--- a/services/gatekeeper/server/package-lock.json
+++ b/services/gatekeeper/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatekeeper-server",
-  "version": "1.4.0-beta.2",
+  "version": "1.4.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatekeeper-server",
-      "version": "1.4.0-beta.2",
+      "version": "1.4.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",

--- a/services/keymaster/client/package-lock.json
+++ b/services/keymaster/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "keymaster-client",
-  "version": "1.1.1",
+  "version": "1.4.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "keymaster-client",
-      "version": "1.1.1",
+      "version": "1.4.0-beta.5",
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",

--- a/services/keymaster/server/package-lock.json
+++ b/services/keymaster/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "keymaster-server",
-  "version": "1.3.0",
+  "version": "1.4.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "keymaster-server",
-      "version": "1.3.0",
+      "version": "1.4.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5",

--- a/services/mediators/satoshi-inscription/package-lock.json
+++ b/services/mediators/satoshi-inscription/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inscription-mediator",
-  "version": "1.4.0-beta.2",
+  "version": "1.4.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inscription-mediator",
-      "version": "1.4.0-beta.2",
+      "version": "1.4.0-beta.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/services/mediators/satoshi/package-lock.json
+++ b/services/mediators/satoshi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "satoshi-mediator",
-  "version": "1.4.0-beta.2",
+  "version": "1.4.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "satoshi-mediator",
-      "version": "1.4.0-beta.2",
+      "version": "1.4.0-beta.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/services/search-server/package-lock.json
+++ b/services/search-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "search-server",
-  "version": "1.3.0",
+  "version": "1.4.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "search-server",
-      "version": "1.3.0",
+      "version": "1.4.0-beta.5",
       "dependencies": {
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",


### PR DESCRIPTION
## Summary
- Fixes Docker build failures (`npm ci` and TypeScript compilation errors)
- Syncs `package-lock.json` versions for 8 services to match their `package.json`
- Adds missing `blockchain` property to `GatekeeperEvent` type used by satoshi mediators

## Changes

### package-lock.json version syncs
| Service | Old Version | New Version |
|---------|------------|-------------|
| services/mediators/satoshi | 1.4.0-beta.2 | 1.4.0-beta.5 |
| services/mediators/satoshi-inscription | 1.4.0-beta.2 | 1.4.0-beta.5 |
| services/explorer | 1.3.0 | 1.4.0-beta.5 |
| services/search-server | 1.3.0 | 1.4.0-beta.5 |
| services/gatekeeper/client | 1.1.1 | 1.4.0-beta.5 |
| services/gatekeeper/server | 1.4.0-beta.2 | 1.4.0-beta.5 |
| services/keymaster/client | 1.1.1 | 1.4.0-beta.5 |
| services/keymaster/server | 1.3.0 | 1.4.0-beta.5 |

### Type fix
Added `blockchain?: DidRegistration` to `GatekeeperEvent` interface in `packages/gatekeeper/src/types.ts`

## Test plan
- [x] `docker build -f Dockerfile.satoshi` succeeds
- [x] `docker build -f Dockerfile.satoshi-inscription` succeeds
- [ ] `docker compose build` completes for all services

🤖 Generated with [Claude Code](https://claude.com/claude-code)