### PR TITLE
Remove version footer from web clients

### DIFF
--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -6578,20 +6578,6 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                     />
                 </Box>
             </header>
-            <Box
-                component="footer"
-                sx={{
-                    mt: 2,
-                    py: 1,
-                    px: 2,
-                    opacity: 0.6,
-                    fontSize: '0.75rem',
-                }}
-            >
-                <Typography variant="caption">
-                    Client v{packageJson.version} | Server v{serverVersion || '...'}
-                </Typography>
-            </Box>
         </div >
     );
 }

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -6578,20 +6578,6 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                     />
                 </Box>
             </header>
-            <Box
-                component="footer"
-                sx={{
-                    mt: 2,
-                    py: 1,
-                    px: 2,
-                    opacity: 0.6,
-                    fontSize: '0.75rem',
-                }}
-            >
-                <Typography variant="caption">
-                    Client v{packageJson.version} | Server v{serverVersion || '...'}
-                </Typography>
-            </Box>
         </div >
     );
 }


### PR DESCRIPTION
## Summary
- Remove the version footer from gatekeeper-client and keymaster-client
- Version info is already available in the Settings tab

Closes #213

## Test plan
- [ ] Verify footer no longer appears in gatekeeper-client
- [ ] Verify footer no longer appears in keymaster-client
- [ ] Verify version info still shows in Settings tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)