### PR TITLE
fix: Support archon:// protocol handler in Firefox

### DIFF
--- a/apps/browser-extension/src/background/background.ts
+++ b/apps/browser-extension/src/background/background.ts
@@ -78,18 +78,34 @@ chrome.runtime.onStartup.addListener(async () => {
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.action === "REQUEST_POPUP_CREDENTIAL" || message.action === "OPEN_CREDENTIAL_TAB") {
-        chrome.action.openPopup(() => {
+        chrome.action.openPopup().then(() => {
             chrome.runtime.sendMessage({
                 action: "SHOW_POPUP_CREDENTIAL",
                 credential: message.credential,
             });
+        }).catch(() => {
+            const credentialEncoded = encodeURIComponent(JSON.stringify(message.credential));
+            chrome.windows.create({
+                url: chrome.runtime.getURL(`popup.html?credential=${credentialEncoded}`),
+                type: "popup",
+                width: 500,
+                height: 600,
+            });
         });
         sendResponse({ success: true });
     } else if (message.action === "REQUEST_POPUP_AUTH" || message.action === "OPEN_AUTH_TAB") {
-        chrome.action.openPopup(() => {
+        chrome.action.openPopup().then(() => {
             chrome.runtime.sendMessage({
                 action: "SHOW_POPUP_AUTH",
                 challenge: message.challenge,
+            });
+        }).catch(() => {
+            const challengeEncoded = encodeURIComponent(message.challenge);
+            chrome.windows.create({
+                url: chrome.runtime.getURL(`popup.html?challenge=${challengeEncoded}`),
+                type: "popup",
+                width: 500,
+                height: 600,
             });
         });
         sendResponse({ success: true });

--- a/apps/browser-extension/src/popup.tsx
+++ b/apps/browser-extension/src/popup.tsx
@@ -8,13 +8,17 @@ import "./static/extension.css";
 const params = new URLSearchParams(window.location.search);
 const nostrRequestId = params.get("nostrRequest");
 const nostrAutoApprove = params.get("autoApprove") === "true";
+const urlChallenge = params.get("challenge") || "";
+const urlCredential = params.get("credential");
 
 const PopupUI = () => {
-    const [pendingAuth, setPendingAuth] = useState<string>("");
-    const [pendingCredential, setPendingCredential] = useState<string>("");
+    const [pendingAuth, setPendingAuth] = useState<string>(urlChallenge);
+    const [pendingCredential, setPendingCredential] = useState<string>(
+        urlCredential ? JSON.parse(decodeURIComponent(urlCredential)) : ""
+    );
 
     useEffect(() => {
-        if (nostrRequestId) {
+        if (nostrRequestId || urlChallenge || urlCredential) {
             return;
         }
         const handleMessage = (


### PR DESCRIPTION
## Summary
- Fix `archon://auth?challenge=...` links in Firefox extension
- `chrome.action.openPopup()` requires a user gesture in Firefox, so fall back to `chrome.windows.create()` with URL params
- Chrome continues to use `openPopup()` as before
- Popup reads `challenge` and `credential` from URL params for the fallback path

Closes #220

## Test plan
- [x] Click `archon://auth?challenge=...` link in Chrome — opens extension popup
- [x] Click `archon://auth?challenge=...` link in Firefox — opens popup window
- [x] Verify credential links work in both browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)