### PR TITLE
Fix Vite client build-time env vars

### DIFF
--- a/Dockerfile.gatekeeper-client
+++ b/Dockerfile.gatekeeper-client
@@ -17,10 +17,14 @@ COPY apps/gatekeeper-client ./apps/gatekeeper-client/
 WORKDIR /app/apps/gatekeeper-client
 
 RUN npm ci
-RUN npm run build
 
 ARG GIT_COMMIT=unknown
 ENV GIT_COMMIT=$GIT_COMMIT
+
+ARG VITE_GATEKEEPER_URL=http://localhost:4224
+ENV VITE_GATEKEEPER_URL=$VITE_GATEKEEPER_URL
+
+RUN npm run build
 
 ENV VITE_PORT=4225
 EXPOSE 4225

--- a/Dockerfile.keymaster-client
+++ b/Dockerfile.keymaster-client
@@ -17,10 +17,14 @@ COPY apps/keymaster-client ./apps/keymaster-client/
 WORKDIR /app/apps/keymaster-client
 
 RUN npm ci
-RUN npm run build
 
 ARG GIT_COMMIT=unknown
 ENV GIT_COMMIT=$GIT_COMMIT
+
+ARG VITE_KEYMASTER_URL=http://localhost:4226
+ENV VITE_KEYMASTER_URL=$VITE_KEYMASTER_URL
+
+RUN npm run build
 
 ENV VITE_PORT=4227
 EXPOSE 4227

--- a/docker-compose.drawbridge.yml
+++ b/docker-compose.drawbridge.yml
@@ -44,10 +44,10 @@ services:
       dockerfile: Dockerfile.gatekeeper-client
       args:
         GIT_COMMIT: ${GIT_COMMIT:-unknown}
-    image: ghcr.io/archetech/gatekeeper-client
+        VITE_GATEKEEPER_URL: http://localhost:${ARCHON_DRAWBRIDGE_PORT:-4222}
+    image: ghcr.io/archetech/drawbridge-client
     environment:
       - VITE_PORT=4223
-      - VITE_GATEKEEPER_URL=http://drawbridge:4222
     user: "${ARCHON_UID}:${ARCHON_GID}"
     ports:
       - "${ARCHON_DRAWBRIDGE_CLIENT_PORT:-4223}:4223"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,10 +163,10 @@ services:
       dockerfile: Dockerfile.gatekeeper-client
       args:
         GIT_COMMIT: ${GIT_COMMIT:-unknown}
+        VITE_GATEKEEPER_URL: http://localhost:${ARCHON_GATEKEEPER_PORT:-4224}
     image: ghcr.io/archetech/gatekeeper-client
     environment:
       - VITE_PORT=4225
-      - VITE_GATEKEEPER_URL=http://gatekeeper:4224
     user: "${ARCHON_UID}:${ARCHON_GID}"
     ports:
       - "${ARCHON_GATEKEEPER_CLIENT_PORT:-4225}:4225"
@@ -179,10 +179,10 @@ services:
       dockerfile: Dockerfile.keymaster-client
       args:
         GIT_COMMIT: ${GIT_COMMIT:-unknown}
+        VITE_KEYMASTER_URL: http://localhost:${ARCHON_KEYMASTER_PORT:-4226}
     image: ghcr.io/archetech/keymaster-client
     environment:
       - VITE_PORT=4227
-      - VITE_KEYMASTER_URL=http://keymaster:4226
     user: "${ARCHON_UID}:${ARCHON_GID}"
     ports:
       - "${ARCHON_KEYMASTER_CLIENT_PORT:-4227}:4227"


### PR DESCRIPTION
## Summary
- Move `VITE_*_URL` from compose `environment:` to `build.args:` so they're baked into the Vite bundle at build time
- Reorder Dockerfiles to set build args before `npm run build`
- Give drawbridge-client its own image tag (`ghcr.io/archetech/drawbridge-client`)

## Test plan
- [x] Rebuild gatekeeper-client, verify it connects to gatekeeper on port 4224
- [x] Rebuild drawbridge-client, verify it connects to drawbridge on port 4222 and shows Lightning tab
- [x] Rebuild keymaster-client, verify it connects to keymaster on port 4226

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)