### PR TITLE
Proxy Herald well-known routes through Drawbridge

### DIFF
--- a/services/drawbridge/server/src/drawbridge-api.ts
+++ b/services/drawbridge/server/src/drawbridge-api.ts
@@ -221,7 +221,7 @@ async function main() {
 
     // Middleware
     app.use((req, res, next) => {
-        if (req.path.startsWith('/names') || req.path.startsWith('/.well-known/names')) {
+        if (req.path.startsWith('/names') || req.path.startsWith('/.well-known')) {
             return heraldCors(req, res, next);
         }
 
@@ -924,7 +924,7 @@ async function main() {
         }
     });
 
-    app.use('/.well-known/names', async (req, res) => {
+    app.use('/.well-known', async (req, res) => {
         try {
             await proxyHeraldRequest(req, res, '');
         } catch (error: any) {


### PR DESCRIPTION
## Summary
- proxy the full root  namespace to Herald through Drawbridge
- widen the Herald-specific credentialed CORS scope to match the proxied well-known routes
- fix the missing root access for Herald endpoints like , , and 

Closes #263

## Testing
- npm run build (services/drawbridge/server)
