### PR TITLE
ci: pin npm toolchain for lockfile consistency

### DIFF
--- a/.github/workflows/android-debug-build-release.yml
+++ b/.github/workflows/android-debug-build-release.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           node-version: "22.15.0"
 
+      - name: Pin npm 10.9.2
+        run: npm install --global npm@10.9.2
+
       - name: Install root dependencies
         run: npm ci
 

--- a/.github/workflows/android-debug-build.yml
+++ b/.github/workflows/android-debug-build.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           node-version: "22.15.0"
 
+      - name: Pin npm 10.9.2
+        run: npm install --global npm@10.9.2
+
       - name: Install root dependencies
         run: npm ci
 

--- a/.github/workflows/build-browser-extension.yml
+++ b/.github/workflows/build-browser-extension.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           node-version: '22.15.0'
 
+      - name: Pin npm 10.9.2
+        run: npm install --global npm@10.9.2
+
       - name: Install root dependencies
         run: npm ci
 

--- a/.github/workflows/build-explorer.yml
+++ b/.github/workflows/build-explorer.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           node-version: '22.15.0'
 
+      - name: Pin npm 10.9.2
+        run: npm install --global npm@10.9.2
+
       - name: Install root dependencies
         run: npm ci
 

--- a/.github/workflows/build-react-wallet-webapp.yml
+++ b/.github/workflows/build-react-wallet-webapp.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           node-version: '22.15.0'
 
+      - name: Pin npm 10.9.2
+        run: npm install --global npm@10.9.2
+
       - name: Install root dependencies
         run: npm ci
 

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -22,7 +22,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          node-version: 20
+          node-version: "22.15.0"
+
+      - name: Pin npm 10.9.2
+        run: npm install --global npm@10.9.2
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/npm-package-publish.yml
+++ b/.github/workflows/npm-package-publish.yml
@@ -55,6 +55,9 @@ jobs:
           node-version: "22.15.0"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Pin npm 10.9.2
+        run: npm install --global npm@10.9.2
+
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -16,7 +16,10 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          node-version: "22"
+          node-version: "22.15.0"
+
+      - name: Pin npm 10.9.2
+        run: npm install --global npm@10.9.2
 
       - name: Install dependencies
         run: npm ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ These rules apply to coding agents working in this repository.
 ## Hygiene
 
 - Always save lessons learned in this file or another persistent repo instruction file. Do not rely on session memory for process corrections.
+- When generating or updating npm lockfiles, use the repo-pinned npm version from the root `package.json` so lockfiles stay compatible with CI.
 - Do not use stash-based branch juggling as the default workflow.
 - Never run mutating git operations in parallel. Serialize `git add`, `git commit`, `git push`, branch moves, stash operations, and any command that writes to `.git`.
 - Prefer a clean branch cut over moving changes around after the fact.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,10 @@
         "swagger-jsdoc": "^6.2.8",
         "ts-jest": "^29.2.6",
         "typescript": "^5.8.2"
+      },
+      "engines": {
+        "node": "22.15.x",
+        "npm": "10.9.x"
       }
     },
     "node_modules/@achingbrain/http-parser-js": {
@@ -7201,7 +7205,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.1",
@@ -7215,7 +7220,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.1",
@@ -7229,7 +7235,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.1",
@@ -7243,7 +7250,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.1",
@@ -7257,7 +7265,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.1",
@@ -7271,7 +7280,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.1",
@@ -7285,7 +7295,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.1",
@@ -7299,7 +7310,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.1",
@@ -7313,7 +7325,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.1",
@@ -7327,7 +7340,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.1",
@@ -7341,7 +7355,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.1",
@@ -7355,7 +7370,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.1",
@@ -7369,7 +7385,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.1",
@@ -7383,7 +7400,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.1",
@@ -7397,7 +7415,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.1",
@@ -7411,7 +7430,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.1",
@@ -7425,7 +7445,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.1",
@@ -7439,7 +7460,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.1",
@@ -7453,7 +7475,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.1",
@@ -7467,7 +7490,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.1",
@@ -7481,7 +7505,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.1",
@@ -7495,7 +7520,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.1",
@@ -7509,7 +7535,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.1",
@@ -7523,7 +7550,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.1",
@@ -7537,7 +7565,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "type": "module",
   "description": "Self-sovereign identity infrastructure for the decentralized web",
   "private": true,
+  "packageManager": "npm@10.9.2",
+  "engines": {
+    "node": "22.15.x",
+    "npm": "10.9.x"
+  },
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
## Summary
- pin the repo package manager and engines to npm 10.9.2 on Node 22.15.x
- install npm 10.9.2 in Node-based GitHub Actions workflows before running `npm ci`
- record the lockfile generation rule in `AGENTS.md`

## Validation
- `npx -y npm@10.9.2 install --package-lock-only`
- `npx -y npm@10.9.2 ci --ignore-scripts`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f) }'`
- `git diff --check`
