### PR TITLE
fix: Set default production Gatekeeper URL for Android APK

### DIFF
--- a/apps/react-wallet/.env.production
+++ b/apps/react-wallet/.env.production
@@ -1,0 +1,1 @@
+VITE_GATEKEEPER_URL=https://archon.technology

--- a/apps/react-wallet/.env.production.example
+++ b/apps/react-wallet/.env.production.example
@@ -1,5 +1,4 @@
-# Copy this file to .env.production and customize per environment.
+# Override production defaults with .env.production.local (gitignored).
 # Vite exposes only variables prefixed with VITE_.
 
-VITE_GATEKEEPER_URL=https://gatekeeper.archetech.com
-VITE_SEARCH_URL=https://search.archetech.com
+VITE_GATEKEEPER_URL=https://archon.technology

--- a/apps/react-wallet/.gitignore
+++ b/apps/react-wallet/.gitignore
@@ -2,6 +2,5 @@ android/.gradle/
 android/build/
 android/app/build/
 
-.env.production
 .env.production.local
 

--- a/apps/react-wallet/src/contexts/WalletProvider.tsx
+++ b/apps/react-wallet/src/contexts/WalletProvider.tsx
@@ -104,8 +104,12 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     async function initialiseServices() {
         const gatekeeperUrl = localStorage.getItem(GATEKEEPER_KEY) || DEFAULT_GATEKEEPER_URL;
         localStorage.setItem(GATEKEEPER_KEY, gatekeeperUrl);
-        await gatekeeper.connect({ url: gatekeeperUrl });
-        setHasLightning(await gatekeeper.isLightningSupported());
+        try {
+            await gatekeeper.connect({ url: gatekeeperUrl });
+            setHasLightning(await gatekeeper.isLightningSupported());
+        } catch (error) {
+            console.error('Failed to connect to gatekeeper:', error);
+        }
     }
 
     const buildKeymaster = async (wallet: WalletBase, passphrase: string) => {


### PR DESCRIPTION
## Summary
- Commit `.env.production` with `VITE_GATEKEEPER_URL=https://archon.technology` so production builds have a working default
- Wrap `initialiseServices` in try/catch so the app renders even when gatekeeper is unreachable (users can change URL in Settings)
- Remove `.env.production` from `.gitignore` (not a secret, needed in CI)
- Update `.env.production.example` to match

Closes #180

## Test plan
- [x] Manual Android debug APK build on branch — tested OK
- [x] Install APK on physical device and verify it connects to https://archon.technology
- [ ] Verify Settings tab is accessible when gatekeeper is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)