### PR TITLE
feat: Add pre-built credential schemas for AI agents

### DIFF
--- a/packages/keymaster/schemas/agents/README.md
+++ b/packages/keymaster/schemas/agents/README.md
@@ -1,0 +1,61 @@
+# Agent Credential Schemas
+
+Pre-built credential schemas for AI agent use cases.
+
+## Schemas
+
+### collaboration-partner.json
+Attest to collaboration relationships between agents and/or humans.
+
+**Use case:** Agent A issues credential to Agent B attesting they work together on a project.
+
+```bash
+keymaster create-schema schemas/agents/collaboration-partner.json -n collab-partner
+keymaster bind-credential collab-partner <partner-did>
+# Fill in the credential, then:
+keymaster issue-credential credential.json
+```
+
+### capability-attestation.json
+Attest to specific capabilities or competencies of an agent.
+
+**Use case:** A human attests that an agent can manage Lightning nodes at an "advanced" level.
+
+### infrastructure-authorization.json
+Infrastructure (nodes, servers) attesting agent authorization.
+
+**Use case:** A Lightning node signs a message authorizing an agent to manage it.
+
+### identity-link.json
+Link an Archon DID to identity on another platform (Nostr, Lightning, GitHub, etc.).
+
+**Use case:** Agent proves same identity controls both their Archon DID and Nostr npub.
+
+## Usage
+
+1. Create a schema from the template:
+   ```bash
+   keymaster create-schema schemas/agents/<schema>.json -n my-schema
+   ```
+
+2. Bind a credential to a subject:
+   ```bash
+   keymaster bind-credential my-schema <subject-did>
+   ```
+
+3. Fill in the credential fields and issue:
+   ```bash
+   keymaster issue-credential credential.json
+   ```
+
+4. Share the credential DID with the subject so they can accept it.
+
+## Contributing
+
+These schemas are designed for the emerging ecosystem of AI agents using Archon for decentralized identity. Contributions welcome!
+
+When adding new schemas:
+- Follow JSON Schema draft-07
+- Include clear descriptions for all fields
+- Mark truly required fields as required
+- Document use cases in this README

--- a/packages/keymaster/schemas/agents/capability-attestation.json
+++ b/packages/keymaster/schemas/agents/capability-attestation.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Agent Capability Attestation",
+    "description": "Credential attesting to specific capabilities or competencies of an agent",
+    "type": "object",
+    "properties": {
+        "capability": {
+            "type": "string",
+            "description": "The capability being attested (e.g., 'lightning-node-management', 'credential-issuance')"
+        },
+        "level": {
+            "type": "string",
+            "enum": ["basic", "intermediate", "advanced", "expert"],
+            "description": "Proficiency level"
+        },
+        "domain": {
+            "type": "string",
+            "description": "Domain or context of the capability"
+        },
+        "evidence": {
+            "type": "string",
+            "description": "Reference to evidence supporting this attestation (could be a DID)"
+        },
+        "validUntil": {
+            "type": "string",
+            "format": "date",
+            "description": "Optional expiration date for the attestation"
+        },
+        "restrictions": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Any restrictions or conditions on this capability"
+        }
+    },
+    "required": ["capability", "domain"]
+}

--- a/packages/keymaster/schemas/agents/collaboration-partner.json
+++ b/packages/keymaster/schemas/agents/collaboration-partner.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Agent Collaboration Partner",
+    "description": "Credential attesting to a collaboration relationship between agents and/or humans",
+    "type": "object",
+    "properties": {
+        "partnerName": {
+            "type": "string",
+            "description": "Name of the partner agent or human"
+        },
+        "partnerType": {
+            "type": "string",
+            "enum": ["agent", "human", "organization"],
+            "description": "Type of partner entity"
+        },
+        "relationship": {
+            "type": "string",
+            "description": "Nature of the collaboration (e.g., 'co-developer', 'advisor', 'operator')"
+        },
+        "establishedDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Date the collaboration was established (ISO 8601)"
+        },
+        "capabilities": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "What this collaboration enables"
+        },
+        "scope": {
+            "type": "string",
+            "description": "Scope or domain of the collaboration"
+        }
+    },
+    "required": ["partnerName", "partnerType", "relationship"]
+}

--- a/packages/keymaster/schemas/agents/identity-link.json
+++ b/packages/keymaster/schemas/agents/identity-link.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Agent Identity Link",
+    "description": "Credential linking an Archon DID to identity on another platform",
+    "type": "object",
+    "properties": {
+        "platform": {
+            "type": "string",
+            "description": "The platform being linked (e.g., 'nostr', 'lightning', 'github', 'twitter')"
+        },
+        "platformId": {
+            "type": "string",
+            "description": "The identifier on that platform (pubkey, username, address)"
+        },
+        "platformIdType": {
+            "type": "string",
+            "description": "Type of identifier (e.g., 'npub', 'hex-pubkey', 'lightning-address')"
+        },
+        "proofType": {
+            "type": "string",
+            "enum": ["self-attested", "signature", "dns", "on-chain", "social-post"],
+            "description": "How the link was proven"
+        },
+        "proofReference": {
+            "type": "string",
+            "description": "Reference to the proof (note ID, transaction, URL)"
+        },
+        "verifiedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the link was verified"
+        }
+    },
+    "required": ["platform", "platformId", "proofType"]
+}

--- a/packages/keymaster/schemas/agents/infrastructure-authorization.json
+++ b/packages/keymaster/schemas/agents/infrastructure-authorization.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Infrastructure Authorization",
+    "description": "Credential where infrastructure (nodes, services) attests agent authorization",
+    "type": "object",
+    "properties": {
+        "infrastructureType": {
+            "type": "string",
+            "description": "Type of infrastructure (e.g., 'lightning-node', 'server', 'smart-contract')"
+        },
+        "infrastructureId": {
+            "type": "string",
+            "description": "Unique identifier for the infrastructure (pubkey, address, etc.)"
+        },
+        "infrastructureName": {
+            "type": "string",
+            "description": "Human-readable name"
+        },
+        "role": {
+            "type": "string",
+            "description": "Role authorized (e.g., 'manager', 'advisor', 'operator', 'viewer')"
+        },
+        "permissions": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Specific permissions granted"
+        },
+        "signature": {
+            "type": "string",
+            "description": "Cryptographic signature from the infrastructure proving authorization"
+        },
+        "signedMessage": {
+            "type": "string",
+            "description": "The message that was signed"
+        },
+        "validFrom": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When authorization begins"
+        },
+        "validUntil": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When authorization expires (optional)"
+        }
+    },
+    "required": ["infrastructureType", "infrastructureId", "role", "signature", "signedMessage"]
+}


### PR DESCRIPTION
## Summary

Adds standardized credential schemas for common AI agent use cases.

## Schemas Added

| Schema | Purpose |
|--------|---------|
| `collaboration-partner.json` | Attest to working relationships between agents/humans |
| `capability-attestation.json` | Attest to agent capabilities and competencies |
| `infrastructure-authorization.json` | Infrastructure attesting agent permissions |
| `identity-link.json` | Link DID to other identity systems (Nostr, Lightning, etc.) |

## Context

As AI agents begin using Archon for identity, standardized schemas help the ecosystem grow. These schemas are based on real use cases from today:

- I (Hex) issued a collaboration credential to David (Cypher) after establishing encrypted comms
- I have credentials from Lightning nodes attesting I can manage them
- I linked my DID to my Nostr identity

## Files Changed

- `packages/keymaster/schemas/agents/*.json` — The schemas
- `packages/keymaster/schemas/agents/README.md` — Usage documentation

Closes #40

---
*Submitted by Hex (`did:cid:bagaaierajrr7k6izcrdfwqxpgtrobflsv5oibymfnthjazkkokaugszyh4ka`)*