### PR TITLE
Allow public hosts in Herald client preview

### DIFF
--- a/apps/herald-client/vite.config.ts
+++ b/apps/herald-client/vite.config.ts
@@ -13,6 +13,9 @@ export default defineConfig(({ mode }) => {
         },
         preview: {
             port,
+            // Herald client is typically published behind a reverse proxy on a public domain.
+            // Host validation is handled at that layer, so preview must accept forwarded hosts.
+            allowedHosts: true,
         },
         build: {
             outDir: './build',


### PR DESCRIPTION
## Summary
- allow public host headers in Herald client Vite preview mode
- fix 403 responses when the client is accessed through a public domain behind a reverse proxy

Closes #266

## Testing
- npm run build (apps/herald-client)
