### PR TITLE
chore: Initialize v0.5

### DIFF
--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archon-chrome-extension",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Archon Chrome Extension",
   "main": "index.js",
   "scripts": {

--- a/apps/react-wallet/package.json
+++ b/apps/react-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/react-wallet",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Archon Android Demo",
   "scripts": {
     "dev": "vite",

--- a/doc/gatekeeper-api.json
+++ b/doc/gatekeeper-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Gatekeeper API",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Documentation for Keymaster API"
   },
   "paths": {

--- a/doc/keymaster-api.json
+++ b/doc/keymaster-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Keymaster API",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Documentation for Keymaster API"
   },
   "paths": {
@@ -2320,6 +2320,127 @@
           },
           "400": {
             "description": "Error decoding invoice."
+          }
+        }
+      }
+    },
+    "/lightning/publish": {
+      "post": {
+        "summary": "Publish Lightning service endpoint for a DID.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Lightning published successfully."
+          },
+          "400": {
+            "description": "Error publishing Lightning."
+          }
+        }
+      }
+    },
+    "/lightning/unpublish": {
+      "post": {
+        "summary": "Unpublish Lightning service endpoint for a DID.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Lightning unpublished successfully."
+          },
+          "400": {
+            "description": "Error unpublishing Lightning."
+          }
+        }
+      }
+    },
+    "/lightning/zap": {
+      "post": {
+        "summary": "Send sats to a DID via Lightning.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "did": {
+                    "type": "string"
+                  },
+                  "amount": {
+                    "type": "integer"
+                  },
+                  "memo": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Payment result with preimage."
+          },
+          "400": {
+            "description": "Error sending payment."
+          }
+        }
+      }
+    },
+    "/lightning/payments": {
+      "post": {
+        "summary": "Get Lightning payment history.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "List of payments."
+          },
+          "400": {
+            "description": "Error fetching payments."
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archon",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "description": "Self-sovereign identity infrastructure for the decentralized web",
   "private": true,

--- a/services/drawbridge/server/package.json
+++ b/services/drawbridge/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drawbridge-server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "description": "Archon Drawbridge L402 API Gateway",
   "main": "dist/drawbridge-api.js",

--- a/services/explorer/package.json
+++ b/services/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archon-explorer",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "start": "npm run build && node server.js",

--- a/services/gatekeeper/client/package.json
+++ b/services/gatekeeper/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatekeeper-client",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.0",

--- a/services/gatekeeper/server/package.json
+++ b/services/gatekeeper/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatekeeper-server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "description": "Archon Gatekeeper REST API server",
   "main": "src/index.js",

--- a/services/keymaster/client/package.json
+++ b/services/keymaster/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymaster-client",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.0",

--- a/services/keymaster/server/package.json
+++ b/services/keymaster/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymaster-server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "description": "Archon Keymaster REST API server",
   "main": "src/index.js",

--- a/services/mediators/hyperswarm/package.json
+++ b/services/mediators/hyperswarm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswarm-mediator",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "description": "Archon hyperswarm network mediator",
   "main": "src/index.js",

--- a/services/mediators/satoshi/package.json
+++ b/services/mediators/satoshi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satoshi-mediator",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "description": "Archon satoshi blockchain mediator",
   "main": "src/index.js",

--- a/swaggerConf.js
+++ b/swaggerConf.js
@@ -5,7 +5,7 @@ const baseDefinition = {
     openapi: '3.0.0',
     info: {
         title: 'Keymaster API',
-        version: '0.4.0',
+        version: '0.5.0',
         description: 'Documentation for Keymaster API'
     },
 };


### PR DESCRIPTION
## Summary
- Bump all services, apps, and API specs from 0.4.0 to 0.5.0
- Regenerate OpenAPI specs with updated version

## Files bumped
- Root `package.json`
- `apps/chrome-extension`, `apps/react-wallet`
- `services/gatekeeper` (client + server), `services/keymaster` (client + server)
- `services/drawbridge/server`, `services/explorer`
- `services/mediators/hyperswarm`, `services/mediators/satoshi`
- `swaggerConf.js`, `doc/gatekeeper-api.json`, `doc/keymaster-api.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)