### PR TITLE
feat: Add identity avatar management tab

### DIFF
--- a/apps/browser-extension/src/components/DropDownID.tsx
+++ b/apps/browser-extension/src/components/DropDownID.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
     Box,
     Button,
@@ -7,11 +7,15 @@ import {
 } from "@mui/material";
 import { ArrowDropDown } from "@mui/icons-material";
 import { useWalletContext } from "../contexts/WalletProvider";
-import { useSnackbar } from "../contexts/SnackbarProvider";
 import { useUIContext } from "../contexts/UIContext";
+import { useSnackbar } from "../contexts/SnackbarProvider";
 import { useVariablesContext } from "../contexts/VariablesProvider";
-import { requestBrowserRefresh } from '../utils/utils'
+import { requestBrowserRefresh } from "../utils/utils";
 import CopyDID from "./CopyDID";
+import GatekeeperClient from "@didcid/gatekeeper/client";
+import type { FileAsset, ImageAsset } from "@didcid/keymaster/types";
+
+const gatekeeper = new GatekeeperClient();
 
 const DropDownID = () => {
     const {
@@ -24,17 +28,64 @@ const DropDownID = () => {
         idList,
         unresolvedIdList,
     } = useVariablesContext();
-    const {
-        setError,
-    } = useSnackbar();
-    const {
-        resetCurrentID,
-    } = useUIContext();
+    const { setError } = useSnackbar();
+    const { resetCurrentID } = useUIContext();
 
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const [avatarPreviewUrl, setAvatarPreviewUrl] = useState<string>("");
 
     const truncatedId =
         currentId?.length > 10 ? currentId.slice(0, 10) + "..." : currentId;
+
+    useEffect(() => {
+        const init = async () => {
+            const { gatekeeperUrl } = await chrome.storage.sync.get(["gatekeeperUrl"]);
+            await gatekeeper.connect({ url: gatekeeperUrl as string });
+        };
+        init();
+    }, []);
+
+    useEffect(() => {
+        const loadAvatar = async () => {
+            if (!keymaster || !currentDID) {
+                setAvatarPreviewUrl("");
+                return;
+            }
+
+            try {
+                const identityDoc = await keymaster.resolveDID(currentDID);
+                const identityData = identityDoc.didDocumentData as Record<string, unknown>;
+                const avatarDid = typeof identityData.avatar === "string" ? identityData.avatar.trim() : "";
+
+                if (!avatarDid) {
+                    setAvatarPreviewUrl("");
+                    return;
+                }
+
+                const avatarDoc = await keymaster.resolveDID(avatarDid);
+                const asset = avatarDoc.didDocumentData as { file?: FileAsset; image?: ImageAsset };
+
+                if (!asset.file?.cid || !asset.file?.type || !asset.image) {
+                    setAvatarPreviewUrl("");
+                    return;
+                }
+
+                const raw = await gatekeeper.getData(asset.file.cid);
+                if (!raw) {
+                    setAvatarPreviewUrl("");
+                    return;
+                }
+
+                setAvatarPreviewUrl(`data:${asset.file.type};base64,${raw.toString("base64")}`);
+            } catch {
+                setAvatarPreviewUrl("");
+            }
+        };
+
+        loadAvatar();
+        window.addEventListener("archon:avatar-changed", loadAvatar);
+        return () => window.removeEventListener("archon:avatar-changed", loadAvatar);
+    }, [currentDID, currentId, keymaster]);
 
     async function selectId(id: string) {
         if (!keymaster) {
@@ -125,6 +176,22 @@ const DropDownID = () => {
                     </Box>
                 )}
                 <CopyDID did={currentDID} />
+                {avatarPreviewUrl && (
+                    <Box
+                        component="img"
+                        src={avatarPreviewUrl}
+                        alt={`${currentId} avatar`}
+                        sx={{
+                            width: 32,
+                            height: 32,
+                            objectFit: "cover",
+                            borderRadius: "50%",
+                            border: "1px solid",
+                            borderColor: "divider",
+                            ml: 1,
+                        }}
+                    />
+                )}
             </Box>
         )
     );

--- a/apps/browser-extension/src/components/DropDownID.tsx
+++ b/apps/browser-extension/src/components/DropDownID.tsx
@@ -76,19 +76,23 @@ const DropDownID = () => {
                     return;
                 }
 
-                if (requestId === avatarRequestCounter) {
+                if (isActive && requestId === avatarRequestCounter) {
                     setAvatarPreviewUrl(`data:${asset.file.type};base64,${raw.toString("base64")}`);
                 }
             } catch {
-                if (requestId === avatarRequestCounter) {
+                if (isActive && requestId === avatarRequestCounter) {
                     setAvatarPreviewUrl("");
                 }
             }
         };
 
+        let isActive = true;
         loadAvatar();
         window.addEventListener("archon:avatar-changed", loadAvatar);
-        return () => window.removeEventListener("archon:avatar-changed", loadAvatar);
+        return () => {
+            isActive = false;
+            window.removeEventListener("archon:avatar-changed", loadAvatar);
+        };
     }, [currentDID, currentId, keymaster]);
 
     async function selectId(id: string) {

--- a/apps/browser-extension/src/components/DropDownID.tsx
+++ b/apps/browser-extension/src/components/DropDownID.tsx
@@ -16,6 +16,7 @@ import GatekeeperClient from "@didcid/gatekeeper/client";
 import type { FileAsset, ImageAsset } from "@didcid/keymaster/types";
 
 const gatekeeper = new GatekeeperClient();
+let avatarRequestCounter = 0;
 
 const DropDownID = () => {
     const {
@@ -47,8 +48,10 @@ const DropDownID = () => {
 
     useEffect(() => {
         const loadAvatar = async () => {
+            const requestId = ++avatarRequestCounter;
+            setAvatarPreviewUrl("");
+
             if (!keymaster || !currentDID) {
-                setAvatarPreviewUrl("");
                 return;
             }
 
@@ -58,7 +61,6 @@ const DropDownID = () => {
                 const avatarDid = typeof identityData.avatar === "string" ? identityData.avatar.trim() : "";
 
                 if (!avatarDid) {
-                    setAvatarPreviewUrl("");
                     return;
                 }
 
@@ -66,19 +68,21 @@ const DropDownID = () => {
                 const asset = avatarDoc.didDocumentData as { file?: FileAsset; image?: ImageAsset };
 
                 if (!asset.file?.cid || !asset.file?.type || !asset.image) {
-                    setAvatarPreviewUrl("");
                     return;
                 }
 
                 const raw = await gatekeeper.getData(asset.file.cid);
                 if (!raw) {
-                    setAvatarPreviewUrl("");
                     return;
                 }
 
-                setAvatarPreviewUrl(`data:${asset.file.type};base64,${raw.toString("base64")}`);
+                if (requestId === avatarRequestCounter) {
+                    setAvatarPreviewUrl(`data:${asset.file.type};base64,${raw.toString("base64")}`);
+                }
             } catch {
-                setAvatarPreviewUrl("");
+                if (requestId === avatarRequestCounter) {
+                    setAvatarPreviewUrl("");
+                }
             }
         };
 

--- a/apps/browser-extension/src/components/IdentitiesTab.tsx
+++ b/apps/browser-extension/src/components/IdentitiesTab.tsx
@@ -1,16 +1,19 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { ChangeEvent, useCallback, useEffect, useState } from "react";
 import JsonView from "@uiw/react-json-view";
 import { useWalletContext } from "../contexts/WalletProvider";
-import { useSnackbar } from "../contexts/SnackbarProvider";
-import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, MenuItem, Paper, Select, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, TextField, Typography } from "@mui/material";
-import { Badge, Login, PermIdentity } from "@mui/icons-material";
+import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormControlLabel, FormLabel, MenuItem, Paper, Radio, RadioGroup, Select, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, TextField, Typography } from "@mui/material";
+import { Badge, Image, Login, PermIdentity } from "@mui/icons-material";
 import { useUIContext } from "../contexts/UIContext";
-import { useVariablesContext } from "../contexts/VariablesProvider";
-import { requestBrowserRefresh } from "../utils/utils";
+import { useSnackbar } from "../contexts/SnackbarProvider";
 import WarningModal from "../modals/WarningModal";
 import TextInputModal from "../modals/TextInputModal";
 import SelectInputModal from "../modals/SelectInputModal";
-import type { AddressCheckResult, AddressInfo, NostrKeys } from "@didcid/keymaster/types";
+import { useVariablesContext } from "../contexts/VariablesProvider";
+import { requestBrowserRefresh } from "../utils/utils";
+import type { AddressCheckResult, AddressInfo, FileAsset, ImageAsset, NostrKeys } from "@didcid/keymaster/types";
+import GatekeeperClient from "@didcid/gatekeeper/client";
+
+const gatekeeper = new GatekeeperClient();
 
 function parseAddressDomain(address: string): string {
     const trimmed = address.trim().toLowerCase();
@@ -38,7 +41,7 @@ function formatAddedDate(value: string): string {
 }
 
 function IdentitiesTab() {
-    const [identityTab, setIdentityTab] = useState<"details" | "addresses" | "nostr">("details");
+    const [identityTab, setIdentityTab] = useState<"details" | "addresses" | "avatar" | "nostr">("details");
     const [name, setName] = useState<string>("");
     const [warningModal, setWarningModal] = useState<boolean>(false);
     const [removeCalled, setRemoveCalled] = useState<boolean>(false);
@@ -56,25 +59,308 @@ function IdentitiesTab() {
     const [selectedAddress, setSelectedAddress] = useState<string>("");
     const [addressDetails, setAddressDetails] = useState<string>("");
     const [addressBusy, setAddressBusy] = useState<boolean>(false);
+    const [avatarMode, setAvatarMode] = useState<"alias" | "did" | "upload">("alias");
+    const [avatarAlias, setAvatarAlias] = useState<string>("");
+    const [avatarInputDid, setAvatarInputDid] = useState<string>("");
+    const [avatarDid, setAvatarDid] = useState<string>("");
+    const [avatarPreviewUrl, setAvatarPreviewUrl] = useState<string>("");
+    const [avatarLoading, setAvatarLoading] = useState<boolean>(false);
+    const [avatarError, setAvatarError] = useState<string>("");
+    const [avatarCandidateDid, setAvatarCandidateDid] = useState<string>("");
+    const [avatarCandidateAlias, setAvatarCandidateAlias] = useState<string>("");
+    const [avatarCandidatePreviewUrl, setAvatarCandidatePreviewUrl] = useState<string>("");
+    const [avatarCandidateLoading, setAvatarCandidateLoading] = useState<boolean>(false);
+    const [avatarCandidateError, setAvatarCandidateError] = useState<string>("");
     const {
         isBrowser,
         keymaster,
     } = useWalletContext();
-    const {
-        currentId,
-        currentDID,
-        registry,
-        setRegistry,
-        registries,
-    } = useVariablesContext();
+    const { setError, setSuccess } = useSnackbar();
     const {
         refreshAll,
         resetCurrentID,
     } = useUIContext();
     const {
-        setError,
-        setSuccess,
-    } = useSnackbar();
+        currentId,
+        currentDID,
+        imageList,
+        aliasList,
+        registry,
+        setRegistry,
+        registries,
+    } = useVariablesContext();
+    useEffect(() => {
+        const init = async () => {
+            const { gatekeeperUrl } = await chrome.storage.sync.get(["gatekeeperUrl"]);
+            await gatekeeper.connect({ url: gatekeeperUrl as string });
+        };
+        init();
+    }, []);
+
+    function findAliasByDid(did: string, allowedAliases?: string[]): string {
+        if (!did) {
+            return "";
+        }
+
+        const allowed = allowedAliases ? new Set(allowedAliases) : null;
+
+        for (const [name, aliasDid] of Object.entries(aliasList)) {
+            if (aliasDid === did && (!allowed || allowed.has(name))) {
+                return name;
+            }
+        }
+
+        return "";
+    }
+
+    async function getImagePreviewDataUrl(doc: Record<string, unknown>): Promise<string> {
+        const docAsset = doc as { file?: FileAsset; image?: ImageAsset };
+
+        if (!docAsset.file?.cid || !docAsset.file?.type || !docAsset.image) {
+            return "";
+        }
+
+        const raw = await gatekeeper.getData(docAsset.file.cid);
+        if (!raw) {
+            return "";
+        }
+
+        return `data:${docAsset.file.type};base64,${raw.toString("base64")}`;
+    }
+
+    function clearAvatarCandidate() {
+        setAvatarCandidateDid("");
+        setAvatarCandidateAlias("");
+        setAvatarCandidatePreviewUrl("");
+        setAvatarCandidateLoading(false);
+        setAvatarCandidateError("");
+    }
+
+    function handleAvatarModeChange(event: ChangeEvent<HTMLInputElement>) {
+        setAvatarMode(event.target.value as "alias" | "did" | "upload");
+        clearAvatarCandidate();
+    }
+
+    async function previewAvatarCandidate(input: string, options: { alias?: string } = {}) {
+        if (!keymaster) {
+            return;
+        }
+
+        const value = input.trim();
+        const preferredAlias = options.alias || "";
+
+        if (!value) {
+            setError("Choose an image alias or enter a DID");
+            return;
+        }
+
+        setAvatarCandidateLoading(true);
+        setAvatarCandidateError("");
+
+        try {
+            const doc = await keymaster.resolveDID(value);
+            const did = doc.didDocument?.id || "";
+            const previewUrl = await getImagePreviewDataUrl(doc.didDocumentData as Record<string, unknown>);
+
+            if (!did) {
+                setError("Unable to resolve avatar DID");
+                clearAvatarCandidate();
+                return;
+            }
+
+            if (!previewUrl) {
+                setAvatarCandidateDid(did);
+                setAvatarCandidateAlias(preferredAlias || findAliasByDid(did, imageList));
+                setAvatarCandidatePreviewUrl("");
+                setAvatarCandidateError("Avatar must resolve to an image asset DID");
+                return;
+            }
+
+            setAvatarCandidateDid(did);
+            setAvatarCandidateAlias(preferredAlias || findAliasByDid(did, imageList));
+            setAvatarCandidatePreviewUrl(previewUrl);
+            setAvatarCandidateError("");
+        } catch (error: any) {
+            clearAvatarCandidate();
+            setAvatarCandidateError(error.error || error.message || String(error));
+        } finally {
+            setAvatarCandidateLoading(false);
+        }
+    }
+
+    const loadAvatar = useCallback(async () => {
+        if (!keymaster || !currentDID) {
+            setAvatarAlias("");
+            setAvatarInputDid("");
+            setAvatarDid("");
+            setAvatarPreviewUrl("");
+            setAvatarError("");
+            clearAvatarCandidate();
+            setAvatarLoading(false);
+            return;
+        }
+
+        setAvatarLoading(true);
+        setAvatarError("");
+
+        try {
+            const identityDoc = await keymaster.resolveDID(currentDID);
+            const data = identityDoc.didDocumentData as Record<string, unknown>;
+            const rawAvatar = data.avatar;
+            const nextDid = typeof rawAvatar === "string" ? rawAvatar.trim() : "";
+
+            if (!nextDid) {
+                setAvatarAlias("");
+                setAvatarInputDid("");
+                setAvatarDid("");
+                setAvatarPreviewUrl("");
+                return;
+            }
+
+            setAvatarDid(nextDid);
+            setAvatarInputDid(nextDid);
+            setAvatarAlias(findAliasByDid(nextDid, imageList));
+
+            try {
+                const avatarDoc = await keymaster.resolveDID(nextDid);
+                const previewUrl = await getImagePreviewDataUrl(avatarDoc.didDocumentData as Record<string, unknown>);
+
+                if (previewUrl) {
+                    setAvatarPreviewUrl(previewUrl);
+                } else {
+                    setAvatarPreviewUrl("");
+                    setAvatarError("The current avatar does not resolve to an image asset.");
+                }
+            } catch (error: any) {
+                setAvatarPreviewUrl("");
+                setAvatarError(error.error || error.message || String(error));
+            }
+        } catch (error: any) {
+            setAvatarPreviewUrl("");
+            setAvatarDid("");
+            setAvatarAlias("");
+            setAvatarInputDid("");
+            setAvatarError(error.error || error.message || String(error));
+        } finally {
+            setAvatarLoading(false);
+        }
+    }, [currentDID, imageList, keymaster, aliasList]);
+
+    useEffect(() => {
+        loadAvatar();
+    }, [loadAvatar]);
+
+    async function applyAvatarCandidate() {
+        if (!keymaster) {
+            return;
+        }
+        if (!avatarCandidateDid || !avatarCandidatePreviewUrl) {
+            setError("Preview an image avatar before setting it");
+            return;
+        }
+
+        try {
+            await keymaster.mergeData(currentId, { avatar: avatarCandidateDid });
+            setAvatarDid(avatarCandidateDid);
+            setAvatarInputDid(avatarCandidateDid);
+            setAvatarAlias(avatarCandidateAlias || findAliasByDid(avatarCandidateDid, imageList));
+            setAvatarPreviewUrl(avatarCandidatePreviewUrl);
+            setAvatarError("");
+            clearAvatarCandidate();
+            await refreshCurrentIdDocs();
+            await loadAvatar();
+            window.dispatchEvent(new Event("archon:avatar-changed"));
+            setSuccess("Avatar updated");
+        } catch (error: any) {
+            setError(error);
+        }
+    }
+
+    async function removeAvatarProperty() {
+        if (!keymaster) {
+            return;
+        }
+
+        try {
+            await keymaster.mergeData(currentId, { avatar: null });
+            setAvatarAlias("");
+            setAvatarInputDid("");
+            setAvatarDid("");
+            setAvatarPreviewUrl("");
+            setAvatarError("");
+            clearAvatarCandidate();
+            await refreshCurrentIdDocs();
+            window.dispatchEvent(new Event("archon:avatar-changed"));
+            setSuccess("Avatar removed");
+        } catch (error: any) {
+            setError(error);
+        }
+    }
+
+    async function uploadAvatarImage(event: ChangeEvent<HTMLInputElement>) {
+        if (!keymaster) {
+            return;
+        }
+
+        try {
+            const fileInput = event.target;
+            if (!fileInput.files || fileInput.files.length === 0) {
+                return;
+            }
+
+            const file = fileInput.files[0];
+            fileInput.value = "";
+
+            const reader = new FileReader();
+
+            reader.onload = async (e) => {
+                try {
+                    if (!e.target?.result || !(e.target.result instanceof ArrayBuffer)) {
+                        setError("Unexpected file reader result");
+                        return;
+                    }
+
+                    const did = await keymaster.createImage(Buffer.from(e.target.result), { registry });
+                    const names = await keymaster.listAliases();
+                    let alias = file.name.slice(0, 26);
+                    let count = 1;
+
+                    while (alias in names) {
+                        alias = `${file.name.slice(0, 26)} (${count++})`;
+                    }
+
+                    await keymaster.addAlias(alias, did);
+                    await refreshAll();
+                    setAvatarMode("upload");
+                    await previewAvatarCandidate(did, { alias });
+                    setSuccess(`Avatar image uploaded successfully: ${alias}. Review the preview, then set the avatar.`);
+                } catch (error: any) {
+                    setError(`Error processing avatar image: ${error}`);
+                }
+            };
+
+            reader.onerror = (error) => {
+                setError(`Error reading file: ${error}`);
+            };
+
+            reader.readAsArrayBuffer(file);
+        } catch (error: any) {
+            setError(`Error uploading avatar image: ${error}`);
+        }
+    }
+
+    const isAvatarPreviewMode = !!(avatarCandidateDid || avatarCandidatePreviewUrl || avatarCandidateError || avatarCandidateLoading);
+    const displayedAvatarPreviewUrl = isAvatarPreviewMode ? avatarCandidatePreviewUrl : avatarPreviewUrl;
+    const displayedAvatarDid = isAvatarPreviewMode ? avatarCandidateDid : avatarDid;
+    const displayedAvatarError = isAvatarPreviewMode ? avatarCandidateError : avatarError;
+    const displayedAvatarLoading = isAvatarPreviewMode ? avatarCandidateLoading : avatarLoading;
+    const displayedAvatarTitle = isAvatarPreviewMode ? "Avatar Preview" : "Current Avatar";
+    const displayedAvatarDidLabel = isAvatarPreviewMode ? "Preview Avatar DID" : "Current Avatar DID";
+    const displayedAvatarEmptyText = displayedAvatarLoading
+        ? (isAvatarPreviewMode ? "Loading preview..." : "Loading avatar...")
+        : displayedAvatarError
+            ? (isAvatarPreviewMode ? "Preview unavailable" : "Avatar preview unavailable")
+            : "No avatar set";
 
     const handleCreateId = async () => {
         if (!keymaster) {
@@ -561,180 +847,323 @@ function IdentitiesTab() {
                 </DialogActions>
             </Dialog>
 
-            <Box display="flex" flexDirection="row" sx={{ gap: 1, mt: 2, flexWrap: 'wrap' }}>
-                <Button
-                    variant="contained"
-                    onClick={openCreateModal}
-                >
-                    Create ID
-                </Button>
+            <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 0, width: '100%' }}>
+                <Box sx={{ mt: currentId ? 2 : 0, display: 'flex', alignItems: 'center', width: '100%', flexWrap: 'wrap', flexDirection: 'row', gap: 1 }}>
+                    <Button variant="contained" onClick={openCreateModal}>
+                        Create ID
+                    </Button>
+                    {currentId && (
+                        <>
+                            <Button
+                                variant="contained"
+                                color="primary"
+                                onClick={handleRenameId}
+                            >
+                                Rename
+                            </Button>
+
+                            <Button
+                                variant="contained"
+                                color="primary"
+                                onClick={handleRemoveId}
+                            >
+                                Remove
+                            </Button>
+
+                            <Button
+                                variant="contained"
+                                color="primary"
+                                onClick={backupId}
+                            >
+                                Backup
+                            </Button>
+
+                            <Button
+                                variant="contained"
+                                color="primary"
+                                onClick={handleRecoverId}
+                            >
+                                Recover
+                            </Button>
+
+                            <Button
+                                variant="contained"
+                                color="primary"
+                                onClick={rotateKeys}
+                            >
+                                Rotate
+                            </Button>
+
+                            <Button
+                                variant="contained"
+                                color="primary"
+                                onClick={() => setMigrateOpen(true)}
+                            >
+                                Migrate...
+                            </Button>
+                        </>
+                    )}
+                </Box>
                 {currentId && (
-                    <>
-                        <Button
-                            variant="contained"
-                            color="primary"
-                            onClick={handleRenameId}
+                    <Box sx={{ mt: 2, width: '100%' }}>
+                        <Tabs
+                            value={identityTab}
+                            onChange={(_event, newValue) => setIdentityTab(newValue)}
+                            variant="scrollable"
+                            scrollButtons="auto"
                         >
-                            Rename
-                        </Button>
+                            <Tab value="details" label="Details" icon={<PermIdentity />} iconPosition="top" />
+                            <Tab value="addresses" label="Addresses" icon={<Badge />} iconPosition="top" />
+                            <Tab value="avatar" label="Avatar" icon={<Image />} iconPosition="top" />
+                            <Tab value="nostr" label="Nostr" icon={<Login />} iconPosition="top" />
+                        </Tabs>
+                        {identityTab === "details" && (
+                            <Box sx={{ mt: 2, width: '100%' }}>
+                                <Paper variant="outlined" sx={{ p: 2, overflowX: "auto", width: '100%' }}>
+                                    {currentIdDocs ? (
+                                        <Box sx={{ width: '100%' }}>
+                                            <JsonView value={currentIdDocs} displayDataTypes={false} />
+                                        </Box>
+                                    ) : (
+                                        <Typography variant="body2" color="text.secondary">
+                                        No DID document available for the current identity.
+                                        </Typography>
+                                    )}
+                                </Paper>
+                            </Box>
+                        )}
+                        {identityTab === "addresses" && (
+                            <Box sx={{ mt: 2, width: '100%' }}>
+                                <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
+                                    <TextField label="Name" size="small" value={addressName} onChange={(e) => setAddressName(e.target.value)} />
+                                    <TextField label="Domain" size="small" value={addressDomain} onChange={(e) => setAddressDomain(e.target.value)} />
+                                </Box>
+                                <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
+                                    <Button variant="contained" size="small" onClick={checkAddressValue} disabled={addressBusy || !addressName.trim() || !addressDomain.trim()}>Check</Button>
+                                    <Button variant="contained" size="small" onClick={addAddressValue} disabled={addressBusy || !addressName.trim() || !addressDomain.trim()}>Add</Button>
+                                    <Button variant="contained" size="small" onClick={() => resolveStoredAddress(addressDomain)} disabled={addressBusy || !addressDomain.trim()}>Get</Button>
+                                    <Button variant="contained" size="small" onClick={importAddressDomain} disabled={addressBusy || !addressDomain.trim()}>Import</Button>
+                                    <Button variant="contained" size="small" onClick={() => removeAddressValue()} disabled={addressBusy || (!selectedAddress && (!addressName.trim() || !addressDomain.trim()))}>Remove</Button>
+                                    <Button variant="contained" size="small" onClick={clearAddressFields} disabled={addressBusy || (!addressName && !addressDomain && !selectedAddress && !addressDetails)}>Clear</Button>
+                                </Box>
+                                <TableContainer component={Paper} sx={{ mb: 1 }}>
+                                    <Table size="small">
+                                        <TableHead>
+                                            <TableRow>
+                                                <TableCell>Address</TableCell>
+                                                <TableCell>Added</TableCell>
+                                                <TableCell>Actions</TableCell>
+                                            </TableRow>
+                                        </TableHead>
+                                        <TableBody>
+                                            {Object.entries(addressList).sort(([a], [b]) => a.localeCompare(b)).map(([address, info]) => (
+                                                <TableRow key={address} selected={address === selectedAddress}>
+                                                    <TableCell sx={{ fontFamily: 'monospace' }}>{address}</TableCell>
+                                                    <TableCell sx={{ fontFamily: 'monospace' }}>{formatAddedDate(info.added)}</TableCell>
+                                                    <TableCell><Button variant="contained" size="small" onClick={() => selectAddress(address)} disabled={addressBusy}>Select</Button></TableCell>
+                                                </TableRow>
+                                            ))}
+                                        </TableBody>
+                                    </Table>
+                                </TableContainer>
+                                <TextField multiline minRows={8} fullWidth value={addressDetails} InputProps={{ readOnly: true }} />
+                            </Box>
+                        )}
+                        {identityTab === "avatar" && (
+                            <Box sx={{ mt: 2, width: "100%" }}>
+                                <Box sx={{ display: "flex", gap: 3, flexWrap: "wrap", alignItems: "flex-start", mb: 3 }}>
+                                    <Box sx={{ width: 220 }}>
+                                        <Typography variant="subtitle1" sx={{ mb: 1 }}>{displayedAvatarTitle}</Typography>
+                                        <Paper variant="outlined" sx={{ width: 220, height: 220, display: "flex", alignItems: "center", justifyContent: "center", overflow: "hidden", bgcolor: "grey.50" }}>
+                                            {displayedAvatarPreviewUrl ? (
+                                                <img src={displayedAvatarPreviewUrl} alt={`${currentId} avatar`} style={{ width: "100%", height: "100%", objectFit: "contain" }} />
+                                            ) : (
+                                                <Typography color="text.secondary" sx={{ textAlign: "center", px: 2 }}>
+                                                    {displayedAvatarEmptyText}
+                                                </Typography>
+                                            )}
+                                        </Paper>
+                                    </Box>
+                                    <Box sx={{ flex: 1, minWidth: 280 }}>
+                                        <Typography variant="body2" sx={{ mb: 1 }}>
+                                            {isAvatarPreviewMode
+                                                ? "Review the preview below, then apply it to the selected identity."
+                                                : "The selected identity stores its avatar as the `avatar` property."}
+                                        </Typography>
+                                        <TextField
+                                            label={displayedAvatarDidLabel}
+                                            value={displayedAvatarDid}
+                                            fullWidth
+                                            size="small"
+                                            margin="normal"
+                                            InputProps={{ readOnly: true }}
+                                        />
+                                        {displayedAvatarError && (
+                                            <Alert severity="warning" sx={{ mt: 1 }}>
+                                                {displayedAvatarError}
+                                            </Alert>
+                                        )}
+                                        <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 2 }}>
+                                            {isAvatarPreviewMode ? (
+                                                <>
+                                                    <Button
+                                                        variant="contained"
+                                                        onClick={applyAvatarCandidate}
+                                                        disabled={!avatarCandidateDid || !avatarCandidatePreviewUrl}
+                                                    >
+                                                        Set Avatar
+                                                    </Button>
+                                                    <Button
+                                                        variant="outlined"
+                                                        onClick={clearAvatarCandidate}
+                                                        disabled={!avatarCandidateDid && !avatarCandidatePreviewUrl && !avatarCandidateError}
+                                                    >
+                                                        Clear Preview
+                                                    </Button>
+                                                </>
+                                            ) : (
+                                                <Button variant="contained" color="error" onClick={removeAvatarProperty} disabled={!avatarDid}>
+                                                    Remove Avatar
+                                                </Button>
+                                            )}
+                                        </Box>
+                                    </Box>
+                                </Box>
 
-                        <Button
-                            variant="contained"
-                            color="primary"
-                            onClick={handleRemoveId}
-                        >
-                            Remove
-                        </Button>
+                                <FormControl sx={{ mb: 2 }}>
+                                    <FormLabel>Set Avatar From</FormLabel>
+                                    <RadioGroup row value={avatarMode} onChange={handleAvatarModeChange}>
+                                        <FormControlLabel value="alias" control={<Radio />} label="Image Alias" />
+                                        <FormControlLabel value="did" control={<Radio />} label="DID" />
+                                        <FormControlLabel value="upload" control={<Radio />} label="Upload Image" />
+                                    </RadioGroup>
+                                </FormControl>
 
-                        <Button
-                            variant="contained"
-                            color="primary"
-                            onClick={backupId}
-                        >
-                            Backup
-                        </Button>
+                                {avatarMode === "alias" && (
+                                    <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+                                        <Select
+                                            value={avatarAlias}
+                                            displayEmpty
+                                            size="small"
+                                            sx={{ minWidth: 280 }}
+                                            onChange={(event) => setAvatarAlias(event.target.value)}
+                                        >
+                                            <MenuItem value="" disabled>Select image alias</MenuItem>
+                                            {imageList.map((name) => (
+                                                <MenuItem key={name} value={name}>{name}</MenuItem>
+                                            ))}
+                                        </Select>
+                                        <Button
+                                            variant="contained"
+                                            onClick={() => previewAvatarCandidate(avatarAlias, { alias: avatarAlias })}
+                                            disabled={!avatarAlias}
+                                        >
+                                            Preview
+                                        </Button>
+                                    </Box>
+                                )}
 
-                        <Button
-                            variant="contained"
-                            color="primary"
-                            onClick={handleRecoverId}
-                        >
-                            Recover
-                        </Button>
+                                {avatarMode === "did" && (
+                                    <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+                                        <TextField
+                                            label="Avatar DID"
+                                            value={avatarInputDid}
+                                            onChange={(e) => setAvatarInputDid(e.target.value)}
+                                            size="small"
+                                            sx={{ minWidth: 420, flex: 1 }}
+                                        />
+                                        <Button
+                                            variant="contained"
+                                            onClick={() => previewAvatarCandidate(avatarInputDid)}
+                                            disabled={!avatarInputDid.trim()}
+                                        >
+                                            Preview
+                                        </Button>
+                                    </Box>
+                                )}
 
-                        <Button
-                            variant="contained"
-                            color="primary"
-                            onClick={rotateKeys}
-                        >
-                            Rotate
-                        </Button>
-
-                        <Button
-                            variant="contained"
-                            color="primary"
-                            onClick={() => setMigrateOpen(true)}
-                        >
-                            Migrate...
-                        </Button>
-                    </>
-                )}
-            </Box>
-            {currentId && (
-                <Box sx={{ mt: 2, width: '100%' }}>
-                    <Tabs
-                        value={identityTab}
-                        onChange={(_event, newValue) => setIdentityTab(newValue)}
-                        variant="scrollable"
-                        scrollButtons="auto"
-                    >
-                        <Tab value="details" label="Details" icon={<PermIdentity />} iconPosition="top" />
-                        <Tab value="addresses" label="Addresses" icon={<Badge />} iconPosition="top" />
-                        <Tab value="nostr" label="Nostr" icon={<Login />} iconPosition="top" />
-                    </Tabs>
-                    {identityTab === "details" && (
-                        <Box sx={{ mt: 2, width: '100%' }}>
-                            <Paper variant="outlined" sx={{ p: 2, overflowX: "auto", width: '100%' }}>
-                                {currentIdDocs ? (
-                                    <Box sx={{ width: '100%' }}>
-                                        <JsonView value={currentIdDocs} displayDataTypes={false} />
+                                {avatarMode === "upload" && (
+                                    <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+                                        <Select
+                                            value={registries.includes(registry) ? registry : ""}
+                                            onChange={(e) => setRegistry(e.target.value)}
+                                            size="small"
+                                            sx={{ minWidth: 220 }}
+                                        >
+                                            {registries.map((r) => (
+                                                <MenuItem key={r} value={r}>{r}</MenuItem>
+                                            ))}
+                                        </Select>
+                                        <Button
+                                            variant="contained"
+                                            onClick={() => document.getElementById("avatarUpload")?.click()}
+                                            disabled={!registry}
+                                        >
+                                            Upload Image...
+                                        </Button>
+                                        <input
+                                            type="file"
+                                            id="avatarUpload"
+                                            accept="image/*"
+                                            style={{ display: "none" }}
+                                            onChange={uploadAvatarImage}
+                                        />
+                                    </Box>
+                                )}
+                            </Box>
+                        )}
+                        {identityTab === "nostr" && (
+                            <Box sx={{ mt: 2, width: '100%' }}>
+                                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 1 }}>
+                                    {nostrKeys ? (
+                                        <Button variant="contained" color="error" onClick={() => setRemoveNostrModal(true)} sx={{ whiteSpace: 'nowrap' }}>
+                                            Remove Nostr
+                                        </Button>
+                                    ) : (
+                                        <Button variant="contained" color="primary" onClick={addNostr} sx={{ whiteSpace: 'nowrap' }}>
+                                            Add Nostr
+                                        </Button>
+                                    )}
+                                    {nostrKeys && (
+                                        nsecValue ? (
+                                            <Button variant="contained" color="warning" onClick={hideNsec} sx={{ whiteSpace: 'nowrap' }}>
+                                                Hide nsec
+                                            </Button>
+                                        ) : (
+                                            <Button variant="contained" color="warning" onClick={showNsec} sx={{ whiteSpace: 'nowrap' }}>
+                                                Show nsec
+                                            </Button>
+                                        )
+                                    )}
+                                </Box>
+                                {nostrKeys ? (
+                                    <Box>
+                                        <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+                                            npub: {nostrKeys.npub}
+                                        </Typography>
+                                        <br />
+                                        <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+                                            pubkey: {nostrKeys.pubkey}
+                                        </Typography>
+                                        {nsecValue && (
+                                            <>
+                                                <br />
+                                                <Typography variant="caption" color="error" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+                                                    nsec: {nsecValue}
+                                                </Typography>
+                                            </>
+                                        )}
                                     </Box>
                                 ) : (
                                     <Typography variant="body2" color="text.secondary">
-                                        No DID document available for the current identity.
+                                        No Nostr keys are configured for this identity yet.
                                     </Typography>
                                 )}
-                            </Paper>
-                        </Box>
-                    )}
-                    {identityTab === "addresses" && (
-                        <Box sx={{ mt: 2, width: '100%' }}>
-                            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
-                                <TextField label="Name" size="small" value={addressName} onChange={(e) => setAddressName(e.target.value)} />
-                                <TextField label="Domain" size="small" value={addressDomain} onChange={(e) => setAddressDomain(e.target.value)} />
                             </Box>
-                            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
-                                <Button variant="contained" size="small" onClick={checkAddressValue} disabled={addressBusy || !addressName.trim() || !addressDomain.trim()}>Check</Button>
-                                <Button variant="contained" size="small" onClick={addAddressValue} disabled={addressBusy || !addressName.trim() || !addressDomain.trim()}>Add</Button>
-                                <Button variant="contained" size="small" onClick={() => resolveStoredAddress(addressDomain)} disabled={addressBusy || !addressDomain.trim()}>Get</Button>
-                                <Button variant="contained" size="small" onClick={importAddressDomain} disabled={addressBusy || !addressDomain.trim()}>Import</Button>
-                                <Button variant="contained" size="small" onClick={() => removeAddressValue()} disabled={addressBusy || (!selectedAddress && (!addressName.trim() || !addressDomain.trim()))}>Remove</Button>
-                                <Button variant="contained" size="small" onClick={clearAddressFields} disabled={addressBusy || (!addressName && !addressDomain && !selectedAddress && !addressDetails)}>Clear</Button>
-                            </Box>
-                            <TableContainer component={Paper} sx={{ mb: 1 }}>
-                                <Table size="small">
-                                    <TableHead>
-                                        <TableRow>
-                                            <TableCell>Address</TableCell>
-                                            <TableCell>Added</TableCell>
-                                            <TableCell>Actions</TableCell>
-                                        </TableRow>
-                                    </TableHead>
-                                    <TableBody>
-                                        {Object.entries(addressList).sort(([a], [b]) => a.localeCompare(b)).map(([address, info]) => (
-                                            <TableRow key={address} selected={address === selectedAddress}>
-                                                <TableCell sx={{ fontFamily: 'monospace' }}>{address}</TableCell>
-                                                <TableCell sx={{ fontFamily: 'monospace' }}>{formatAddedDate(info.added)}</TableCell>
-                                                <TableCell><Button variant="contained" size="small" onClick={() => selectAddress(address)} disabled={addressBusy}>Select</Button></TableCell>
-                                            </TableRow>
-                                        ))}
-                                    </TableBody>
-                                </Table>
-                            </TableContainer>
-                            <TextField multiline minRows={8} fullWidth value={addressDetails} InputProps={{ readOnly: true }} />
-                        </Box>
-                    )}
-                    {identityTab === "nostr" && (
-                        <Box sx={{ mt: 2, width: '100%' }}>
-                            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 1 }}>
-                                {nostrKeys ? (
-                                    <Button variant="contained" color="error" onClick={() => setRemoveNostrModal(true)} sx={{ whiteSpace: 'nowrap' }}>
-                                        Remove Nostr
-                                    </Button>
-                                ) : (
-                                    <Button variant="contained" color="primary" onClick={addNostr} sx={{ whiteSpace: 'nowrap' }}>
-                                        Add Nostr
-                                    </Button>
-                                )}
-                                {nostrKeys && (
-                                    nsecValue ? (
-                                        <Button variant="contained" color="warning" onClick={hideNsec} sx={{ whiteSpace: 'nowrap' }}>
-                                            Hide nsec
-                                        </Button>
-                                    ) : (
-                                        <Button variant="contained" color="warning" onClick={showNsec} sx={{ whiteSpace: 'nowrap' }}>
-                                            Show nsec
-                                        </Button>
-                                    )
-                                )}
-                            </Box>
-                            {nostrKeys ? (
-                                <Box>
-                                    <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
-                                        npub: {nostrKeys.npub}
-                                    </Typography>
-                                    <br />
-                                    <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
-                                        pubkey: {nostrKeys.pubkey}
-                                    </Typography>
-                                    {nsecValue && (
-                                        <>
-                                            <br />
-                                            <Typography variant="caption" color="error" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
-                                                nsec: {nsecValue}
-                                            </Typography>
-                                        </>
-                                    )}
-                                </Box>
-                            ) : (
-                                <Typography variant="body2" color="text.secondary">
-                                    No Nostr keys are configured for this identity yet.
-                                </Typography>
-                            )}
-                        </Box>
-                    )}
-                </Box>
-            )}
+                        )}
+                    </Box>
+                )}
+            </Box>
         </Box>
     );
 }

--- a/apps/browser-extension/src/components/IdentitiesTab.tsx
+++ b/apps/browser-extension/src/components/IdentitiesTab.tsx
@@ -984,7 +984,7 @@ function IdentitiesTab() {
                                             )}
                                         </Paper>
                                     </Box>
-                                    <Box sx={{ flex: 1, minWidth: 280 }}>
+                                    <Box sx={{ flex: "0 1 520px", minWidth: 280, maxWidth: 520 }}>
                                         <Typography variant="body2" sx={{ mb: 1 }}>
                                             {isAvatarPreviewMode
                                                 ? "Review the preview below, then apply it to the selected identity."

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -369,6 +369,11 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [avatarPreviewUrl, setAvatarPreviewUrl] = useState('');
     const [avatarLoading, setAvatarLoading] = useState(false);
     const [avatarError, setAvatarError] = useState('');
+    const [avatarCandidateDid, setAvatarCandidateDid] = useState('');
+    const [avatarCandidateAlias, setAvatarCandidateAlias] = useState('');
+    const [avatarCandidatePreviewUrl, setAvatarCandidatePreviewUrl] = useState('');
+    const [avatarCandidateLoading, setAvatarCandidateLoading] = useState(false);
+    const [avatarCandidateError, setAvatarCandidateError] = useState('');
 
     const [lightningTab, setLightningTab] = useState('wallet');
     const [lightningBalance, setLightningBalance] = useState(null);
@@ -875,6 +880,62 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         return cid ? `${serverUrl}/api/v1/ipfs/data/${cid}` : '';
     }
 
+    function clearAvatarCandidate() {
+        setAvatarCandidateDid('');
+        setAvatarCandidateAlias('');
+        setAvatarCandidatePreviewUrl('');
+        setAvatarCandidateLoading(false);
+        setAvatarCandidateError('');
+    }
+
+    function handleAvatarModeChange(event) {
+        setAvatarMode(event.target.value);
+        clearAvatarCandidate();
+    }
+
+    async function previewAvatarCandidate(input, options = {}) {
+        const value = input?.trim();
+        const preferredAlias = options.alias || '';
+
+        if (!value) {
+            showAlert('Choose an image alias or enter a DID');
+            return;
+        }
+
+        setAvatarCandidateLoading(true);
+        setAvatarCandidateError('');
+
+        try {
+            const doc = await keymaster.resolveDID(value);
+            const did = doc?.didDocument?.id;
+            const previewUrl = getImagePreviewUrl(doc);
+
+            if (!did) {
+                showAlert('Unable to resolve avatar DID');
+                clearAvatarCandidate();
+                return;
+            }
+
+            if (!previewUrl) {
+                setAvatarCandidateDid(did);
+                setAvatarCandidateAlias(preferredAlias || findAliasByDid(did, imageList || []));
+                setAvatarCandidatePreviewUrl('');
+                setAvatarCandidateError('Avatar must resolve to an image asset DID');
+                return;
+            }
+
+            setAvatarCandidateDid(did);
+            setAvatarCandidateAlias(preferredAlias || findAliasByDid(did, imageList || []));
+            setAvatarCandidatePreviewUrl(previewUrl);
+            setAvatarCandidateError('');
+        } catch (error) {
+            clearAvatarCandidate();
+            setAvatarCandidateError(error.error || error.message || String(error));
+        } finally {
+            setAvatarCandidateLoading(false);
+        }
+    }
+
     async function loadAvatar() {
         if (!selectedId) {
             setAvatarAlias('');
@@ -882,6 +943,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             setAvatarDid('');
             setAvatarPreviewUrl('');
             setAvatarError('');
+            clearAvatarCandidate();
             setAvatarLoading(false);
             return;
         }
@@ -935,35 +997,20 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedId, aliasList, imageList]);
 
-    async function setAvatarProperty(input) {
-        const value = input?.trim();
-
-        if (!value) {
-            showAlert('Choose an image alias or enter a DID');
+    async function applyAvatarCandidate() {
+        if (!avatarCandidateDid || !avatarCandidatePreviewUrl) {
+            showAlert('Preview an image avatar before setting it');
             return;
         }
 
         try {
-            const doc = await keymaster.resolveDID(value);
-            const did = doc?.didDocument?.id;
-            const previewUrl = getImagePreviewUrl(doc);
-
-            if (!did) {
-                showAlert('Unable to resolve avatar DID');
-                return;
-            }
-
-            if (!previewUrl) {
-                showAlert('Avatar must resolve to an image asset DID');
-                return;
-            }
-
-            await keymaster.mergeData(selectedId, { avatar: did });
-            setAvatarDid(did);
-            setAvatarInputDid(did);
-            setAvatarAlias(findAliasByDid(did, imageList || []));
-            setAvatarPreviewUrl(previewUrl);
+            await keymaster.mergeData(selectedId, { avatar: avatarCandidateDid });
+            setAvatarDid(avatarCandidateDid);
+            setAvatarInputDid(avatarCandidateDid);
+            setAvatarAlias(avatarCandidateAlias || findAliasByDid(avatarCandidateDid, imageList || []));
+            setAvatarPreviewUrl(avatarCandidatePreviewUrl);
             setAvatarError('');
+            clearAvatarCandidate();
             showSuccess('Avatar updated');
             await resolveId();
         } catch (error) {
@@ -979,6 +1026,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             setAvatarDid('');
             setAvatarPreviewUrl('');
             setAvatarError('');
+            clearAvatarCandidate();
             showSuccess('Avatar removed');
             await resolveId();
         } catch (error) {
@@ -1012,15 +1060,9 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
 
                     await keymaster.addAlias(alias, did);
                     await refreshNames();
-                    await keymaster.mergeData(selectedId, { avatar: did });
-                    setAvatarDid(did);
-                    setAvatarInputDid(did);
-                    setAvatarAlias(alias);
-                    setAvatarPreviewUrl(getImagePreviewUrl(await keymaster.resolveDID(did)));
-                    setAvatarError('');
-                    setAvatarMode('alias');
-                    await resolveId();
-                    showSuccess(`Avatar image uploaded successfully: ${alias}`);
+                    setAvatarMode('upload');
+                    await previewAvatarCandidate(did, { alias });
+                    showSuccess(`Avatar image uploaded successfully: ${alias}. Review the preview, then set the avatar.`);
                 } catch (error) {
                     showError(`Error processing avatar image: ${error}`);
                 }
@@ -4568,7 +4610,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
 
                                     <FormControl sx={{ mb: 2 }}>
                                         <FormLabel>Set Avatar From</FormLabel>
-                                        <RadioGroup row value={avatarMode} onChange={(e) => setAvatarMode(e.target.value)}>
+                                        <RadioGroup row value={avatarMode} onChange={handleAvatarModeChange}>
                                             <FormControlLabel value="alias" control={<Radio />} label="Image Alias" />
                                             <FormControlLabel value="did" control={<Radio />} label="DID" />
                                             <FormControlLabel value="upload" control={<Radio />} label="Upload Image" />
@@ -4591,10 +4633,10 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                             </Select>
                                             <Button
                                                 variant="contained"
-                                                onClick={() => setAvatarProperty(avatarAlias)}
+                                                onClick={() => previewAvatarCandidate(avatarAlias, { alias: avatarAlias })}
                                                 disabled={!avatarAlias}
                                             >
-                                                Set Avatar
+                                                Preview
                                             </Button>
                                         </Box>
                                     }
@@ -4610,10 +4652,10 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                             />
                                             <Button
                                                 variant="contained"
-                                                onClick={() => setAvatarProperty(avatarInputDid)}
+                                                onClick={() => previewAvatarCandidate(avatarInputDid)}
                                                 disabled={!avatarInputDid.trim()}
                                             >
-                                                Set Avatar
+                                                Preview
                                             </Button>
                                         </Box>
                                     }
@@ -4638,6 +4680,60 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                             />
                                         </Box>
                                     }
+
+                                    <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', alignItems: 'flex-start', mt: 3 }}>
+                                        <Box sx={{ width: 220 }}>
+                                            <Typography variant="subtitle1" sx={{ mb: 1 }}>Pending Avatar</Typography>
+                                            <Paper variant="outlined" sx={{ width: 220, height: 220, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden', bgcolor: 'grey.50' }}>
+                                                {avatarCandidatePreviewUrl ? (
+                                                    <img src={avatarCandidatePreviewUrl} alt="Pending avatar preview" style={{ width: '100%', height: '100%', objectFit: 'contain' }} />
+                                                ) : (
+                                                    <Typography color="text.secondary" sx={{ textAlign: 'center', px: 2 }}>
+                                                        {avatarCandidateLoading ? 'Loading preview...' : avatarCandidateError ? 'Preview unavailable' : 'Preview an avatar before setting it'}
+                                                    </Typography>
+                                                )}
+                                            </Paper>
+                                        </Box>
+                                        <Box sx={{ flex: 1, minWidth: 280 }}>
+                                            <TextField
+                                                label="Pending Avatar DID"
+                                                value={avatarCandidateDid}
+                                                fullWidth
+                                                size="small"
+                                                margin="normal"
+                                                InputProps={{ readOnly: true }}
+                                            />
+                                            <TextField
+                                                label="Pending Avatar Alias"
+                                                value={avatarCandidateAlias}
+                                                fullWidth
+                                                size="small"
+                                                margin="normal"
+                                                InputProps={{ readOnly: true }}
+                                            />
+                                            {avatarCandidateError &&
+                                                <Alert severity="warning" sx={{ mt: 1 }}>
+                                                    {avatarCandidateError}
+                                                </Alert>
+                                            }
+                                            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 2 }}>
+                                                <Button
+                                                    variant="contained"
+                                                    onClick={applyAvatarCandidate}
+                                                    disabled={!avatarCandidateDid || !avatarCandidatePreviewUrl}
+                                                >
+                                                    Set Avatar
+                                                </Button>
+                                                <Button
+                                                    variant="outlined"
+                                                    onClick={clearAvatarCandidate}
+                                                    disabled={!avatarCandidateDid && !avatarCandidatePreviewUrl && !avatarCandidateError}
+                                                >
+                                                    Clear Preview
+                                                </Button>
+                                            </Box>
+                                        </Box>
+                                    </Box>
                                 </Box>
                             }
                             {identityTab === 'nostr' &&

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -50,6 +50,7 @@ import {
     Block,
     Bolt,
     Clear,
+    ContentCopy,
     Create,
     Groups,
     Delete,
@@ -1075,6 +1076,15 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             reader.readAsArrayBuffer(file);
         } catch (error) {
             showError(`Error uploading avatar image: ${error}`);
+        }
+    }
+
+    async function copyCurrentDid() {
+        try {
+            await navigator.clipboard.writeText(currentDID);
+            showSuccess('DID copied to clipboard');
+        } catch (error) {
+            showError(error);
         }
     }
 
@@ -4348,14 +4358,29 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                         </Grid>
                     }
                     <Grid item>
-                        <Typography style={{ fontSize: '1.5em', fontWeight: 'bold' }}>
-                            {currentId}
-                        </Typography>
+                        <Select
+                            size="small"
+                            style={{ width: '300px' }}
+                            value={selectedId}
+                            onChange={(event) => selectId(event.target.value)}
+                        >
+                            {idList?.map((idname, index) => (
+                                <MenuItem value={idname} key={index}>
+                                    {idname}
+                                </MenuItem>
+                            ))}
+                        </Select>
                     </Grid>
                     <Grid item>
-                        <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
-                            {currentDID}
-                        </Typography>
+                        <Button
+                            variant="outlined"
+                            size="small"
+                            startIcon={<ContentCopy />}
+                            onClick={copyCurrentDid}
+                            disabled={!currentDID}
+                        >
+                            Copy DID
+                        </Button>
                     </Grid>
                 </Grid>
 
@@ -4408,22 +4433,6 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                 <Box style={{ width: '90vw' }}>
                     {tab === 'identity' &&
                         <Box>
-                            <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
-                                <Grid item>
-                                    <Select
-                                        style={{ width: '300px' }}
-                                        value={selectedId}
-                                        fullWidth
-                                        onChange={(event) => selectId(event.target.value)}
-                                    >
-                                        {idList.map((idname, index) => (
-                                            <MenuItem value={idname} key={index}>
-                                                {idname}
-                                            </MenuItem>
-                                        ))}
-                                    </Select>
-                                </Grid>
-                            </Grid>
                             <Box sx={{ mt: 2, mb: 2 }}>
                                 <Tabs
                                     value={identityTab}

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -1078,6 +1078,19 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
     }
 
+    const isAvatarPreviewMode = !!(avatarCandidateDid || avatarCandidatePreviewUrl || avatarCandidateError || avatarCandidateLoading);
+    const displayedAvatarPreviewUrl = isAvatarPreviewMode ? avatarCandidatePreviewUrl : avatarPreviewUrl;
+    const displayedAvatarDid = isAvatarPreviewMode ? avatarCandidateDid : avatarDid;
+    const displayedAvatarError = isAvatarPreviewMode ? avatarCandidateError : avatarError;
+    const displayedAvatarLoading = isAvatarPreviewMode ? avatarCandidateLoading : avatarLoading;
+    const displayedAvatarTitle = isAvatarPreviewMode ? 'Avatar Preview' : 'Current Avatar';
+    const displayedAvatarDidLabel = isAvatarPreviewMode ? 'Preview Avatar DID' : 'Current Avatar DID';
+    const displayedAvatarEmptyText = displayedAvatarLoading
+        ? (isAvatarPreviewMode ? 'Loading preview...' : 'Loading avatar...')
+        : displayedAvatarError
+            ? (isAvatarPreviewMode ? 'Preview unavailable' : 'Avatar preview unavailable')
+            : 'No avatar set';
+
     async function showCreate() {
         setSaveId(currentId);
         setCurrentId('');
@@ -4572,38 +4585,59 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                 <Box sx={{ width: '800px', maxWidth: '100%' }}>
                                     <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', alignItems: 'flex-start', mb: 3 }}>
                                         <Box sx={{ width: 220 }}>
-                                            <Typography variant="subtitle1" sx={{ mb: 1 }}>Current Avatar</Typography>
+                                            <Typography variant="subtitle1" sx={{ mb: 1 }}>{displayedAvatarTitle}</Typography>
                                             <Paper variant="outlined" sx={{ width: 220, height: 220, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden', bgcolor: 'grey.50' }}>
-                                                {avatarPreviewUrl ? (
-                                                    <img src={avatarPreviewUrl} alt={`${selectedId} avatar`} style={{ width: '100%', height: '100%', objectFit: 'contain' }} />
+                                                {displayedAvatarPreviewUrl ? (
+                                                    <img src={displayedAvatarPreviewUrl} alt={`${selectedId} avatar`} style={{ width: '100%', height: '100%', objectFit: 'contain' }} />
                                                 ) : (
                                                     <Typography color="text.secondary" sx={{ textAlign: 'center', px: 2 }}>
-                                                        {avatarLoading ? 'Loading avatar...' : avatarError ? 'Avatar preview unavailable' : 'No avatar set'}
+                                                        {displayedAvatarEmptyText}
                                                     </Typography>
                                                 )}
                                             </Paper>
                                         </Box>
                                         <Box sx={{ flex: 1, minWidth: 280 }}>
                                             <Typography variant="body2" sx={{ mb: 1 }}>
-                                                The selected identity stores its avatar as the `avatar` property.
+                                                {isAvatarPreviewMode
+                                                    ? 'Review the preview below, then apply it to the selected identity.'
+                                                    : 'The selected identity stores its avatar as the `avatar` property.'}
                                             </Typography>
                                             <TextField
-                                                label="Current Avatar DID"
-                                                value={avatarDid}
+                                                label={displayedAvatarDidLabel}
+                                                value={displayedAvatarDid}
                                                 fullWidth
                                                 size="small"
                                                 margin="normal"
                                                 InputProps={{ readOnly: true }}
                                             />
-                                            {avatarError &&
+                                            {displayedAvatarError &&
                                                 <Alert severity="warning" sx={{ mt: 1 }}>
-                                                    {avatarError}
+                                                    {displayedAvatarError}
                                                 </Alert>
                                             }
-                                            <Box sx={{ mt: 2 }}>
-                                                <Button variant="contained" color="error" onClick={removeAvatarProperty} disabled={!avatarDid}>
-                                                    Remove Avatar
-                                                </Button>
+                                            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 2 }}>
+                                                {isAvatarPreviewMode ? (
+                                                    <>
+                                                        <Button
+                                                            variant="contained"
+                                                            onClick={applyAvatarCandidate}
+                                                            disabled={!avatarCandidateDid || !avatarCandidatePreviewUrl}
+                                                        >
+                                                            Set Avatar
+                                                        </Button>
+                                                        <Button
+                                                            variant="outlined"
+                                                            onClick={clearAvatarCandidate}
+                                                            disabled={!avatarCandidateDid && !avatarCandidatePreviewUrl && !avatarCandidateError}
+                                                        >
+                                                            Clear Preview
+                                                        </Button>
+                                                    </>
+                                                ) : (
+                                                    <Button variant="contained" color="error" onClick={removeAvatarProperty} disabled={!avatarDid}>
+                                                        Remove Avatar
+                                                    </Button>
+                                                )}
                                             </Box>
                                         </Box>
                                     </Box>
@@ -4680,60 +4714,6 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                             />
                                         </Box>
                                     }
-
-                                    <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', alignItems: 'flex-start', mt: 3 }}>
-                                        <Box sx={{ width: 220 }}>
-                                            <Typography variant="subtitle1" sx={{ mb: 1 }}>Pending Avatar</Typography>
-                                            <Paper variant="outlined" sx={{ width: 220, height: 220, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden', bgcolor: 'grey.50' }}>
-                                                {avatarCandidatePreviewUrl ? (
-                                                    <img src={avatarCandidatePreviewUrl} alt="Pending avatar preview" style={{ width: '100%', height: '100%', objectFit: 'contain' }} />
-                                                ) : (
-                                                    <Typography color="text.secondary" sx={{ textAlign: 'center', px: 2 }}>
-                                                        {avatarCandidateLoading ? 'Loading preview...' : avatarCandidateError ? 'Preview unavailable' : 'Preview an avatar before setting it'}
-                                                    </Typography>
-                                                )}
-                                            </Paper>
-                                        </Box>
-                                        <Box sx={{ flex: 1, minWidth: 280 }}>
-                                            <TextField
-                                                label="Pending Avatar DID"
-                                                value={avatarCandidateDid}
-                                                fullWidth
-                                                size="small"
-                                                margin="normal"
-                                                InputProps={{ readOnly: true }}
-                                            />
-                                            <TextField
-                                                label="Pending Avatar Alias"
-                                                value={avatarCandidateAlias}
-                                                fullWidth
-                                                size="small"
-                                                margin="normal"
-                                                InputProps={{ readOnly: true }}
-                                            />
-                                            {avatarCandidateError &&
-                                                <Alert severity="warning" sx={{ mt: 1 }}>
-                                                    {avatarCandidateError}
-                                                </Alert>
-                                            }
-                                            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 2 }}>
-                                                <Button
-                                                    variant="contained"
-                                                    onClick={applyAvatarCandidate}
-                                                    disabled={!avatarCandidateDid || !avatarCandidatePreviewUrl}
-                                                >
-                                                    Set Avatar
-                                                </Button>
-                                                <Button
-                                                    variant="outlined"
-                                                    onClick={clearAvatarCandidate}
-                                                    disabled={!avatarCandidateDid && !avatarCandidatePreviewUrl && !avatarCandidateError}
-                                                >
-                                                    Clear Preview
-                                                </Button>
-                                            </Box>
-                                        </Box>
-                                    </Box>
                                 </Box>
                             }
                             {identityTab === 'nostr' &&

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -362,6 +362,13 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [propsEditValue, setPropsEditValue] = useState('');
     const [propsDeleteOpen, setPropsDeleteOpen] = useState(false);
     const [propsDeleteKey, setPropsDeleteKey] = useState('');
+    const [avatarMode, setAvatarMode] = useState('alias');
+    const [avatarAlias, setAvatarAlias] = useState('');
+    const [avatarInputDid, setAvatarInputDid] = useState('');
+    const [avatarDid, setAvatarDid] = useState('');
+    const [avatarPreviewUrl, setAvatarPreviewUrl] = useState('');
+    const [avatarLoading, setAvatarLoading] = useState(false);
+    const [avatarError, setAvatarError] = useState('');
 
     const [lightningTab, setLightningTab] = useState('wallet');
     const [lightningBalance, setLightningBalance] = useState(null);
@@ -845,6 +852,188 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     function propsFormatValue(value) {
         if (typeof value === 'string') return value;
         return JSON.stringify(value);
+    }
+
+    function findAliasByDid(did, allowedAliases = null) {
+        if (!did || !aliasList) {
+            return '';
+        }
+
+        const allowed = allowedAliases ? new Set(allowedAliases) : null;
+
+        for (const [name, aliasDid] of Object.entries(aliasList)) {
+            if (aliasDid === did && (!allowed || allowed.has(name))) {
+                return name;
+            }
+        }
+
+        return '';
+    }
+
+    function getImagePreviewUrl(doc) {
+        const cid = doc?.didDocumentData?.file?.cid;
+        return cid ? `${serverUrl}/api/v1/ipfs/data/${cid}` : '';
+    }
+
+    async function loadAvatar() {
+        if (!selectedId) {
+            setAvatarAlias('');
+            setAvatarInputDid('');
+            setAvatarDid('');
+            setAvatarPreviewUrl('');
+            setAvatarError('');
+            setAvatarLoading(false);
+            return;
+        }
+
+        setAvatarLoading(true);
+        setAvatarError('');
+
+        try {
+            const identityDoc = await keymaster.resolveDID(selectedId);
+            const rawAvatar = identityDoc?.didDocumentData?.avatar;
+            const nextDid = typeof rawAvatar === 'string' ? rawAvatar.trim() : '';
+
+            if (!nextDid) {
+                setAvatarAlias('');
+                setAvatarInputDid('');
+                setAvatarDid('');
+                setAvatarPreviewUrl('');
+                return;
+            }
+
+            setAvatarDid(nextDid);
+            setAvatarInputDid(nextDid);
+            setAvatarAlias(findAliasByDid(nextDid, imageList || []));
+            try {
+                const avatarDoc = await keymaster.resolveDID(nextDid);
+                const previewUrl = getImagePreviewUrl(avatarDoc);
+
+                if (previewUrl) {
+                    setAvatarPreviewUrl(previewUrl);
+                } else {
+                    setAvatarPreviewUrl('');
+                    setAvatarError('The current avatar does not resolve to an image asset.');
+                }
+            } catch (error) {
+                setAvatarPreviewUrl('');
+                setAvatarError(error.error || error.message || String(error));
+            }
+        } catch (error) {
+            setAvatarPreviewUrl('');
+            setAvatarDid('');
+            setAvatarAlias('');
+            setAvatarInputDid('');
+            setAvatarError(error.error || error.message || String(error));
+        } finally {
+            setAvatarLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        loadAvatar();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedId, aliasList, imageList]);
+
+    async function setAvatarProperty(input) {
+        const value = input?.trim();
+
+        if (!value) {
+            showAlert('Choose an image alias or enter a DID');
+            return;
+        }
+
+        try {
+            const doc = await keymaster.resolveDID(value);
+            const did = doc?.didDocument?.id;
+            const previewUrl = getImagePreviewUrl(doc);
+
+            if (!did) {
+                showAlert('Unable to resolve avatar DID');
+                return;
+            }
+
+            if (!previewUrl) {
+                showAlert('Avatar must resolve to an image asset DID');
+                return;
+            }
+
+            await keymaster.mergeData(selectedId, { avatar: did });
+            setAvatarDid(did);
+            setAvatarInputDid(did);
+            setAvatarAlias(findAliasByDid(did, imageList || []));
+            setAvatarPreviewUrl(previewUrl);
+            setAvatarError('');
+            showSuccess('Avatar updated');
+            await resolveId();
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    async function removeAvatarProperty() {
+        try {
+            await keymaster.mergeData(selectedId, { avatar: null });
+            setAvatarAlias('');
+            setAvatarInputDid('');
+            setAvatarDid('');
+            setAvatarPreviewUrl('');
+            setAvatarError('');
+            showSuccess('Avatar removed');
+            await resolveId();
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    async function uploadAvatarImage(event) {
+        try {
+            const fileInput = event.target;
+            const file = fileInput.files[0];
+
+            if (!file) return;
+
+            fileInput.value = "";
+
+            const reader = new FileReader();
+
+            reader.onload = async (e) => {
+                try {
+                    const arrayBuffer = e.target.result;
+                    const buffer = Buffer.from(arrayBuffer);
+                    const did = await keymaster.createImage(buffer, { registry });
+                    const names = await keymaster.listAliases();
+                    let alias = file.name.slice(0, 26);
+                    let count = 1;
+
+                    while (alias in names) {
+                        alias = `${file.name.slice(0, 26)} (${count++})`;
+                    }
+
+                    await keymaster.addAlias(alias, did);
+                    await refreshNames();
+                    await keymaster.mergeData(selectedId, { avatar: did });
+                    setAvatarDid(did);
+                    setAvatarInputDid(did);
+                    setAvatarAlias(alias);
+                    setAvatarPreviewUrl(getImagePreviewUrl(await keymaster.resolveDID(did)));
+                    setAvatarError('');
+                    setAvatarMode('alias');
+                    await resolveId();
+                    showSuccess(`Avatar image uploaded successfully: ${alias}`);
+                } catch (error) {
+                    showError(`Error processing avatar image: ${error}`);
+                }
+            };
+
+            reader.onerror = (error) => {
+                showError(`Error reading file: ${error}`);
+            };
+
+            reader.readAsArrayBuffer(file);
+        } catch (error) {
+            showError(`Error uploading avatar image: ${error}`);
+        }
     }
 
     async function showCreate() {
@@ -4174,6 +4363,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                 >
                                     <Tab key="details" value="details" label={'Details'} icon={<PermIdentity />} />
                                     <Tab key="addresses" value="addresses" label={'Addresses'} icon={<Badge />} />
+                                    <Tab key="avatar" value="avatar" label={'Avatar'} icon={<Image />} />
                                     <Tab key="nostr" value="nostr" label={'Nostr'} icon={<Login />} />
                                 </Tabs>
                             </Box>
@@ -4334,6 +4524,120 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                         readOnly
                                         style={{ width: '100%', height: '240px', overflow: 'auto' }}
                                     />
+                                </Box>
+                            }
+                            {identityTab === 'avatar' &&
+                                <Box sx={{ width: '800px', maxWidth: '100%' }}>
+                                    <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', alignItems: 'flex-start', mb: 3 }}>
+                                        <Box sx={{ width: 220 }}>
+                                            <Typography variant="subtitle1" sx={{ mb: 1 }}>Current Avatar</Typography>
+                                            <Paper variant="outlined" sx={{ width: 220, height: 220, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden', bgcolor: 'grey.50' }}>
+                                                {avatarPreviewUrl ? (
+                                                    <img src={avatarPreviewUrl} alt={`${selectedId} avatar`} style={{ width: '100%', height: '100%', objectFit: 'contain' }} />
+                                                ) : (
+                                                    <Typography color="text.secondary" sx={{ textAlign: 'center', px: 2 }}>
+                                                        {avatarLoading ? 'Loading avatar...' : avatarError ? 'Avatar preview unavailable' : 'No avatar set'}
+                                                    </Typography>
+                                                )}
+                                            </Paper>
+                                        </Box>
+                                        <Box sx={{ flex: 1, minWidth: 280 }}>
+                                            <Typography variant="body2" sx={{ mb: 1 }}>
+                                                The selected identity stores its avatar as the `avatar` property.
+                                            </Typography>
+                                            <TextField
+                                                label="Current Avatar DID"
+                                                value={avatarDid}
+                                                fullWidth
+                                                size="small"
+                                                margin="normal"
+                                                InputProps={{ readOnly: true }}
+                                            />
+                                            {avatarError &&
+                                                <Alert severity="warning" sx={{ mt: 1 }}>
+                                                    {avatarError}
+                                                </Alert>
+                                            }
+                                            <Box sx={{ mt: 2 }}>
+                                                <Button variant="contained" color="error" onClick={removeAvatarProperty} disabled={!avatarDid}>
+                                                    Remove Avatar
+                                                </Button>
+                                            </Box>
+                                        </Box>
+                                    </Box>
+
+                                    <FormControl sx={{ mb: 2 }}>
+                                        <FormLabel>Set Avatar From</FormLabel>
+                                        <RadioGroup row value={avatarMode} onChange={(e) => setAvatarMode(e.target.value)}>
+                                            <FormControlLabel value="alias" control={<Radio />} label="Image Alias" />
+                                            <FormControlLabel value="did" control={<Radio />} label="DID" />
+                                            <FormControlLabel value="upload" control={<Radio />} label="Upload Image" />
+                                        </RadioGroup>
+                                    </FormControl>
+
+                                    {avatarMode === 'alias' &&
+                                        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
+                                            <Select
+                                                value={avatarAlias}
+                                                displayEmpty
+                                                size="small"
+                                                sx={{ minWidth: 280 }}
+                                                onChange={(event) => setAvatarAlias(event.target.value)}
+                                            >
+                                                <MenuItem value="" disabled>Select image alias</MenuItem>
+                                                {(imageList || []).map((name) => (
+                                                    <MenuItem key={name} value={name}>{name}</MenuItem>
+                                                ))}
+                                            </Select>
+                                            <Button
+                                                variant="contained"
+                                                onClick={() => setAvatarProperty(avatarAlias)}
+                                                disabled={!avatarAlias}
+                                            >
+                                                Set Avatar
+                                            </Button>
+                                        </Box>
+                                    }
+
+                                    {avatarMode === 'did' &&
+                                        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
+                                            <TextField
+                                                label="Avatar DID"
+                                                value={avatarInputDid}
+                                                onChange={(e) => setAvatarInputDid(e.target.value)}
+                                                size="small"
+                                                sx={{ minWidth: 420, flex: 1 }}
+                                            />
+                                            <Button
+                                                variant="contained"
+                                                onClick={() => setAvatarProperty(avatarInputDid)}
+                                                disabled={!avatarInputDid.trim()}
+                                            >
+                                                Set Avatar
+                                            </Button>
+                                        </Box>
+                                    }
+
+                                    {avatarMode === 'upload' &&
+                                        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
+                                            <RegistrySelect />
+                                            <Button
+                                                variant="contained"
+                                                color="primary"
+                                                onClick={() => document.getElementById('avatarUpload').click()}
+                                                disabled={!registry}
+                                            >
+                                                Upload Image...
+                                            </Button>
+                                            <input
+                                                type="file"
+                                                id="avatarUpload"
+                                                accept="image/*"
+                                                style={{ display: 'none' }}
+                                                onChange={uploadAvatarImage}
+                                            />
+                                        </Box>
+                                    }
                                 </Box>
                             }
                             {identityTab === 'nostr' &&

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -877,8 +877,12 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     }
 
     function getImagePreviewUrl(doc) {
+        const image = doc?.didDocumentData?.image;
         const cid = doc?.didDocumentData?.file?.cid;
-        return cid ? `${serverUrl}/api/v1/ipfs/data/${cid}` : '';
+        const fileType = doc?.didDocumentData?.file?.type;
+        const isImageType = !fileType || fileType.startsWith('image/');
+
+        return image && cid && isImageType ? `${serverUrl}/api/v1/ipfs/data/${cid}` : '';
     }
 
     function clearAvatarCandidate() {

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -4340,23 +4340,6 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                             ID:
                         </Typography>
                     </Grid>
-                    {avatarPreviewUrl && !avatarLoading &&
-                        <Grid item>
-                            <Box
-                                component="img"
-                                src={avatarPreviewUrl}
-                                alt={`${currentId} avatar`}
-                                sx={{
-                                    width: 40,
-                                    height: 40,
-                                    objectFit: 'cover',
-                                    borderRadius: '50%',
-                                    border: '1px solid',
-                                    borderColor: 'divider',
-                                }}
-                            />
-                        </Grid>
-                    }
                     <Grid item>
                         <Select
                             size="small"
@@ -4382,6 +4365,23 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                             Copy DID
                         </Button>
                     </Grid>
+                    {avatarPreviewUrl &&
+                        <Grid item>
+                            <Box
+                                component="img"
+                                src={avatarPreviewUrl}
+                                alt={`${currentId} avatar`}
+                                sx={{
+                                    width: 40,
+                                    height: 40,
+                                    objectFit: 'cover',
+                                    borderRadius: '50%',
+                                    border: '1px solid',
+                                    borderColor: 'divider',
+                                }}
+                            />
+                        </Grid>
+                    }
                 </Grid>
 
                 <Box>

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -4330,6 +4330,23 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                             ID:
                         </Typography>
                     </Grid>
+                    {avatarPreviewUrl && !avatarLoading &&
+                        <Grid item>
+                            <Box
+                                component="img"
+                                src={avatarPreviewUrl}
+                                alt={`${currentId} avatar`}
+                                sx={{
+                                    width: 40,
+                                    height: 40,
+                                    objectFit: 'cover',
+                                    borderRadius: '50%',
+                                    border: '1px solid',
+                                    borderColor: 'divider',
+                                }}
+                            />
+                        </Grid>
+                    }
                     <Grid item>
                         <Typography style={{ fontSize: '1.5em', fontWeight: 'bold' }}>
                             {currentId}

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -50,6 +50,7 @@ import {
     Block,
     Bolt,
     Clear,
+    ContentCopy,
     Create,
     Groups,
     Delete,
@@ -362,6 +363,18 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [propsEditValue, setPropsEditValue] = useState('');
     const [propsDeleteOpen, setPropsDeleteOpen] = useState(false);
     const [propsDeleteKey, setPropsDeleteKey] = useState('');
+    const [avatarMode, setAvatarMode] = useState('alias');
+    const [avatarAlias, setAvatarAlias] = useState('');
+    const [avatarInputDid, setAvatarInputDid] = useState('');
+    const [avatarDid, setAvatarDid] = useState('');
+    const [avatarPreviewUrl, setAvatarPreviewUrl] = useState('');
+    const [avatarLoading, setAvatarLoading] = useState(false);
+    const [avatarError, setAvatarError] = useState('');
+    const [avatarCandidateDid, setAvatarCandidateDid] = useState('');
+    const [avatarCandidateAlias, setAvatarCandidateAlias] = useState('');
+    const [avatarCandidatePreviewUrl, setAvatarCandidatePreviewUrl] = useState('');
+    const [avatarCandidateLoading, setAvatarCandidateLoading] = useState(false);
+    const [avatarCandidateError, setAvatarCandidateError] = useState('');
 
     const [lightningTab, setLightningTab] = useState('wallet');
     const [lightningBalance, setLightningBalance] = useState(null);
@@ -846,6 +859,247 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         if (typeof value === 'string') return value;
         return JSON.stringify(value);
     }
+
+    function findAliasByDid(did, allowedAliases = null) {
+        if (!did || !aliasList) {
+            return '';
+        }
+
+        const allowed = allowedAliases ? new Set(allowedAliases) : null;
+
+        for (const [name, aliasDid] of Object.entries(aliasList)) {
+            if (aliasDid === did && (!allowed || allowed.has(name))) {
+                return name;
+            }
+        }
+
+        return '';
+    }
+
+    function getImagePreviewUrl(doc) {
+        const cid = doc?.didDocumentData?.file?.cid;
+        return cid ? `${serverUrl}/api/v1/ipfs/data/${cid}` : '';
+    }
+
+    function clearAvatarCandidate() {
+        setAvatarCandidateDid('');
+        setAvatarCandidateAlias('');
+        setAvatarCandidatePreviewUrl('');
+        setAvatarCandidateLoading(false);
+        setAvatarCandidateError('');
+    }
+
+    function handleAvatarModeChange(event) {
+        setAvatarMode(event.target.value);
+        clearAvatarCandidate();
+    }
+
+    async function previewAvatarCandidate(input, options = {}) {
+        const value = input?.trim();
+        const preferredAlias = options.alias || '';
+
+        if (!value) {
+            showAlert('Choose an image alias or enter a DID');
+            return;
+        }
+
+        setAvatarCandidateLoading(true);
+        setAvatarCandidateError('');
+
+        try {
+            const doc = await keymaster.resolveDID(value);
+            const did = doc?.didDocument?.id;
+            const previewUrl = getImagePreviewUrl(doc);
+
+            if (!did) {
+                showAlert('Unable to resolve avatar DID');
+                clearAvatarCandidate();
+                return;
+            }
+
+            if (!previewUrl) {
+                setAvatarCandidateDid(did);
+                setAvatarCandidateAlias(preferredAlias || findAliasByDid(did, imageList || []));
+                setAvatarCandidatePreviewUrl('');
+                setAvatarCandidateError('Avatar must resolve to an image asset DID');
+                return;
+            }
+
+            setAvatarCandidateDid(did);
+            setAvatarCandidateAlias(preferredAlias || findAliasByDid(did, imageList || []));
+            setAvatarCandidatePreviewUrl(previewUrl);
+            setAvatarCandidateError('');
+        } catch (error) {
+            clearAvatarCandidate();
+            setAvatarCandidateError(error.error || error.message || String(error));
+        } finally {
+            setAvatarCandidateLoading(false);
+        }
+    }
+
+    async function loadAvatar() {
+        if (!selectedId) {
+            setAvatarAlias('');
+            setAvatarInputDid('');
+            setAvatarDid('');
+            setAvatarPreviewUrl('');
+            setAvatarError('');
+            clearAvatarCandidate();
+            setAvatarLoading(false);
+            return;
+        }
+
+        setAvatarLoading(true);
+        setAvatarError('');
+
+        try {
+            const identityDoc = await keymaster.resolveDID(selectedId);
+            const rawAvatar = identityDoc?.didDocumentData?.avatar;
+            const nextDid = typeof rawAvatar === 'string' ? rawAvatar.trim() : '';
+
+            if (!nextDid) {
+                setAvatarAlias('');
+                setAvatarInputDid('');
+                setAvatarDid('');
+                setAvatarPreviewUrl('');
+                return;
+            }
+
+            setAvatarDid(nextDid);
+            setAvatarInputDid(nextDid);
+            setAvatarAlias(findAliasByDid(nextDid, imageList || []));
+            try {
+                const avatarDoc = await keymaster.resolveDID(nextDid);
+                const previewUrl = getImagePreviewUrl(avatarDoc);
+
+                if (previewUrl) {
+                    setAvatarPreviewUrl(previewUrl);
+                } else {
+                    setAvatarPreviewUrl('');
+                    setAvatarError('The current avatar does not resolve to an image asset.');
+                }
+            } catch (error) {
+                setAvatarPreviewUrl('');
+                setAvatarError(error.error || error.message || String(error));
+            }
+        } catch (error) {
+            setAvatarPreviewUrl('');
+            setAvatarDid('');
+            setAvatarAlias('');
+            setAvatarInputDid('');
+            setAvatarError(error.error || error.message || String(error));
+        } finally {
+            setAvatarLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        loadAvatar();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedId, aliasList, imageList]);
+
+    async function applyAvatarCandidate() {
+        if (!avatarCandidateDid || !avatarCandidatePreviewUrl) {
+            showAlert('Preview an image avatar before setting it');
+            return;
+        }
+
+        try {
+            await keymaster.mergeData(selectedId, { avatar: avatarCandidateDid });
+            setAvatarDid(avatarCandidateDid);
+            setAvatarInputDid(avatarCandidateDid);
+            setAvatarAlias(avatarCandidateAlias || findAliasByDid(avatarCandidateDid, imageList || []));
+            setAvatarPreviewUrl(avatarCandidatePreviewUrl);
+            setAvatarError('');
+            clearAvatarCandidate();
+            showSuccess('Avatar updated');
+            await resolveId();
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    async function removeAvatarProperty() {
+        try {
+            await keymaster.mergeData(selectedId, { avatar: null });
+            setAvatarAlias('');
+            setAvatarInputDid('');
+            setAvatarDid('');
+            setAvatarPreviewUrl('');
+            setAvatarError('');
+            clearAvatarCandidate();
+            showSuccess('Avatar removed');
+            await resolveId();
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    async function uploadAvatarImage(event) {
+        try {
+            const fileInput = event.target;
+            const file = fileInput.files[0];
+
+            if (!file) return;
+
+            fileInput.value = "";
+
+            const reader = new FileReader();
+
+            reader.onload = async (e) => {
+                try {
+                    const arrayBuffer = e.target.result;
+                    const buffer = Buffer.from(arrayBuffer);
+                    const did = await keymaster.createImage(buffer, { registry });
+                    const names = await keymaster.listAliases();
+                    let alias = file.name.slice(0, 26);
+                    let count = 1;
+
+                    while (alias in names) {
+                        alias = `${file.name.slice(0, 26)} (${count++})`;
+                    }
+
+                    await keymaster.addAlias(alias, did);
+                    await refreshNames();
+                    setAvatarMode('upload');
+                    await previewAvatarCandidate(did, { alias });
+                    showSuccess(`Avatar image uploaded successfully: ${alias}. Review the preview, then set the avatar.`);
+                } catch (error) {
+                    showError(`Error processing avatar image: ${error}`);
+                }
+            };
+
+            reader.onerror = (error) => {
+                showError(`Error reading file: ${error}`);
+            };
+
+            reader.readAsArrayBuffer(file);
+        } catch (error) {
+            showError(`Error uploading avatar image: ${error}`);
+        }
+    }
+
+    async function copyCurrentDid() {
+        try {
+            await navigator.clipboard.writeText(currentDID);
+            showSuccess('DID copied to clipboard');
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    const isAvatarPreviewMode = !!(avatarCandidateDid || avatarCandidatePreviewUrl || avatarCandidateError || avatarCandidateLoading);
+    const displayedAvatarPreviewUrl = isAvatarPreviewMode ? avatarCandidatePreviewUrl : avatarPreviewUrl;
+    const displayedAvatarDid = isAvatarPreviewMode ? avatarCandidateDid : avatarDid;
+    const displayedAvatarError = isAvatarPreviewMode ? avatarCandidateError : avatarError;
+    const displayedAvatarLoading = isAvatarPreviewMode ? avatarCandidateLoading : avatarLoading;
+    const displayedAvatarTitle = isAvatarPreviewMode ? 'Avatar Preview' : 'Current Avatar';
+    const displayedAvatarDidLabel = isAvatarPreviewMode ? 'Preview Avatar DID' : 'Current Avatar DID';
+    const displayedAvatarEmptyText = displayedAvatarLoading
+        ? (isAvatarPreviewMode ? 'Loading preview...' : 'Loading avatar...')
+        : displayedAvatarError
+            ? (isAvatarPreviewMode ? 'Preview unavailable' : 'Avatar preview unavailable')
+            : 'No avatar set';
 
     async function showCreate() {
         setSaveId(currentId);
@@ -4087,15 +4341,47 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                         </Typography>
                     </Grid>
                     <Grid item>
-                        <Typography style={{ fontSize: '1.5em', fontWeight: 'bold' }}>
-                            {currentId}
-                        </Typography>
+                        <Select
+                            size="small"
+                            style={{ width: '300px' }}
+                            value={selectedId}
+                            onChange={(event) => selectId(event.target.value)}
+                        >
+                            {idList?.map((idname, index) => (
+                                <MenuItem value={idname} key={index}>
+                                    {idname}
+                                </MenuItem>
+                            ))}
+                        </Select>
                     </Grid>
                     <Grid item>
-                        <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
-                            {currentDID}
-                        </Typography>
+                        <Button
+                            variant="outlined"
+                            size="small"
+                            startIcon={<ContentCopy />}
+                            onClick={copyCurrentDid}
+                            disabled={!currentDID}
+                        >
+                            Copy DID
+                        </Button>
                     </Grid>
+                    {avatarPreviewUrl &&
+                        <Grid item>
+                            <Box
+                                component="img"
+                                src={avatarPreviewUrl}
+                                alt={`${currentId} avatar`}
+                                sx={{
+                                    width: 40,
+                                    height: 40,
+                                    objectFit: 'cover',
+                                    borderRadius: '50%',
+                                    border: '1px solid',
+                                    borderColor: 'divider',
+                                }}
+                            />
+                        </Grid>
+                    }
                 </Grid>
 
                 <Box>
@@ -4147,22 +4433,6 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                 <Box style={{ width: '90vw' }}>
                     {tab === 'identity' &&
                         <Box>
-                            <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
-                                <Grid item>
-                                    <Select
-                                        style={{ width: '300px' }}
-                                        value={selectedId}
-                                        fullWidth
-                                        onChange={(event) => selectId(event.target.value)}
-                                    >
-                                        {idList.map((idname, index) => (
-                                            <MenuItem value={idname} key={index}>
-                                                {idname}
-                                            </MenuItem>
-                                        ))}
-                                    </Select>
-                                </Grid>
-                            </Grid>
                             <Box sx={{ mt: 2, mb: 2 }}>
                                 <Tabs
                                     value={identityTab}
@@ -4174,6 +4444,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                 >
                                     <Tab key="details" value="details" label={'Details'} icon={<PermIdentity />} />
                                     <Tab key="addresses" value="addresses" label={'Addresses'} icon={<Badge />} />
+                                    <Tab key="avatar" value="avatar" label={'Avatar'} icon={<Image />} />
                                     <Tab key="nostr" value="nostr" label={'Nostr'} icon={<Login />} />
                                 </Tabs>
                             </Box>
@@ -4334,6 +4605,141 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                         readOnly
                                         style={{ width: '100%', height: '240px', overflow: 'auto' }}
                                     />
+                                </Box>
+                            }
+                            {identityTab === 'avatar' &&
+                                <Box sx={{ width: '800px', maxWidth: '100%' }}>
+                                    <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', alignItems: 'flex-start', mb: 3 }}>
+                                        <Box sx={{ width: 220 }}>
+                                            <Typography variant="subtitle1" sx={{ mb: 1 }}>{displayedAvatarTitle}</Typography>
+                                            <Paper variant="outlined" sx={{ width: 220, height: 220, display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden', bgcolor: 'grey.50' }}>
+                                                {displayedAvatarPreviewUrl ? (
+                                                    <img src={displayedAvatarPreviewUrl} alt={`${selectedId} avatar`} style={{ width: '100%', height: '100%', objectFit: 'contain' }} />
+                                                ) : (
+                                                    <Typography color="text.secondary" sx={{ textAlign: 'center', px: 2 }}>
+                                                        {displayedAvatarEmptyText}
+                                                    </Typography>
+                                                )}
+                                            </Paper>
+                                        </Box>
+                                        <Box sx={{ flex: 1, minWidth: 280 }}>
+                                            <Typography variant="body2" sx={{ mb: 1 }}>
+                                                {isAvatarPreviewMode
+                                                    ? 'Review the preview below, then apply it to the selected identity.'
+                                                    : 'The selected identity stores its avatar as the `avatar` property.'}
+                                            </Typography>
+                                            <TextField
+                                                label={displayedAvatarDidLabel}
+                                                value={displayedAvatarDid}
+                                                fullWidth
+                                                size="small"
+                                                margin="normal"
+                                                InputProps={{ readOnly: true }}
+                                            />
+                                            {displayedAvatarError &&
+                                                <Alert severity="warning" sx={{ mt: 1 }}>
+                                                    {displayedAvatarError}
+                                                </Alert>
+                                            }
+                                            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 2 }}>
+                                                {isAvatarPreviewMode ? (
+                                                    <>
+                                                        <Button
+                                                            variant="contained"
+                                                            onClick={applyAvatarCandidate}
+                                                            disabled={!avatarCandidateDid || !avatarCandidatePreviewUrl}
+                                                        >
+                                                            Set Avatar
+                                                        </Button>
+                                                        <Button
+                                                            variant="outlined"
+                                                            onClick={clearAvatarCandidate}
+                                                            disabled={!avatarCandidateDid && !avatarCandidatePreviewUrl && !avatarCandidateError}
+                                                        >
+                                                            Clear Preview
+                                                        </Button>
+                                                    </>
+                                                ) : (
+                                                    <Button variant="contained" color="error" onClick={removeAvatarProperty} disabled={!avatarDid}>
+                                                        Remove Avatar
+                                                    </Button>
+                                                )}
+                                            </Box>
+                                        </Box>
+                                    </Box>
+
+                                    <FormControl sx={{ mb: 2 }}>
+                                        <FormLabel>Set Avatar From</FormLabel>
+                                        <RadioGroup row value={avatarMode} onChange={handleAvatarModeChange}>
+                                            <FormControlLabel value="alias" control={<Radio />} label="Image Alias" />
+                                            <FormControlLabel value="did" control={<Radio />} label="DID" />
+                                            <FormControlLabel value="upload" control={<Radio />} label="Upload Image" />
+                                        </RadioGroup>
+                                    </FormControl>
+
+                                    {avatarMode === 'alias' &&
+                                        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
+                                            <Select
+                                                value={avatarAlias}
+                                                displayEmpty
+                                                size="small"
+                                                sx={{ minWidth: 280 }}
+                                                onChange={(event) => setAvatarAlias(event.target.value)}
+                                            >
+                                                <MenuItem value="" disabled>Select image alias</MenuItem>
+                                                {(imageList || []).map((name) => (
+                                                    <MenuItem key={name} value={name}>{name}</MenuItem>
+                                                ))}
+                                            </Select>
+                                            <Button
+                                                variant="contained"
+                                                onClick={() => previewAvatarCandidate(avatarAlias, { alias: avatarAlias })}
+                                                disabled={!avatarAlias}
+                                            >
+                                                Preview
+                                            </Button>
+                                        </Box>
+                                    }
+
+                                    {avatarMode === 'did' &&
+                                        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
+                                            <TextField
+                                                label="Avatar DID"
+                                                value={avatarInputDid}
+                                                onChange={(e) => setAvatarInputDid(e.target.value)}
+                                                size="small"
+                                                sx={{ minWidth: 420, flex: 1 }}
+                                            />
+                                            <Button
+                                                variant="contained"
+                                                onClick={() => previewAvatarCandidate(avatarInputDid)}
+                                                disabled={!avatarInputDid.trim()}
+                                            >
+                                                Preview
+                                            </Button>
+                                        </Box>
+                                    }
+
+                                    {avatarMode === 'upload' &&
+                                        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
+                                            <RegistrySelect />
+                                            <Button
+                                                variant="contained"
+                                                color="primary"
+                                                onClick={() => document.getElementById('avatarUpload').click()}
+                                                disabled={!registry}
+                                            >
+                                                Upload Image...
+                                            </Button>
+                                            <input
+                                                type="file"
+                                                id="avatarUpload"
+                                                accept="image/*"
+                                                style={{ display: 'none' }}
+                                                onChange={uploadAvatarImage}
+                                            />
+                                        </Box>
+                                    }
                                 </Box>
                             }
                             {identityTab === 'nostr' &&

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -877,8 +877,12 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     }
 
     function getImagePreviewUrl(doc) {
+        const image = doc?.didDocumentData?.image;
         const cid = doc?.didDocumentData?.file?.cid;
-        return cid ? `${serverUrl}/api/v1/ipfs/data/${cid}` : '';
+        const fileType = doc?.didDocumentData?.file?.type;
+        const isImageType = !fileType || fileType.startsWith('image/');
+
+        return image && cid && isImageType ? `${serverUrl}/api/v1/ipfs/data/${cid}` : '';
     }
 
     function clearAvatarCandidate() {

--- a/apps/react-wallet/src/components/DropDownID.tsx
+++ b/apps/react-wallet/src/components/DropDownID.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
     Box,
     Button,
@@ -11,6 +11,14 @@ import { useUIContext } from "../contexts/UIContext";
 import { useSnackbar } from "../contexts/SnackbarProvider";
 import { useVariablesContext } from "../contexts/VariablesProvider";
 import CopyDID from "./CopyDID";
+import GatekeeperClient from "@didcid/gatekeeper/client";
+import type { FileAsset, ImageAsset } from "@didcid/keymaster/types";
+import {
+    DEFAULT_GATEKEEPER_URL,
+    GATEKEEPER_KEY
+} from "../constants";
+
+const gatekeeper = new GatekeeperClient();
 
 const DropDownID = () => {
     const { keymaster } = useWalletContext();
@@ -24,9 +32,60 @@ const DropDownID = () => {
     const { resetCurrentID } = useUIContext();
 
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const [avatarPreviewUrl, setAvatarPreviewUrl] = useState<string>("");
 
     const truncatedId =
         currentId?.length > 10 ? currentId.slice(0, 10) + "..." : currentId;
+
+    useEffect(() => {
+        const init = async () => {
+            const gatekeeperUrl = localStorage.getItem(GATEKEEPER_KEY);
+            await gatekeeper.connect({ url: gatekeeperUrl || DEFAULT_GATEKEEPER_URL });
+        };
+        init();
+    }, []);
+
+    useEffect(() => {
+        const loadAvatar = async () => {
+            if (!keymaster || !currentDID) {
+                setAvatarPreviewUrl("");
+                return;
+            }
+
+            try {
+                const identityDoc = await keymaster.resolveDID(currentDID);
+                const identityData = identityDoc.didDocumentData as Record<string, unknown>;
+                const avatarDid = typeof identityData.avatar === "string" ? identityData.avatar.trim() : "";
+
+                if (!avatarDid) {
+                    setAvatarPreviewUrl("");
+                    return;
+                }
+
+                const avatarDoc = await keymaster.resolveDID(avatarDid);
+                const asset = avatarDoc.didDocumentData as { file?: FileAsset; image?: ImageAsset };
+
+                if (!asset.file?.cid || !asset.file?.type || !asset.image) {
+                    setAvatarPreviewUrl("");
+                    return;
+                }
+
+                const raw = await gatekeeper.getData(asset.file.cid);
+                if (!raw) {
+                    setAvatarPreviewUrl("");
+                    return;
+                }
+
+                setAvatarPreviewUrl(`data:${asset.file.type};base64,${raw.toString("base64")}`);
+            } catch {
+                setAvatarPreviewUrl("");
+            }
+        };
+
+        loadAvatar();
+        window.addEventListener("archon:avatar-changed", loadAvatar);
+        return () => window.removeEventListener("archon:avatar-changed", loadAvatar);
+    }, [currentDID, currentId, keymaster]);
 
     async function selectId(id: string) {
         if (!keymaster) {
@@ -116,6 +175,22 @@ const DropDownID = () => {
                     </Box>
                 )}
                 <CopyDID did={currentDID} />
+                {avatarPreviewUrl && (
+                    <Box
+                        component="img"
+                        src={avatarPreviewUrl}
+                        alt={`${currentId} avatar`}
+                        sx={{
+                            width: 32,
+                            height: 32,
+                            objectFit: "cover",
+                            borderRadius: "50%",
+                            border: "1px solid",
+                            borderColor: "divider",
+                            ml: 1,
+                        }}
+                    />
+                )}
             </Box>
         )
     );

--- a/apps/react-wallet/src/components/DropDownID.tsx
+++ b/apps/react-wallet/src/components/DropDownID.tsx
@@ -76,19 +76,23 @@ const DropDownID = () => {
                     return;
                 }
 
-                if (requestId === avatarRequestCounter) {
+                if (isActive && requestId === avatarRequestCounter) {
                     setAvatarPreviewUrl(`data:${asset.file.type};base64,${raw.toString("base64")}`);
                 }
             } catch {
-                if (requestId === avatarRequestCounter) {
+                if (isActive && requestId === avatarRequestCounter) {
                     setAvatarPreviewUrl("");
                 }
             }
         };
 
+        let isActive = true;
         loadAvatar();
         window.addEventListener("archon:avatar-changed", loadAvatar);
-        return () => window.removeEventListener("archon:avatar-changed", loadAvatar);
+        return () => {
+            isActive = false;
+            window.removeEventListener("archon:avatar-changed", loadAvatar);
+        };
     }, [currentDID, currentId, keymaster]);
 
     async function selectId(id: string) {

--- a/apps/react-wallet/src/components/DropDownID.tsx
+++ b/apps/react-wallet/src/components/DropDownID.tsx
@@ -19,6 +19,7 @@ import {
 } from "../constants";
 
 const gatekeeper = new GatekeeperClient();
+let avatarRequestCounter = 0;
 
 const DropDownID = () => {
     const { keymaster } = useWalletContext();
@@ -47,8 +48,10 @@ const DropDownID = () => {
 
     useEffect(() => {
         const loadAvatar = async () => {
+            const requestId = ++avatarRequestCounter;
+            setAvatarPreviewUrl("");
+
             if (!keymaster || !currentDID) {
-                setAvatarPreviewUrl("");
                 return;
             }
 
@@ -58,7 +61,6 @@ const DropDownID = () => {
                 const avatarDid = typeof identityData.avatar === "string" ? identityData.avatar.trim() : "";
 
                 if (!avatarDid) {
-                    setAvatarPreviewUrl("");
                     return;
                 }
 
@@ -66,19 +68,21 @@ const DropDownID = () => {
                 const asset = avatarDoc.didDocumentData as { file?: FileAsset; image?: ImageAsset };
 
                 if (!asset.file?.cid || !asset.file?.type || !asset.image) {
-                    setAvatarPreviewUrl("");
                     return;
                 }
 
                 const raw = await gatekeeper.getData(asset.file.cid);
                 if (!raw) {
-                    setAvatarPreviewUrl("");
                     return;
                 }
 
-                setAvatarPreviewUrl(`data:${asset.file.type};base64,${raw.toString("base64")}`);
+                if (requestId === avatarRequestCounter) {
+                    setAvatarPreviewUrl(`data:${asset.file.type};base64,${raw.toString("base64")}`);
+                }
             } catch {
-                setAvatarPreviewUrl("");
+                if (requestId === avatarRequestCounter) {
+                    setAvatarPreviewUrl("");
+                }
             }
         };
 

--- a/apps/react-wallet/src/components/IdentitiesTab.tsx
+++ b/apps/react-wallet/src/components/IdentitiesTab.tsx
@@ -1,16 +1,22 @@
-import { useCallback, useEffect, useState } from "react";
+import { ChangeEvent, useCallback, useEffect, useState } from "react";
 import JsonView from "@uiw/react-json-view";
 import { useWalletContext } from "../contexts/WalletProvider";
-import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, MenuItem, Paper, Select, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, TextField, Typography } from "@mui/material";
-import { Badge, Login, PermIdentity } from "@mui/icons-material";
+import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormControlLabel, FormLabel, MenuItem, Paper, Radio, RadioGroup, Select, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, TextField, Typography } from "@mui/material";
+import { Badge, Image, Login, PermIdentity } from "@mui/icons-material";
 import { useUIContext } from "../contexts/UIContext";
 import { useSnackbar } from "../contexts/SnackbarProvider";
 import WarningModal from "../modals/WarningModal";
 import TextInputModal from "../modals/TextInputModal";
 import SelectInputModal from "../modals/SelectInputModal";
-import { useThemeContext } from "../contexts/ContextProviders";
 import { useVariablesContext } from "../contexts/VariablesProvider";
-import type { AddressCheckResult, AddressInfo, NostrKeys } from "@didcid/keymaster/types";
+import type { AddressCheckResult, AddressInfo, FileAsset, ImageAsset, NostrKeys } from "@didcid/keymaster/types";
+import GatekeeperClient from "@didcid/gatekeeper/client";
+import {
+    DEFAULT_GATEKEEPER_URL,
+    GATEKEEPER_KEY
+} from "../constants";
+
+const gatekeeper = new GatekeeperClient();
 
 function parseAddressDomain(address: string): string {
     const trimmed = address.trim().toLowerCase();
@@ -38,7 +44,7 @@ function formatAddedDate(value: string): string {
 }
 
 function IdentitiesTab() {
-    const [identityTab, setIdentityTab] = useState<"details" | "addresses" | "nostr">("details");
+    const [identityTab, setIdentityTab] = useState<"details" | "addresses" | "avatar" | "nostr">("details");
     const [name, setName] = useState<string>("");
     const [warningModal, setWarningModal] = useState<boolean>(false);
     const [removeCalled, setRemoveCalled] = useState<boolean>(false);
@@ -56,6 +62,18 @@ function IdentitiesTab() {
     const [selectedAddress, setSelectedAddress] = useState<string>("");
     const [addressDetails, setAddressDetails] = useState<string>("");
     const [addressBusy, setAddressBusy] = useState<boolean>(false);
+    const [avatarMode, setAvatarMode] = useState<"alias" | "did" | "upload">("alias");
+    const [avatarAlias, setAvatarAlias] = useState<string>("");
+    const [avatarInputDid, setAvatarInputDid] = useState<string>("");
+    const [avatarDid, setAvatarDid] = useState<string>("");
+    const [avatarPreviewUrl, setAvatarPreviewUrl] = useState<string>("");
+    const [avatarLoading, setAvatarLoading] = useState<boolean>(false);
+    const [avatarError, setAvatarError] = useState<string>("");
+    const [avatarCandidateDid, setAvatarCandidateDid] = useState<string>("");
+    const [avatarCandidateAlias, setAvatarCandidateAlias] = useState<string>("");
+    const [avatarCandidatePreviewUrl, setAvatarCandidatePreviewUrl] = useState<string>("");
+    const [avatarCandidateLoading, setAvatarCandidateLoading] = useState<boolean>(false);
+    const [avatarCandidateError, setAvatarCandidateError] = useState<string>("");
     const { keymaster } = useWalletContext();
     const { setError, setSuccess } = useSnackbar();
     const {
@@ -65,11 +83,284 @@ function IdentitiesTab() {
     const {
         currentId,
         currentDID,
+        imageList,
+        aliasList,
         registry,
         setRegistry,
         registries,
     } = useVariablesContext();
-    const { isTabletUp } = useThemeContext();
+    useEffect(() => {
+        const init = async () => {
+            const gatekeeperUrl = localStorage.getItem(GATEKEEPER_KEY);
+            await gatekeeper.connect({ url: gatekeeperUrl || DEFAULT_GATEKEEPER_URL });
+        };
+        init();
+    }, []);
+
+    function findAliasByDid(did: string, allowedAliases?: string[]): string {
+        if (!did) {
+            return "";
+        }
+
+        const allowed = allowedAliases ? new Set(allowedAliases) : null;
+
+        for (const [name, aliasDid] of Object.entries(aliasList)) {
+            if (aliasDid === did && (!allowed || allowed.has(name))) {
+                return name;
+            }
+        }
+
+        return "";
+    }
+
+    async function getImagePreviewDataUrl(doc: Record<string, unknown>): Promise<string> {
+        const docAsset = doc as { file?: FileAsset; image?: ImageAsset };
+
+        if (!docAsset.file?.cid || !docAsset.file?.type || !docAsset.image) {
+            return "";
+        }
+
+        const raw = await gatekeeper.getData(docAsset.file.cid);
+        if (!raw) {
+            return "";
+        }
+
+        return `data:${docAsset.file.type};base64,${raw.toString("base64")}`;
+    }
+
+    function clearAvatarCandidate() {
+        setAvatarCandidateDid("");
+        setAvatarCandidateAlias("");
+        setAvatarCandidatePreviewUrl("");
+        setAvatarCandidateLoading(false);
+        setAvatarCandidateError("");
+    }
+
+    function handleAvatarModeChange(event: ChangeEvent<HTMLInputElement>) {
+        setAvatarMode(event.target.value as "alias" | "did" | "upload");
+        clearAvatarCandidate();
+    }
+
+    async function previewAvatarCandidate(input: string, options: { alias?: string } = {}) {
+        if (!keymaster) {
+            return;
+        }
+
+        const value = input.trim();
+        const preferredAlias = options.alias || "";
+
+        if (!value) {
+            setError("Choose an image alias or enter a DID");
+            return;
+        }
+
+        setAvatarCandidateLoading(true);
+        setAvatarCandidateError("");
+
+        try {
+            const doc = await keymaster.resolveDID(value);
+            const did = doc.didDocument?.id || "";
+            const previewUrl = await getImagePreviewDataUrl(doc.didDocumentData as Record<string, unknown>);
+
+            if (!did) {
+                setError("Unable to resolve avatar DID");
+                clearAvatarCandidate();
+                return;
+            }
+
+            if (!previewUrl) {
+                setAvatarCandidateDid(did);
+                setAvatarCandidateAlias(preferredAlias || findAliasByDid(did, imageList));
+                setAvatarCandidatePreviewUrl("");
+                setAvatarCandidateError("Avatar must resolve to an image asset DID");
+                return;
+            }
+
+            setAvatarCandidateDid(did);
+            setAvatarCandidateAlias(preferredAlias || findAliasByDid(did, imageList));
+            setAvatarCandidatePreviewUrl(previewUrl);
+            setAvatarCandidateError("");
+        } catch (error: any) {
+            clearAvatarCandidate();
+            setAvatarCandidateError(error.error || error.message || String(error));
+        } finally {
+            setAvatarCandidateLoading(false);
+        }
+    }
+
+    const loadAvatar = useCallback(async () => {
+        if (!keymaster || !currentDID) {
+            setAvatarAlias("");
+            setAvatarInputDid("");
+            setAvatarDid("");
+            setAvatarPreviewUrl("");
+            setAvatarError("");
+            clearAvatarCandidate();
+            setAvatarLoading(false);
+            return;
+        }
+
+        setAvatarLoading(true);
+        setAvatarError("");
+
+        try {
+            const identityDoc = await keymaster.resolveDID(currentDID);
+            const data = identityDoc.didDocumentData as Record<string, unknown>;
+            const rawAvatar = data.avatar;
+            const nextDid = typeof rawAvatar === "string" ? rawAvatar.trim() : "";
+
+            if (!nextDid) {
+                setAvatarAlias("");
+                setAvatarInputDid("");
+                setAvatarDid("");
+                setAvatarPreviewUrl("");
+                return;
+            }
+
+            setAvatarDid(nextDid);
+            setAvatarInputDid(nextDid);
+            setAvatarAlias(findAliasByDid(nextDid, imageList));
+
+            try {
+                const avatarDoc = await keymaster.resolveDID(nextDid);
+                const previewUrl = await getImagePreviewDataUrl(avatarDoc.didDocumentData as Record<string, unknown>);
+
+                if (previewUrl) {
+                    setAvatarPreviewUrl(previewUrl);
+                } else {
+                    setAvatarPreviewUrl("");
+                    setAvatarError("The current avatar does not resolve to an image asset.");
+                }
+            } catch (error: any) {
+                setAvatarPreviewUrl("");
+                setAvatarError(error.error || error.message || String(error));
+            }
+        } catch (error: any) {
+            setAvatarPreviewUrl("");
+            setAvatarDid("");
+            setAvatarAlias("");
+            setAvatarInputDid("");
+            setAvatarError(error.error || error.message || String(error));
+        } finally {
+            setAvatarLoading(false);
+        }
+    }, [currentDID, imageList, keymaster, aliasList]);
+
+    useEffect(() => {
+        loadAvatar();
+    }, [loadAvatar]);
+
+    async function applyAvatarCandidate() {
+        if (!keymaster) {
+            return;
+        }
+        if (!avatarCandidateDid || !avatarCandidatePreviewUrl) {
+            setError("Preview an image avatar before setting it");
+            return;
+        }
+
+        try {
+            await keymaster.mergeData(currentId, { avatar: avatarCandidateDid });
+            setAvatarDid(avatarCandidateDid);
+            setAvatarInputDid(avatarCandidateDid);
+            setAvatarAlias(avatarCandidateAlias || findAliasByDid(avatarCandidateDid, imageList));
+            setAvatarPreviewUrl(avatarCandidatePreviewUrl);
+            setAvatarError("");
+            clearAvatarCandidate();
+            await refreshCurrentIdDocs();
+            await loadAvatar();
+            window.dispatchEvent(new Event("archon:avatar-changed"));
+            setSuccess("Avatar updated");
+        } catch (error: any) {
+            setError(error);
+        }
+    }
+
+    async function removeAvatarProperty() {
+        if (!keymaster) {
+            return;
+        }
+
+        try {
+            await keymaster.mergeData(currentId, { avatar: null });
+            setAvatarAlias("");
+            setAvatarInputDid("");
+            setAvatarDid("");
+            setAvatarPreviewUrl("");
+            setAvatarError("");
+            clearAvatarCandidate();
+            await refreshCurrentIdDocs();
+            window.dispatchEvent(new Event("archon:avatar-changed"));
+            setSuccess("Avatar removed");
+        } catch (error: any) {
+            setError(error);
+        }
+    }
+
+    async function uploadAvatarImage(event: ChangeEvent<HTMLInputElement>) {
+        if (!keymaster) {
+            return;
+        }
+
+        try {
+            const fileInput = event.target;
+            if (!fileInput.files || fileInput.files.length === 0) {
+                return;
+            }
+
+            const file = fileInput.files[0];
+            fileInput.value = "";
+
+            const reader = new FileReader();
+
+            reader.onload = async (e) => {
+                try {
+                    if (!e.target?.result || !(e.target.result instanceof ArrayBuffer)) {
+                        setError("Unexpected file reader result");
+                        return;
+                    }
+
+                    const did = await keymaster.createImage(Buffer.from(e.target.result), { registry });
+                    const names = await keymaster.listAliases();
+                    let alias = file.name.slice(0, 26);
+                    let count = 1;
+
+                    while (alias in names) {
+                        alias = `${file.name.slice(0, 26)} (${count++})`;
+                    }
+
+                    await keymaster.addAlias(alias, did);
+                    await refreshAll();
+                    setAvatarMode("upload");
+                    await previewAvatarCandidate(did, { alias });
+                    setSuccess(`Avatar image uploaded successfully: ${alias}. Review the preview, then set the avatar.`);
+                } catch (error: any) {
+                    setError(`Error processing avatar image: ${error}`);
+                }
+            };
+
+            reader.onerror = (error) => {
+                setError(`Error reading file: ${error}`);
+            };
+
+            reader.readAsArrayBuffer(file);
+        } catch (error: any) {
+            setError(`Error uploading avatar image: ${error}`);
+        }
+    }
+
+    const isAvatarPreviewMode = !!(avatarCandidateDid || avatarCandidatePreviewUrl || avatarCandidateError || avatarCandidateLoading);
+    const displayedAvatarPreviewUrl = isAvatarPreviewMode ? avatarCandidatePreviewUrl : avatarPreviewUrl;
+    const displayedAvatarDid = isAvatarPreviewMode ? avatarCandidateDid : avatarDid;
+    const displayedAvatarError = isAvatarPreviewMode ? avatarCandidateError : avatarError;
+    const displayedAvatarLoading = isAvatarPreviewMode ? avatarCandidateLoading : avatarLoading;
+    const displayedAvatarTitle = isAvatarPreviewMode ? "Avatar Preview" : "Current Avatar";
+    const displayedAvatarDidLabel = isAvatarPreviewMode ? "Preview Avatar DID" : "Current Avatar DID";
+    const displayedAvatarEmptyText = displayedAvatarLoading
+        ? (isAvatarPreviewMode ? "Loading preview..." : "Loading avatar...")
+        : displayedAvatarError
+            ? (isAvatarPreviewMode ? "Preview unavailable" : "Avatar preview unavailable")
+            : "No avatar set";
 
     const handleCreateId = async () => {
         if (!keymaster) {
@@ -622,6 +913,7 @@ function IdentitiesTab() {
                         >
                             <Tab value="details" label="Details" icon={<PermIdentity />} iconPosition="top" />
                             <Tab value="addresses" label="Addresses" icon={<Badge />} iconPosition="top" />
+                            <Tab value="avatar" label="Avatar" icon={<Image />} iconPosition="top" />
                             <Tab value="nostr" label="Nostr" icon={<Login />} iconPosition="top" />
                         </Tabs>
                         {identityTab === "details" && (
@@ -674,6 +966,149 @@ function IdentitiesTab() {
                                     </Table>
                                 </TableContainer>
                                 <TextField multiline minRows={8} fullWidth value={addressDetails} InputProps={{ readOnly: true }} />
+                            </Box>
+                        )}
+                        {identityTab === "avatar" && (
+                            <Box sx={{ mt: 2, width: "100%" }}>
+                                <Box sx={{ display: "flex", gap: 3, flexWrap: "wrap", alignItems: "flex-start", mb: 3 }}>
+                                    <Box sx={{ width: 220 }}>
+                                        <Typography variant="subtitle1" sx={{ mb: 1 }}>{displayedAvatarTitle}</Typography>
+                                        <Paper variant="outlined" sx={{ width: 220, height: 220, display: "flex", alignItems: "center", justifyContent: "center", overflow: "hidden", bgcolor: "grey.50" }}>
+                                            {displayedAvatarPreviewUrl ? (
+                                                <img src={displayedAvatarPreviewUrl} alt={`${currentId} avatar`} style={{ width: "100%", height: "100%", objectFit: "contain" }} />
+                                            ) : (
+                                                <Typography color="text.secondary" sx={{ textAlign: "center", px: 2 }}>
+                                                    {displayedAvatarEmptyText}
+                                                </Typography>
+                                            )}
+                                        </Paper>
+                                    </Box>
+                                    <Box sx={{ flex: 1, minWidth: 280 }}>
+                                        <Typography variant="body2" sx={{ mb: 1 }}>
+                                            {isAvatarPreviewMode
+                                                ? "Review the preview below, then apply it to the selected identity."
+                                                : "The selected identity stores its avatar as the `avatar` property."}
+                                        </Typography>
+                                        <TextField
+                                            label={displayedAvatarDidLabel}
+                                            value={displayedAvatarDid}
+                                            fullWidth
+                                            size="small"
+                                            margin="normal"
+                                            InputProps={{ readOnly: true }}
+                                        />
+                                        {displayedAvatarError && (
+                                            <Alert severity="warning" sx={{ mt: 1 }}>
+                                                {displayedAvatarError}
+                                            </Alert>
+                                        )}
+                                        <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 2 }}>
+                                            {isAvatarPreviewMode ? (
+                                                <>
+                                                    <Button
+                                                        variant="contained"
+                                                        onClick={applyAvatarCandidate}
+                                                        disabled={!avatarCandidateDid || !avatarCandidatePreviewUrl}
+                                                    >
+                                                        Set Avatar
+                                                    </Button>
+                                                    <Button
+                                                        variant="outlined"
+                                                        onClick={clearAvatarCandidate}
+                                                        disabled={!avatarCandidateDid && !avatarCandidatePreviewUrl && !avatarCandidateError}
+                                                    >
+                                                        Clear Preview
+                                                    </Button>
+                                                </>
+                                            ) : (
+                                                <Button variant="contained" color="error" onClick={removeAvatarProperty} disabled={!avatarDid}>
+                                                    Remove Avatar
+                                                </Button>
+                                            )}
+                                        </Box>
+                                    </Box>
+                                </Box>
+
+                                <FormControl sx={{ mb: 2 }}>
+                                    <FormLabel>Set Avatar From</FormLabel>
+                                    <RadioGroup row value={avatarMode} onChange={handleAvatarModeChange}>
+                                        <FormControlLabel value="alias" control={<Radio />} label="Image Alias" />
+                                        <FormControlLabel value="did" control={<Radio />} label="DID" />
+                                        <FormControlLabel value="upload" control={<Radio />} label="Upload Image" />
+                                    </RadioGroup>
+                                </FormControl>
+
+                                {avatarMode === "alias" && (
+                                    <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+                                        <Select
+                                            value={avatarAlias}
+                                            displayEmpty
+                                            size="small"
+                                            sx={{ minWidth: 280 }}
+                                            onChange={(event) => setAvatarAlias(event.target.value)}
+                                        >
+                                            <MenuItem value="" disabled>Select image alias</MenuItem>
+                                            {imageList.map((name) => (
+                                                <MenuItem key={name} value={name}>{name}</MenuItem>
+                                            ))}
+                                        </Select>
+                                        <Button
+                                            variant="contained"
+                                            onClick={() => previewAvatarCandidate(avatarAlias, { alias: avatarAlias })}
+                                            disabled={!avatarAlias}
+                                        >
+                                            Preview
+                                        </Button>
+                                    </Box>
+                                )}
+
+                                {avatarMode === "did" && (
+                                    <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+                                        <TextField
+                                            label="Avatar DID"
+                                            value={avatarInputDid}
+                                            onChange={(e) => setAvatarInputDid(e.target.value)}
+                                            size="small"
+                                            sx={{ minWidth: 420, flex: 1 }}
+                                        />
+                                        <Button
+                                            variant="contained"
+                                            onClick={() => previewAvatarCandidate(avatarInputDid)}
+                                            disabled={!avatarInputDid.trim()}
+                                        >
+                                            Preview
+                                        </Button>
+                                    </Box>
+                                )}
+
+                                {avatarMode === "upload" && (
+                                    <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+                                        <Select
+                                            value={registries.includes(registry) ? registry : ""}
+                                            onChange={(e) => setRegistry(e.target.value)}
+                                            size="small"
+                                            sx={{ minWidth: 220 }}
+                                        >
+                                            {registries.map((r) => (
+                                                <MenuItem key={r} value={r}>{r}</MenuItem>
+                                            ))}
+                                        </Select>
+                                        <Button
+                                            variant="contained"
+                                            onClick={() => document.getElementById("avatarUpload")?.click()}
+                                            disabled={!registry}
+                                        >
+                                            Upload Image...
+                                        </Button>
+                                        <input
+                                            type="file"
+                                            id="avatarUpload"
+                                            accept="image/*"
+                                            style={{ display: "none" }}
+                                            onChange={uploadAvatarImage}
+                                        />
+                                    </Box>
+                                )}
                             </Box>
                         )}
                         {identityTab === "nostr" && (


### PR DESCRIPTION
## What changed
- adds an `Avatar` sub-tab under `Identities` in the gatekeeper client
- lets a user set an identity avatar from an image alias, a DID, or a newly uploaded image asset
- shows the current avatar preview and supports removing the `avatar` property

## Why
The identity UI already exposes other identity-specific settings, but avatar management still required editing DID document data indirectly. This adds a dedicated flow for assigning and clearing an identity avatar from the UI.

## Impact
Users can manage the `avatar` property directly from the identity screen, validate that it points to an image asset DID, and confirm the current avatar visually before changing it.

## Validation
- `npm run build` in `apps/gatekeeper-client`
