### PR TITLE
feat: V2 groups — promote name, add version field (#109)

### DIFF
--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -76,6 +76,11 @@ export interface Group {
     members: string[];
 }
 
+export interface GroupData {
+    version: 2;
+    members: string[];
+}
+
 export interface CredentialSchema {
     id: string;
     type: "JsonSchema";


### PR DESCRIPTION
New storage format: { name, group: { version: 2, members } } Old formats (V0 raw, V1 wrapped) are auto-upgraded on first read.