### PR TITLE
feat: add Gatekeeper DID resolution benchmark

### DIFF
--- a/scripts/did-resolution-benchmark.js
+++ b/scripts/did-resolution-benchmark.js
@@ -249,11 +249,13 @@ program
                     const durationMs = performance.now() - requestStarted;
 
                     if (!response.ok) {
+                        const errorSuffix = body?.error ? `: ${body.error}` : '';
+
                         results.push({
                             ok: false,
                             did,
                             durationMs,
-                            error: `${response.status} ${response.statusText}${body?.error ? `: ${body.error}` : ''}`,
+                            error: `${response.status} ${response.statusText}${errorSuffix}`,
                         });
                         continue;
                     }


### PR DESCRIPTION
## Summary
- add `scripts/did-resolution-benchmark.js` to benchmark DID resolution through the Gatekeeper HTTP API
- support explicit DIDs, file-based DID input, or auto-fetching a sample DID set from Gatekeeper
- report latency percentiles, throughput, and request failures for benchmark runs

## Validation
- `node scripts/did-resolution-benchmark.js --help`
- `node scripts/did-resolution-benchmark.js --limit 1 --iterations 1 --timeout-ms 3000`
