### PR TITLE
Fix Hyperswarm mediator healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,7 @@ services:
     ports:
       - "127.0.0.1:4232:4232"
     healthcheck:
-      test: ["CMD", "node", "-e", "const http=require('http');const req=http.get('http://127.0.0.1:4232/ready',res=>{let body='';res.on('data',chunk=>body+=chunk);res.on('end',()=>process.exit(res.statusCode===200&&body.includes('\"ready\":true')?0:1));});req.on('error',()=>process.exit(1));"]
+      test: ["CMD", "node", "-e", "const http=require('http');const req=http.get('http://127.0.0.1:4232/health',res=>process.exit(res.statusCode===200?0:1));req.on('error',()=>process.exit(1));"]
       interval: 15s
       timeout: 5s
       retries: 6

--- a/services/mediators/hyperswarm/src/hyperswarm-mediator.ts
+++ b/services/mediators/hyperswarm/src/hyperswarm-mediator.ts
@@ -187,6 +187,10 @@ function updateGauges(): void {
 function startMetricsServer(): void {
     const app = express();
 
+    app.get('/health', (_req, res) => {
+        res.json({ ok: true });
+    });
+
     app.get('/ready', async (_req, res) => {
         try {
             const [gatekeeperReady, keymasterReady, ipfsReady] = await Promise.all([


### PR DESCRIPTION
## Summary
- add a lightweight  endpoint to the Hyperswarm mediator metrics server
- keep  as the dependency readiness signal
- point the Docker healthcheck at  so transient downstream dependency issues do not mark the container unhealthy

## Verification
- npm run build --prefix services/mediators/hyperswarm
- docker compose config
