### PR TITLE
fix: confirm alias handoff in browser extension

### DIFF
--- a/apps/browser-extension/src/contexts/UIContext.tsx
+++ b/apps/browser-extension/src/contexts/UIContext.tsx
@@ -321,9 +321,9 @@ export function UIProvider(
             setPendingUsed(true);
         } else if (pendingAlias && !pendingUsed) {
             (async () => {
-                await setSelectedTab("aliases");
                 await setAlias(pendingAlias.alias);
                 await setAliasDID(pendingAlias.did);
+                openBrowserWindow({ tab: "aliases" });
             })();
             setPendingUsed(true);
         } else if (pendingTab) {


### PR DESCRIPTION
## Summary
- stop auto-adding aliases in the browser extension when an alias handoff link is opened
- open the Aliases tab and prefill the alias and DID instead
- align browser extension alias handoff behavior with the React wallet flow

## Validation
- `cd apps/browser-extension && npx -y npm@10.9.2 run build`
