### PR TITLE
fix: Explorer DID version history not showing

### DIFF
--- a/services/explorer/src/components/JsonViewer.tsx
+++ b/services/explorer/src/components/JsonViewer.tsx
@@ -74,7 +74,7 @@ function JsonViewer(
             }
             setAliasDocs(docs);
 
-            const versions = docs.didDocumentMetadata.version ?? 1;
+            const versions = parseInt(docs.didDocumentMetadata.versionSequence ?? "1", 10);
             if (versions) {
                 setAliasDocsVersion(versions);
                 setAliasDocsVersionMax(versions);


### PR DESCRIPTION
## Summary
- Explorer showed only 1 version for DIDs that have multiple versions
- Root cause: Explorer uses the gatekeeper client which returns `versionSequence` (string), but the code looked for `version` (only added by keymaster)
- Fix: use `versionSequence` and parse it to an integer

Fixes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)