### PR TITLE
Align aliases UI across clients

### DIFF
--- a/apps/browser-extension/src/components/AliasedDIDs.tsx
+++ b/apps/browser-extension/src/components/AliasedDIDs.tsx
@@ -446,7 +446,7 @@ function AliasedDIDs() {
                     style={{ flex: "0 0 150px" }}
                     slotProps={{
                         htmlInput: {
-                            maxLength: 40,
+                            maxLength: 32,
                         },
                     }}
                 />

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -1323,16 +1323,23 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         try {
             const trimmedName = name.trim();
             const docs = await keymaster.resolveDID(trimmedName);
+            const did = docs.didDocument?.id;
+            const data = docs.didDocumentData || {};
+            const resolvedName = typeof data.name === 'string' ? data.name : '';
+            if (!did) {
+                showError(`Unable to resolve DID document for "${trimmedName}".`);
+                return;
+            }
             setSelectedName(trimmedName);
             if (alias.trim()) {
-                setAliasDID(docs.didDocument.id);
+                setAliasDID(did);
             }
-            else if (docs.didDocumentData?.name) {
-                setAlias(docs.didDocumentData.name);
+            else if (resolvedName) {
+                setAlias(resolvedName);
             }
             setAliasIsOwned(!!docs.didDocumentMetadata?.isOwned);
             setAliasDocs(JSON.stringify(docs, null, 4));
-            const versions = docs.didDocumentMetadata.version ?? 1;
+            const versions = docs.didDocumentMetadata?.version ?? 1;
             setAliasDocsVersion(versions);
             setAliasDocsVersionMax(versions);
         } catch (error) {
@@ -3983,7 +3990,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                     fullWidth
                                                     value={alias}
                                                     onChange={(e) => setAlias(e.target.value)}
-                                                    inputProps={{ maxLength: 40 }}
+                                                    inputProps={{ maxLength: 32 }}
                                                 />
                                             </TableCell>
                                             <TableCell style={{ borderBottom: 'none' }}>

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -1323,16 +1323,23 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         try {
             const trimmedName = name.trim();
             const docs = await keymaster.resolveDID(trimmedName);
+            const did = docs.didDocument?.id;
+            const data = docs.didDocumentData || {};
+            const resolvedName = typeof data.name === 'string' ? data.name : '';
+            if (!did) {
+                showError(`Unable to resolve DID document for "${trimmedName}".`);
+                return;
+            }
             setSelectedName(trimmedName);
             if (alias.trim()) {
-                setAliasDID(docs.didDocument.id);
+                setAliasDID(did);
             }
-            else if (docs.didDocumentData?.name) {
-                setAlias(docs.didDocumentData.name);
+            else if (resolvedName) {
+                setAlias(resolvedName);
             }
             setAliasIsOwned(!!docs.didDocumentMetadata?.isOwned);
             setAliasDocs(JSON.stringify(docs, null, 4));
-            const versions = docs.didDocumentMetadata.version ?? 1;
+            const versions = docs.didDocumentMetadata?.version ?? 1;
             setAliasDocsVersion(versions);
             setAliasDocsVersionMax(versions);
         } catch (error) {
@@ -3983,7 +3990,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                     fullWidth
                                                     value={alias}
                                                     onChange={(e) => setAlias(e.target.value)}
-                                                    inputProps={{ maxLength: 40 }}
+                                                    inputProps={{ maxLength: 32 }}
                                                 />
                                             </TableCell>
                                             <TableCell style={{ borderBottom: 'none' }}>

--- a/apps/react-wallet/src/components/AliasedDIDs.tsx
+++ b/apps/react-wallet/src/components/AliasedDIDs.tsx
@@ -453,7 +453,7 @@ function AliasedDIDs() {
                     style={{ flex: "0 0 150px" }}
                     slotProps={{
                         htmlInput: {
-                            maxLength: 40,
+                            maxLength: 32,
                         },
                     }}
                 />


### PR DESCRIPTION
## Summary
- rename the names tab and related labels to aliases in the gatekeeper and keymaster clients
- align alias resolve and clear-field behavior across gatekeeper, keymaster, react-wallet, and browser-extension
- keep alias input validation aligned with Keymaster by capping client-side alias length at 32
- harden alias resolution handling when a DID document or resolved name is missing

## Testing
- npx tsc -p apps/browser-extension/tsconfig.json --noEmit
- npx tsc -p apps/react-wallet/tsconfig.json --noEmit