### PR TITLE
ci: throttle Dependabot pull request volume

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: "monday"
       time: "05:00"
       timezone: "America/Toronto"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
     commit-message:
@@ -29,7 +29,7 @@ updates:
       day: "monday"
       time: "05:00"
       timezone: "America/Toronto"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "javascript"
@@ -56,7 +56,7 @@ updates:
       day: "monday"
       time: "05:00"
       timezone: "America/Toronto"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "javascript"
@@ -87,7 +87,7 @@ updates:
       day: "monday"
       time: "05:00"
       timezone: "America/Toronto"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
     labels:
       - "dependencies"
       - "javascript"


### PR DESCRIPTION
## Summary
Reduce Dependabot concurrency so new update PRs stop arriving faster than they can be reviewed and merged.

## Changes
- lower `open-pull-requests-limit` from 2/3 down to 1 for all configured ecosystems
- keep existing schedules and grouping intact

## Why
The current settings allow multiple ecosystems to each open several PRs at once, which creates a sustained review backlog. This change serializes the queue so only one open PR per configured ecosystem block is allowed at a time.

## Validation
- parsed `.github/dependabot.yml` as YAML
- ran `git diff --check`
