### PR TITLE
fix: Persist Tor hidden service key across container recreates

### DIFF
--- a/docker-compose.lightning.yml
+++ b/docker-compose.lightning.yml
@@ -20,6 +20,7 @@ services:
       - LOG_LEVEL=${ARCHON_CLN_LOG_LEVEL:-info}
     volumes:
       - ./data/cln-mainnet:/data/lightning
+      - ./data/cln-mainnet/tor:/var/lib/tor
     networks:
       default:
         aliases:
@@ -221,3 +222,4 @@ services:
         condition: service_completed_successfully
       cln-mainnet-node:
         condition: service_started
+


### PR DESCRIPTION
## Summary
- Add `./data/cln-mainnet/tor:/var/lib/tor` bind mount to `cln-mainnet-node` in `docker-compose.lightning.yml`
- Without this, recreating the container generates a new `.onion` address, breaking published Lightning endpoints

## Test plan
- [x] Verified onion address survives `docker compose up -d --force-recreate cln-mainnet-node`
- [x] Tor keys persist in `./data/cln-mainnet/tor/cln-service/`

Fixes #187
Related: archetech/cl-hive#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)