### PR TITLE
ci: configure Dependabot for the monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,103 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "America/Toronto"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/demo/commonjs-demo"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "05:00"
+      timezone: "America/Toronto"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "deps"
+    groups:
+      shared-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+        group-by: "dependency-name"
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/apps/browser-extension"
+      - "/apps/gatekeeper-client"
+      - "/apps/herald-client"
+      - "/apps/keymaster-client"
+      - "/apps/react-wallet"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "05:00"
+      timezone: "America/Toronto"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "deps"
+    groups:
+      frontend-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+        group-by: "dependency-name"
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/services/drawbridge/server"
+      - "/services/explorer"
+      - "/services/gatekeeper/server"
+      - "/services/herald"
+      - "/services/herald/server"
+      - "/services/keymaster/server"
+      - "/services/mediators/hyperswarm"
+      - "/services/mediators/satoshi"
+      - "/services/satoshi-wallet/server"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "05:00"
+      timezone: "America/Toronto"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "deps"
+    groups:
+      backend-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+        group-by: "dependency-name"


### PR DESCRIPTION
## Summary
- add a repository-level `.github/dependabot.yml` for GitHub Actions and npm directories across the monorepo
- group routine minor and patch updates by dependency name within shared, frontend, and backend areas
- cap open PR counts and use a monthly cadence for npm updates to keep review load manageable

## Notes
- root and workspace-managed dependencies are covered by the `/` npm entry
- app and service directories with their own lockfiles are configured explicitly
- grouping uses `group-by: dependency-name` to avoid another broad kitchen-sink PR while still reducing duplicate PRs across related directories

## Validation
- YAML parse check for `.github/dependabot.yml`
- directory coverage check against lockfile-bearing npm paths in the repo
