### PR TITLE
fix: Make /dids/export unrestricted (#137)

### DIFF
--- a/services/gatekeeper/server/src/gatekeeper-api.ts
+++ b/services/gatekeeper/server/src/gatekeeper-api.ts
@@ -1021,7 +1021,7 @@ v1router.post('/dids/remove', requireAdminKey, async (req, res) => {
  *             schema:
  *               type: string
  */
-v1router.post('/dids/export', requireAdminKey, async (req, res) => {
+v1router.post('/dids/export', async (req, res) => {
     try {
         const { dids } = req.body;
         const response = await gatekeeper.exportDIDs(dids);


### PR DESCRIPTION
## Summary
- Remove `requireAdminKey` from `/dids/export` route — DID event history is public data
- `getDIDs` is already unrestricted, so `exportDIDs` should be consistent
- Fixes Explorer 401 error without needing server-side API key injection

Fixes #137

## Test plan
- [x] Verify Explorer loads without 401 on `/dids/export`
- [x] Verify other admin routes remain protected

🤖 Generated with [Claude Code](https://claude.com/claude-code)