### PR TITLE
fix: Allow create-id to auto-create wallet (#102)

### DIFF
--- a/packages/keymaster/src/cli.ts
+++ b/packages/keymaster/src/cli.ts
@@ -1698,7 +1698,7 @@ async function run() {
         const cipher = new CipherNode();
 
         // For commands that need an existing wallet, verify it exists
-        const walletCreationCommands = ['create-wallet', 'new-wallet', 'import-wallet', 'restore-wallet-file'];
+        const walletCreationCommands = ['create-wallet', 'new-wallet', 'create-id', 'import-wallet', 'restore-wallet-file'];
         const commandName = process.argv[2];
         if (commandName && !walletCreationCommands.includes(commandName)) {
             const existing = await wallet.loadWallet();


### PR DESCRIPTION
The wallet existence check added in #53 blocked create-id from auto-creating the wallet via loadWallet → newWallet.