### PR TITLE
fix: Filter unpaid invoices from lightning payments

### DIFF
--- a/services/drawbridge/server/src/lnbits.ts
+++ b/services/drawbridge/server/src/lnbits.ts
@@ -102,7 +102,7 @@ export async function getPayments(
             headers: { 'X-Api-Key': adminKey },
         });
         return (response.data || [])
-            .filter((p: any) => p.pending !== true)
+            .filter((p: any) => p.status === 'success')
             .map((p: any) => ({
                 paymentHash: p.payment_hash || p.checking_id || '',
                 amount: Math.floor((p.amount || 0) / 1000),


### PR DESCRIPTION
## Summary
- Filter out pending/unpaid invoices in `lnbits.getPayments()` so the Payments tab only shows settled transactions

Closes #223

## Test plan
- [x] Verify Payments tab no longer shows unpaid invoices
- [x] Verify paid incoming and outgoing transactions still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)