### PR TITLE
feat: Allow any URI as credentialSubject.id per W3C VC Data Model v2

### DIFF
--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -1765,7 +1765,7 @@ export default class Keymaster implements KeymasterInterface {
         const signed = await this.addProof(credential);
         const subjectId = credential.credentialSubject!.id;
 
-        if (this.isDID(subjectId)) {
+        if (this.isManagedDID(subjectId)) {
             return this.encryptJSON(signed, subjectId, { ...options, includeHash: true });
         }
 
@@ -1784,7 +1784,7 @@ export default class Keymaster implements KeymasterInterface {
 
         const subjectId = vc.credentialSubject!.id;
 
-        if (!this.isDID(subjectId)) {
+        if (!this.isManagedDID(subjectId)) {
             return null;
         }
 
@@ -1799,8 +1799,8 @@ export default class Keymaster implements KeymasterInterface {
         return this.createNotice(message, { registry, validUntil, ...options });
     }
 
-    private isDID(value: string): boolean {
-        return value.startsWith('did:');
+    private isManagedDID(value: string): boolean {
+        return value.startsWith('did:cid:');
     }
 
     private isVerifiableCredential(obj: unknown): obj is VerifiableCredential {
@@ -1843,7 +1843,7 @@ export default class Keymaster implements KeymasterInterface {
         const msgHash = this.cipher.hashMessage(msg);
         let encrypted: EncryptedMessage;
 
-        if (this.isDID(holder)) {
+        if (this.isManagedDID(holder)) {
             const holderDoc = await this.resolveDID(holder, { confirm: true });
             const receivePublicJwk = this.getPublicKeyJwk(holderDoc);
             encrypted = {

--- a/tests/keymaster/credential.test.ts
+++ b/tests/keymaster/credential.test.ts
@@ -730,7 +730,7 @@ describe('acceptCredential', () => {
     });
 });
 
-describe('non-DID credentialSubject', () => {
+describe('external credentialSubject', () => {
     it('should bind credential with mailto: URI subject', async () => {
         await keymaster.createId('Alice');
 
@@ -826,5 +826,20 @@ describe('non-DID credentialSubject', () => {
 
         const issued = await keymaster.listIssued();
         expect(issued).toContain(did);
+    });
+
+    it('should issue credential with did:key subject (non-secp256k1)', async () => {
+        await keymaster.createId('Alice');
+
+        const credentialDid = await keymaster.createSchema(mockSchema);
+        const didKey = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
+        const boundCredential = await keymaster.bindCredential(didKey, { schema: credentialDid });
+
+        expect(boundCredential.credentialSubject.id).toBe(didKey);
+
+        const did = await keymaster.issueCredential(boundCredential);
+        const credential = await keymaster.getCredential(did);
+        expect(credential).not.toBeNull();
+        expect(credential!.credentialSubject!.id).toBe(didKey);
     });
 });


### PR DESCRIPTION
Non-DID subjects (mailto:, https:, etc.) are now supported. When the subject isn't a DID, credentials are encrypted only for the issuer.