### PR TITLE
chore: Upgrade Kubo to v0.40.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - 127.0.0.1:6379:6379
 
   ipfs:
-    image: ipfs/kubo:v0.39.0
+    image: ipfs/kubo:v0.40.1
     ports:
       - 4001:4001
       - 4001:4001/udp


### PR DESCRIPTION
## Summary
- Upgrade IPFS Kubo from v0.39.0 to v0.40.1

Closes #216

## Test plan
- [x] Verify IPFS node starts and syncs
- [x] Verify DID operations (create, resolve) work

🤖 Generated with [Claude Code](https://claude.com/claude-code)