### PR TITLE
Default L402 to disabled (opt-in)

### DIFF
--- a/services/drawbridge/server/src/config.ts
+++ b/services/drawbridge/server/src/config.ts
@@ -9,7 +9,7 @@ const config = {
     adminApiKey: process.env.ARCHON_ADMIN_API_KEY || '',
 
     // Lightning / L402
-    l402Enabled: process.env.ARCHON_DRAWBRIDGE_L402_ENABLED !== 'false',
+    l402Enabled: process.env.ARCHON_DRAWBRIDGE_L402_ENABLED === 'true',
     clnRestUrl: process.env.ARCHON_DRAWBRIDGE_CLN_REST_URL || 'http://localhost:3001',
     clnRune: process.env.ARCHON_DRAWBRIDGE_CLN_RUNE || '',
     macaroonSecret: process.env.ARCHON_DRAWBRIDGE_MACAROON_SECRET || '',


### PR DESCRIPTION
## Summary
- Change `ARCHON_DRAWBRIDGE_L402_ENABLED` default from `true` to `false`
- L402 gating is now opt-in: must explicitly set `ARCHON_DRAWBRIDGE_L402_ENABLED=true`

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)