### PR TITLE
feat: Add identity name property tab

### DIFF
--- a/apps/browser-extension/src/components/IdentitiesTab.tsx
+++ b/apps/browser-extension/src/components/IdentitiesTab.tsx
@@ -101,7 +101,7 @@ function IdentitiesTab() {
         init();
     }, []);
 
-    function findAliasByDid(did: string, allowedAliases?: string[]): string {
+    const findAliasByDid = useCallback((did: string, allowedAliases?: string[]): string => {
         if (!did) {
             return "";
         }
@@ -115,7 +115,7 @@ function IdentitiesTab() {
         }
 
         return "";
-    }
+    }, [aliasList]);
 
     async function getImagePreviewDataUrl(doc: Record<string, unknown>): Promise<string> {
         const docAsset = doc as { file?: FileAsset; image?: ImageAsset };
@@ -248,7 +248,7 @@ function IdentitiesTab() {
         } finally {
             setAvatarLoading(false);
         }
-    }, [currentDID, imageList, keymaster, aliasList]);
+    }, [currentDID, findAliasByDid, imageList, keymaster]);
 
     useEffect(() => {
         loadAvatar();

--- a/apps/browser-extension/src/components/IdentitiesTab.tsx
+++ b/apps/browser-extension/src/components/IdentitiesTab.tsx
@@ -526,13 +526,28 @@ function IdentitiesTab() {
     const refreshCurrentIdDocs = useCallback(async () => {
         if (!keymaster || !currentDID) {
             setCurrentIdDocs(null);
+            setIdentityNameValue("");
+            setIdentityNameInput("");
+            setIdentityNameError("");
+            setIdentityNameLoading(false);
             return;
         }
         try {
             const docs = await keymaster.resolveDID(currentDID);
             setCurrentIdDocs(docs as Record<string, unknown>);
+            const rawName = (docs.didDocumentData as Record<string, unknown>)?.name;
+            const nextName = typeof rawName === "string" ? rawName : "";
+
+            setIdentityNameValue(nextName);
+            setIdentityNameInput(nextName);
+            setIdentityNameError("");
         } catch {
             setCurrentIdDocs(null);
+            setIdentityNameValue("");
+            setIdentityNameInput("");
+            setIdentityNameError("Unable to load identity details");
+        } finally {
+            setIdentityNameLoading(false);
         }
     }, [keymaster, currentDID]);
 
@@ -540,8 +555,8 @@ function IdentitiesTab() {
         refreshCurrentIdDocs();
     }, [refreshCurrentIdDocs]);
 
-    const loadIdentityName = useCallback(async () => {
-        if (!keymaster || !currentDID) {
+    useEffect(() => {
+        if (!currentDID) {
             setIdentityNameValue("");
             setIdentityNameInput("");
             setIdentityNameError("");
@@ -551,26 +566,7 @@ function IdentitiesTab() {
 
         setIdentityNameLoading(true);
         setIdentityNameError("");
-
-        try {
-            const identityDoc = await keymaster.resolveDID(currentDID);
-            const rawName = (identityDoc.didDocumentData as Record<string, unknown>)?.name;
-            const nextName = typeof rawName === "string" ? rawName : "";
-
-            setIdentityNameValue(nextName);
-            setIdentityNameInput(nextName);
-        } catch (error: any) {
-            setIdentityNameValue("");
-            setIdentityNameInput("");
-            setIdentityNameError(error.error || error.message || String(error));
-        } finally {
-            setIdentityNameLoading(false);
-        }
-    }, [currentDID, keymaster]);
-
-    useEffect(() => {
-        loadIdentityName();
-    }, [loadIdentityName]);
+    }, [currentDID]);
 
     const refreshAddresses = useCallback(async () => {
         if (!keymaster || !currentId) {

--- a/apps/browser-extension/src/components/IdentitiesTab.tsx
+++ b/apps/browser-extension/src/components/IdentitiesTab.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, useCallback, useEffect, useState } from "react";
 import JsonView from "@uiw/react-json-view";
 import { useWalletContext } from "../contexts/WalletProvider";
 import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormControlLabel, FormLabel, MenuItem, Paper, Radio, RadioGroup, Select, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, TextField, Typography } from "@mui/material";
-import { Badge, Image, Login, PermIdentity } from "@mui/icons-material";
+import { Badge, Create, Image, Login, PermIdentity } from "@mui/icons-material";
 import { useUIContext } from "../contexts/UIContext";
 import { useSnackbar } from "../contexts/SnackbarProvider";
 import WarningModal from "../modals/WarningModal";
@@ -41,7 +41,7 @@ function formatAddedDate(value: string): string {
 }
 
 function IdentitiesTab() {
-    const [identityTab, setIdentityTab] = useState<"details" | "addresses" | "avatar" | "nostr">("details");
+    const [identityTab, setIdentityTab] = useState<"details" | "addresses" | "name" | "avatar" | "nostr">("details");
     const [name, setName] = useState<string>("");
     const [warningModal, setWarningModal] = useState<boolean>(false);
     const [removeCalled, setRemoveCalled] = useState<boolean>(false);
@@ -59,6 +59,10 @@ function IdentitiesTab() {
     const [selectedAddress, setSelectedAddress] = useState<string>("");
     const [addressDetails, setAddressDetails] = useState<string>("");
     const [addressBusy, setAddressBusy] = useState<boolean>(false);
+    const [identityNameValue, setIdentityNameValue] = useState<string>("");
+    const [identityNameInput, setIdentityNameInput] = useState<string>("");
+    const [identityNameLoading, setIdentityNameLoading] = useState<boolean>(false);
+    const [identityNameError, setIdentityNameError] = useState<string>("");
     const [avatarMode, setAvatarMode] = useState<"alias" | "did" | "upload">("alias");
     const [avatarAlias, setAvatarAlias] = useState<string>("");
     const [avatarInputDid, setAvatarInputDid] = useState<string>("");
@@ -536,6 +540,38 @@ function IdentitiesTab() {
         refreshCurrentIdDocs();
     }, [refreshCurrentIdDocs]);
 
+    const loadIdentityName = useCallback(async () => {
+        if (!keymaster || !currentDID) {
+            setIdentityNameValue("");
+            setIdentityNameInput("");
+            setIdentityNameError("");
+            setIdentityNameLoading(false);
+            return;
+        }
+
+        setIdentityNameLoading(true);
+        setIdentityNameError("");
+
+        try {
+            const identityDoc = await keymaster.resolveDID(currentDID);
+            const rawName = (identityDoc.didDocumentData as Record<string, unknown>)?.name;
+            const nextName = typeof rawName === "string" ? rawName : "";
+
+            setIdentityNameValue(nextName);
+            setIdentityNameInput(nextName);
+        } catch (error: any) {
+            setIdentityNameValue("");
+            setIdentityNameInput("");
+            setIdentityNameError(error.error || error.message || String(error));
+        } finally {
+            setIdentityNameLoading(false);
+        }
+    }, [currentDID, keymaster]);
+
+    useEffect(() => {
+        loadIdentityName();
+    }, [loadIdentityName]);
+
     const refreshAddresses = useCallback(async () => {
         if (!keymaster || !currentId) {
             setAddressList({});
@@ -751,6 +787,47 @@ function IdentitiesTab() {
         }
     }
 
+    async function setIdentityNameProperty() {
+        if (!keymaster) {
+            return;
+        }
+
+        const nextName = identityNameInput.trim();
+
+        if (!nextName) {
+            setError("Enter a name to set");
+            return;
+        }
+
+        try {
+            await keymaster.mergeData(currentId, { name: nextName });
+            setIdentityNameValue(nextName);
+            setIdentityNameInput(nextName);
+            setIdentityNameError("");
+            await refreshCurrentIdDocs();
+            setSuccess("Name updated");
+        } catch (error: any) {
+            setError(error);
+        }
+    }
+
+    async function removeIdentityNameProperty() {
+        if (!keymaster) {
+            return;
+        }
+
+        try {
+            await keymaster.mergeData(currentId, { name: null });
+            setIdentityNameValue("");
+            setIdentityNameInput("");
+            setIdentityNameError("");
+            await refreshCurrentIdDocs();
+            setSuccess("Name removed");
+        } catch (error: any) {
+            setError(error);
+        }
+    }
+
     return (
         <Box sx={{ width: '100%' }}>
             <WarningModal
@@ -914,6 +991,7 @@ function IdentitiesTab() {
                         >
                             <Tab value="details" label="Details" icon={<PermIdentity />} iconPosition="top" />
                             <Tab value="addresses" label="Addresses" icon={<Badge />} iconPosition="top" />
+                            <Tab value="name" label="Name" icon={<Create />} iconPosition="top" />
                             <Tab value="avatar" label="Avatar" icon={<Image />} iconPosition="top" />
                             <Tab value="nostr" label="Nostr" icon={<Login />} iconPosition="top" />
                         </Tabs>
@@ -967,6 +1045,53 @@ function IdentitiesTab() {
                                     </Table>
                                 </TableContainer>
                                 <TextField multiline minRows={8} fullWidth value={addressDetails} InputProps={{ readOnly: true }} />
+                            </Box>
+                        )}
+                        {identityTab === "name" && (
+                            <Box sx={{ mt: 2, width: '100%', maxWidth: 520 }}>
+                                <Typography variant="body2" sx={{ mb: 1 }}>
+                                    The selected identity stores its display name as the `name` property.
+                                </Typography>
+                                <TextField
+                                    label="Current Name"
+                                    value={identityNameValue}
+                                    fullWidth
+                                    size="small"
+                                    margin="normal"
+                                    slotProps={{ input: { readOnly: true } }}
+                                    placeholder={identityNameLoading ? "Loading..." : "No name set"}
+                                />
+                                <TextField
+                                    label="Name"
+                                    value={identityNameInput}
+                                    onChange={(e) => setIdentityNameInput(e.target.value)}
+                                    fullWidth
+                                    size="small"
+                                    margin="normal"
+                                    placeholder="Enter name"
+                                />
+                                {identityNameError && (
+                                    <Alert severity="warning" sx={{ mt: 1 }}>
+                                        {identityNameError}
+                                    </Alert>
+                                )}
+                                <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 2 }}>
+                                    <Button
+                                        variant="contained"
+                                        onClick={setIdentityNameProperty}
+                                        disabled={!identityNameInput.trim()}
+                                    >
+                                        Set Name
+                                    </Button>
+                                    <Button
+                                        variant="contained"
+                                        color="error"
+                                        onClick={removeIdentityNameProperty}
+                                        disabled={!identityNameValue}
+                                    >
+                                        Remove Name
+                                    </Button>
+                                </Box>
                             </Box>
                         )}
                         {identityTab === "avatar" && (

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -1006,6 +1006,21 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedId, aliasList, imageList]);
 
+    useEffect(() => {
+        if (!selectedId) {
+            setIdentityNameValue('');
+            setIdentityNameInput('');
+            setIdentityNameError('');
+            setIdentityNameLoading(false);
+            return;
+        }
+
+        setIdentityNameValue('');
+        setIdentityNameInput('');
+        setIdentityNameError('');
+        setIdentityNameLoading(true);
+    }, [selectedId]);
+
     async function applyAvatarCandidate() {
         if (!avatarCandidateDid || !avatarCandidatePreviewUrl) {
             showAlert('Preview an image avatar before setting it');
@@ -1096,39 +1111,6 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
     }
 
-    async function loadIdentityName() {
-        if (!selectedId) {
-            setIdentityNameValue('');
-            setIdentityNameInput('');
-            setIdentityNameError('');
-            setIdentityNameLoading(false);
-            return;
-        }
-
-        setIdentityNameLoading(true);
-        setIdentityNameError('');
-
-        try {
-            const identityDoc = await keymaster.resolveDID(selectedId);
-            const rawName = identityDoc?.didDocumentData?.name;
-            const nextName = typeof rawName === 'string' ? rawName : '';
-
-            setIdentityNameValue(nextName);
-            setIdentityNameInput(nextName);
-        } catch (error) {
-            setIdentityNameValue('');
-            setIdentityNameInput('');
-            setIdentityNameError(error.error || error.message || String(error));
-        } finally {
-            setIdentityNameLoading(false);
-        }
-    }
-
-    useEffect(() => {
-        loadIdentityName();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [selectedId]);
-
     async function setIdentityNameProperty() {
         const nextName = identityNameInput.trim();
 
@@ -1204,11 +1186,21 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             setManifest(docs.didDocumentData.manifest);
             setNostrKeys(docs.didDocumentData.nostr || null);
             setDocsString(JSON.stringify(docs, null, 4));
+            const rawName = docs?.didDocumentData?.name;
+            const nextName = typeof rawName === 'string' ? rawName : '';
+            setIdentityNameValue(nextName);
+            setIdentityNameInput(nextName);
+            setIdentityNameError('');
+            setIdentityNameLoading(false);
 
             const versions = docs.didDocumentMetadata.version ?? 1;
             setDocsVersion(versions);
             setDocsVersionMax(versions);
         } catch (error) {
+            setIdentityNameValue('');
+            setIdentityNameInput('');
+            setIdentityNameError(error.error || error.message || String(error));
+            setIdentityNameLoading(false);
             showError(error);
         }
     }

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -375,6 +375,10 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [avatarCandidatePreviewUrl, setAvatarCandidatePreviewUrl] = useState('');
     const [avatarCandidateLoading, setAvatarCandidateLoading] = useState(false);
     const [avatarCandidateError, setAvatarCandidateError] = useState('');
+    const [identityNameValue, setIdentityNameValue] = useState('');
+    const [identityNameInput, setIdentityNameInput] = useState('');
+    const [identityNameLoading, setIdentityNameLoading] = useState(false);
+    const [identityNameError, setIdentityNameError] = useState('');
 
     const [lightningTab, setLightningTab] = useState('wallet');
     const [lightningBalance, setLightningBalance] = useState(null);
@@ -1087,6 +1091,72 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         try {
             await navigator.clipboard.writeText(currentDID);
             showSuccess('DID copied to clipboard');
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    async function loadIdentityName() {
+        if (!selectedId) {
+            setIdentityNameValue('');
+            setIdentityNameInput('');
+            setIdentityNameError('');
+            setIdentityNameLoading(false);
+            return;
+        }
+
+        setIdentityNameLoading(true);
+        setIdentityNameError('');
+
+        try {
+            const identityDoc = await keymaster.resolveDID(selectedId);
+            const rawName = identityDoc?.didDocumentData?.name;
+            const nextName = typeof rawName === 'string' ? rawName : '';
+
+            setIdentityNameValue(nextName);
+            setIdentityNameInput(nextName);
+        } catch (error) {
+            setIdentityNameValue('');
+            setIdentityNameInput('');
+            setIdentityNameError(error.error || error.message || String(error));
+        } finally {
+            setIdentityNameLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        loadIdentityName();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedId]);
+
+    async function setIdentityNameProperty() {
+        const nextName = identityNameInput.trim();
+
+        if (!nextName) {
+            showAlert('Enter a name to set');
+            return;
+        }
+
+        try {
+            await keymaster.mergeData(selectedId, { name: nextName });
+            setIdentityNameValue(nextName);
+            setIdentityNameInput(nextName);
+            setIdentityNameError('');
+            showSuccess('Name updated');
+            await resolveId();
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    async function removeIdentityNameProperty() {
+        try {
+            await keymaster.mergeData(selectedId, { name: null });
+            setIdentityNameValue('');
+            setIdentityNameInput('');
+            setIdentityNameError('');
+            showSuccess('Name removed');
+            await resolveId();
         } catch (error) {
             showError(error);
         }
@@ -4448,6 +4518,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                 >
                                     <Tab key="details" value="details" label={'Details'} icon={<PermIdentity />} />
                                     <Tab key="addresses" value="addresses" label={'Addresses'} icon={<Badge />} />
+                                    <Tab key="name" value="name" label={'Name'} icon={<Create />} />
                                     <Tab key="avatar" value="avatar" label={'Avatar'} icon={<Image />} />
                                     <Tab key="nostr" value="nostr" label={'Nostr'} icon={<Login />} />
                                 </Tabs>
@@ -4609,6 +4680,55 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                         readOnly
                                         style={{ width: '100%', height: '240px', overflow: 'auto' }}
                                     />
+                                </Box>
+                            }
+                            {identityTab === 'name' &&
+                                <Box sx={{ width: '800px', maxWidth: '100%' }}>
+                                    <Box sx={{ maxWidth: 520 }}>
+                                        <Typography variant="body2" sx={{ mb: 1 }}>
+                                            The selected identity stores its display name as the `name` property.
+                                        </Typography>
+                                        <TextField
+                                            label="Current Name"
+                                            value={identityNameValue}
+                                            fullWidth
+                                            size="small"
+                                            margin="normal"
+                                            InputProps={{ readOnly: true }}
+                                            placeholder={identityNameLoading ? 'Loading...' : 'No name set'}
+                                        />
+                                        <TextField
+                                            label="Name"
+                                            value={identityNameInput}
+                                            onChange={(e) => setIdentityNameInput(e.target.value)}
+                                            fullWidth
+                                            size="small"
+                                            margin="normal"
+                                            placeholder="Enter name"
+                                        />
+                                        {identityNameError &&
+                                            <Alert severity="warning" sx={{ mt: 1 }}>
+                                                {identityNameError}
+                                            </Alert>
+                                        }
+                                        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 2 }}>
+                                            <Button
+                                                variant="contained"
+                                                onClick={setIdentityNameProperty}
+                                                disabled={!identityNameInput.trim()}
+                                            >
+                                                Set Name
+                                            </Button>
+                                            <Button
+                                                variant="contained"
+                                                color="error"
+                                                onClick={removeIdentityNameProperty}
+                                                disabled={!identityNameValue}
+                                            >
+                                                Remove Name
+                                            </Button>
+                                        </Box>
+                                    </Box>
                                 </Box>
                             }
                             {identityTab === 'avatar' &&

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -1006,6 +1006,21 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedId, aliasList, imageList]);
 
+    useEffect(() => {
+        if (!selectedId) {
+            setIdentityNameValue('');
+            setIdentityNameInput('');
+            setIdentityNameError('');
+            setIdentityNameLoading(false);
+            return;
+        }
+
+        setIdentityNameValue('');
+        setIdentityNameInput('');
+        setIdentityNameError('');
+        setIdentityNameLoading(true);
+    }, [selectedId]);
+
     async function applyAvatarCandidate() {
         if (!avatarCandidateDid || !avatarCandidatePreviewUrl) {
             showAlert('Preview an image avatar before setting it');
@@ -1096,39 +1111,6 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
     }
 
-    async function loadIdentityName() {
-        if (!selectedId) {
-            setIdentityNameValue('');
-            setIdentityNameInput('');
-            setIdentityNameError('');
-            setIdentityNameLoading(false);
-            return;
-        }
-
-        setIdentityNameLoading(true);
-        setIdentityNameError('');
-
-        try {
-            const identityDoc = await keymaster.resolveDID(selectedId);
-            const rawName = identityDoc?.didDocumentData?.name;
-            const nextName = typeof rawName === 'string' ? rawName : '';
-
-            setIdentityNameValue(nextName);
-            setIdentityNameInput(nextName);
-        } catch (error) {
-            setIdentityNameValue('');
-            setIdentityNameInput('');
-            setIdentityNameError(error.error || error.message || String(error));
-        } finally {
-            setIdentityNameLoading(false);
-        }
-    }
-
-    useEffect(() => {
-        loadIdentityName();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [selectedId]);
-
     async function setIdentityNameProperty() {
         const nextName = identityNameInput.trim();
 
@@ -1204,11 +1186,21 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             setManifest(docs.didDocumentData.manifest);
             setNostrKeys(docs.didDocumentData.nostr || null);
             setDocsString(JSON.stringify(docs, null, 4));
+            const rawName = docs?.didDocumentData?.name;
+            const nextName = typeof rawName === 'string' ? rawName : '';
+            setIdentityNameValue(nextName);
+            setIdentityNameInput(nextName);
+            setIdentityNameError('');
+            setIdentityNameLoading(false);
 
             const versions = docs.didDocumentMetadata.version ?? 1;
             setDocsVersion(versions);
             setDocsVersionMax(versions);
         } catch (error) {
+            setIdentityNameValue('');
+            setIdentityNameInput('');
+            setIdentityNameError(error.error || error.message || String(error));
+            setIdentityNameLoading(false);
             showError(error);
         }
     }

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -375,6 +375,10 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [avatarCandidatePreviewUrl, setAvatarCandidatePreviewUrl] = useState('');
     const [avatarCandidateLoading, setAvatarCandidateLoading] = useState(false);
     const [avatarCandidateError, setAvatarCandidateError] = useState('');
+    const [identityNameValue, setIdentityNameValue] = useState('');
+    const [identityNameInput, setIdentityNameInput] = useState('');
+    const [identityNameLoading, setIdentityNameLoading] = useState(false);
+    const [identityNameError, setIdentityNameError] = useState('');
 
     const [lightningTab, setLightningTab] = useState('wallet');
     const [lightningBalance, setLightningBalance] = useState(null);
@@ -1087,6 +1091,72 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         try {
             await navigator.clipboard.writeText(currentDID);
             showSuccess('DID copied to clipboard');
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    async function loadIdentityName() {
+        if (!selectedId) {
+            setIdentityNameValue('');
+            setIdentityNameInput('');
+            setIdentityNameError('');
+            setIdentityNameLoading(false);
+            return;
+        }
+
+        setIdentityNameLoading(true);
+        setIdentityNameError('');
+
+        try {
+            const identityDoc = await keymaster.resolveDID(selectedId);
+            const rawName = identityDoc?.didDocumentData?.name;
+            const nextName = typeof rawName === 'string' ? rawName : '';
+
+            setIdentityNameValue(nextName);
+            setIdentityNameInput(nextName);
+        } catch (error) {
+            setIdentityNameValue('');
+            setIdentityNameInput('');
+            setIdentityNameError(error.error || error.message || String(error));
+        } finally {
+            setIdentityNameLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        loadIdentityName();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedId]);
+
+    async function setIdentityNameProperty() {
+        const nextName = identityNameInput.trim();
+
+        if (!nextName) {
+            showAlert('Enter a name to set');
+            return;
+        }
+
+        try {
+            await keymaster.mergeData(selectedId, { name: nextName });
+            setIdentityNameValue(nextName);
+            setIdentityNameInput(nextName);
+            setIdentityNameError('');
+            showSuccess('Name updated');
+            await resolveId();
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    async function removeIdentityNameProperty() {
+        try {
+            await keymaster.mergeData(selectedId, { name: null });
+            setIdentityNameValue('');
+            setIdentityNameInput('');
+            setIdentityNameError('');
+            showSuccess('Name removed');
+            await resolveId();
         } catch (error) {
             showError(error);
         }
@@ -4448,6 +4518,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                 >
                                     <Tab key="details" value="details" label={'Details'} icon={<PermIdentity />} />
                                     <Tab key="addresses" value="addresses" label={'Addresses'} icon={<Badge />} />
+                                    <Tab key="name" value="name" label={'Name'} icon={<Create />} />
                                     <Tab key="avatar" value="avatar" label={'Avatar'} icon={<Image />} />
                                     <Tab key="nostr" value="nostr" label={'Nostr'} icon={<Login />} />
                                 </Tabs>
@@ -4609,6 +4680,55 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                         readOnly
                                         style={{ width: '100%', height: '240px', overflow: 'auto' }}
                                     />
+                                </Box>
+                            }
+                            {identityTab === 'name' &&
+                                <Box sx={{ width: '800px', maxWidth: '100%' }}>
+                                    <Box sx={{ maxWidth: 520 }}>
+                                        <Typography variant="body2" sx={{ mb: 1 }}>
+                                            The selected identity stores its display name as the `name` property.
+                                        </Typography>
+                                        <TextField
+                                            label="Current Name"
+                                            value={identityNameValue}
+                                            fullWidth
+                                            size="small"
+                                            margin="normal"
+                                            InputProps={{ readOnly: true }}
+                                            placeholder={identityNameLoading ? 'Loading...' : 'No name set'}
+                                        />
+                                        <TextField
+                                            label="Name"
+                                            value={identityNameInput}
+                                            onChange={(e) => setIdentityNameInput(e.target.value)}
+                                            fullWidth
+                                            size="small"
+                                            margin="normal"
+                                            placeholder="Enter name"
+                                        />
+                                        {identityNameError &&
+                                            <Alert severity="warning" sx={{ mt: 1 }}>
+                                                {identityNameError}
+                                            </Alert>
+                                        }
+                                        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 2 }}>
+                                            <Button
+                                                variant="contained"
+                                                onClick={setIdentityNameProperty}
+                                                disabled={!identityNameInput.trim()}
+                                            >
+                                                Set Name
+                                            </Button>
+                                            <Button
+                                                variant="contained"
+                                                color="error"
+                                                onClick={removeIdentityNameProperty}
+                                                disabled={!identityNameValue}
+                                            >
+                                                Remove Name
+                                            </Button>
+                                        </Box>
+                                    </Box>
                                 </Box>
                             }
                             {identityTab === 'avatar' &&

--- a/apps/react-wallet/src/components/IdentitiesTab.tsx
+++ b/apps/react-wallet/src/components/IdentitiesTab.tsx
@@ -525,13 +525,28 @@ function IdentitiesTab() {
     const refreshCurrentIdDocs = useCallback(async () => {
         if (!keymaster || !currentDID) {
             setCurrentIdDocs(null);
+            setIdentityNameValue("");
+            setIdentityNameInput("");
+            setIdentityNameError("");
+            setIdentityNameLoading(false);
             return;
         }
         try {
             const docs = await keymaster.resolveDID(currentDID);
             setCurrentIdDocs(docs as Record<string, unknown>);
+            const rawName = (docs.didDocumentData as Record<string, unknown>)?.name;
+            const nextName = typeof rawName === "string" ? rawName : "";
+
+            setIdentityNameValue(nextName);
+            setIdentityNameInput(nextName);
+            setIdentityNameError("");
         } catch {
             setCurrentIdDocs(null);
+            setIdentityNameValue("");
+            setIdentityNameInput("");
+            setIdentityNameError("Unable to load identity details");
+        } finally {
+            setIdentityNameLoading(false);
         }
     }, [keymaster, currentDID]);
 
@@ -539,8 +554,8 @@ function IdentitiesTab() {
         refreshCurrentIdDocs();
     }, [refreshCurrentIdDocs]);
 
-    const loadIdentityName = useCallback(async () => {
-        if (!keymaster || !currentDID) {
+    useEffect(() => {
+        if (!currentDID) {
             setIdentityNameValue("");
             setIdentityNameInput("");
             setIdentityNameError("");
@@ -550,26 +565,7 @@ function IdentitiesTab() {
 
         setIdentityNameLoading(true);
         setIdentityNameError("");
-
-        try {
-            const identityDoc = await keymaster.resolveDID(currentDID);
-            const rawName = (identityDoc.didDocumentData as Record<string, unknown>)?.name;
-            const nextName = typeof rawName === "string" ? rawName : "";
-
-            setIdentityNameValue(nextName);
-            setIdentityNameInput(nextName);
-        } catch (error: any) {
-            setIdentityNameValue("");
-            setIdentityNameInput("");
-            setIdentityNameError(error.error || error.message || String(error));
-        } finally {
-            setIdentityNameLoading(false);
-        }
-    }, [currentDID, keymaster]);
-
-    useEffect(() => {
-        loadIdentityName();
-    }, [loadIdentityName]);
+    }, [currentDID]);
 
     const refreshAddresses = useCallback(async () => {
         if (!keymaster || !currentId) {

--- a/apps/react-wallet/src/components/IdentitiesTab.tsx
+++ b/apps/react-wallet/src/components/IdentitiesTab.tsx
@@ -101,7 +101,7 @@ function IdentitiesTab() {
         init();
     }, []);
 
-    function findAliasByDid(did: string, allowedAliases?: string[]): string {
+    const findAliasByDid = useCallback((did: string, allowedAliases?: string[]): string => {
         if (!did) {
             return "";
         }
@@ -115,7 +115,7 @@ function IdentitiesTab() {
         }
 
         return "";
-    }
+    }, [aliasList]);
 
     async function getImagePreviewDataUrl(doc: Record<string, unknown>): Promise<string> {
         const docAsset = doc as { file?: FileAsset; image?: ImageAsset };
@@ -248,7 +248,7 @@ function IdentitiesTab() {
         } finally {
             setAvatarLoading(false);
         }
-    }, [currentDID, imageList, keymaster, aliasList]);
+    }, [currentDID, findAliasByDid, imageList, keymaster]);
 
     useEffect(() => {
         loadAvatar();

--- a/apps/react-wallet/src/components/IdentitiesTab.tsx
+++ b/apps/react-wallet/src/components/IdentitiesTab.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent, useCallback, useEffect, useState } from "react";
 import JsonView from "@uiw/react-json-view";
 import { useWalletContext } from "../contexts/WalletProvider";
 import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormControlLabel, FormLabel, MenuItem, Paper, Radio, RadioGroup, Select, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, TextField, Typography } from "@mui/material";
-import { Badge, Image, Login, PermIdentity } from "@mui/icons-material";
+import { Badge, Create, Image, Login, PermIdentity } from "@mui/icons-material";
 import { useUIContext } from "../contexts/UIContext";
 import { useSnackbar } from "../contexts/SnackbarProvider";
 import WarningModal from "../modals/WarningModal";
@@ -44,7 +44,7 @@ function formatAddedDate(value: string): string {
 }
 
 function IdentitiesTab() {
-    const [identityTab, setIdentityTab] = useState<"details" | "addresses" | "avatar" | "nostr">("details");
+    const [identityTab, setIdentityTab] = useState<"details" | "addresses" | "name" | "avatar" | "nostr">("details");
     const [name, setName] = useState<string>("");
     const [warningModal, setWarningModal] = useState<boolean>(false);
     const [removeCalled, setRemoveCalled] = useState<boolean>(false);
@@ -62,6 +62,10 @@ function IdentitiesTab() {
     const [selectedAddress, setSelectedAddress] = useState<string>("");
     const [addressDetails, setAddressDetails] = useState<string>("");
     const [addressBusy, setAddressBusy] = useState<boolean>(false);
+    const [identityNameValue, setIdentityNameValue] = useState<string>("");
+    const [identityNameInput, setIdentityNameInput] = useState<string>("");
+    const [identityNameLoading, setIdentityNameLoading] = useState<boolean>(false);
+    const [identityNameError, setIdentityNameError] = useState<string>("");
     const [avatarMode, setAvatarMode] = useState<"alias" | "did" | "upload">("alias");
     const [avatarAlias, setAvatarAlias] = useState<string>("");
     const [avatarInputDid, setAvatarInputDid] = useState<string>("");
@@ -535,6 +539,38 @@ function IdentitiesTab() {
         refreshCurrentIdDocs();
     }, [refreshCurrentIdDocs]);
 
+    const loadIdentityName = useCallback(async () => {
+        if (!keymaster || !currentDID) {
+            setIdentityNameValue("");
+            setIdentityNameInput("");
+            setIdentityNameError("");
+            setIdentityNameLoading(false);
+            return;
+        }
+
+        setIdentityNameLoading(true);
+        setIdentityNameError("");
+
+        try {
+            const identityDoc = await keymaster.resolveDID(currentDID);
+            const rawName = (identityDoc.didDocumentData as Record<string, unknown>)?.name;
+            const nextName = typeof rawName === "string" ? rawName : "";
+
+            setIdentityNameValue(nextName);
+            setIdentityNameInput(nextName);
+        } catch (error: any) {
+            setIdentityNameValue("");
+            setIdentityNameInput("");
+            setIdentityNameError(error.error || error.message || String(error));
+        } finally {
+            setIdentityNameLoading(false);
+        }
+    }, [currentDID, keymaster]);
+
+    useEffect(() => {
+        loadIdentityName();
+    }, [loadIdentityName]);
+
     const refreshAddresses = useCallback(async () => {
         if (!keymaster || !currentId) {
             setAddressList({});
@@ -750,6 +786,47 @@ function IdentitiesTab() {
         }
     }
 
+    async function setIdentityNameProperty() {
+        if (!keymaster) {
+            return;
+        }
+
+        const nextName = identityNameInput.trim();
+
+        if (!nextName) {
+            setError("Enter a name to set");
+            return;
+        }
+
+        try {
+            await keymaster.mergeData(currentId, { name: nextName });
+            setIdentityNameValue(nextName);
+            setIdentityNameInput(nextName);
+            setIdentityNameError("");
+            await refreshCurrentIdDocs();
+            setSuccess("Name updated");
+        } catch (error: any) {
+            setError(error);
+        }
+    }
+
+    async function removeIdentityNameProperty() {
+        if (!keymaster) {
+            return;
+        }
+
+        try {
+            await keymaster.mergeData(currentId, { name: null });
+            setIdentityNameValue("");
+            setIdentityNameInput("");
+            setIdentityNameError("");
+            await refreshCurrentIdDocs();
+            setSuccess("Name removed");
+        } catch (error: any) {
+            setError(error);
+        }
+    }
+
     return (
         <Box sx={{ width: '100%' }}>
             <WarningModal
@@ -913,6 +990,7 @@ function IdentitiesTab() {
                         >
                             <Tab value="details" label="Details" icon={<PermIdentity />} iconPosition="top" />
                             <Tab value="addresses" label="Addresses" icon={<Badge />} iconPosition="top" />
+                            <Tab value="name" label="Name" icon={<Create />} iconPosition="top" />
                             <Tab value="avatar" label="Avatar" icon={<Image />} iconPosition="top" />
                             <Tab value="nostr" label="Nostr" icon={<Login />} iconPosition="top" />
                         </Tabs>
@@ -966,6 +1044,53 @@ function IdentitiesTab() {
                                     </Table>
                                 </TableContainer>
                                 <TextField multiline minRows={8} fullWidth value={addressDetails} InputProps={{ readOnly: true }} />
+                            </Box>
+                        )}
+                        {identityTab === "name" && (
+                            <Box sx={{ mt: 2, width: '100%', maxWidth: 520 }}>
+                                <Typography variant="body2" sx={{ mb: 1 }}>
+                                    The selected identity stores its display name as the `name` property.
+                                </Typography>
+                                <TextField
+                                    label="Current Name"
+                                    value={identityNameValue}
+                                    fullWidth
+                                    size="small"
+                                    margin="normal"
+                                    slotProps={{ input: { readOnly: true } }}
+                                    placeholder={identityNameLoading ? "Loading..." : "No name set"}
+                                />
+                                <TextField
+                                    label="Name"
+                                    value={identityNameInput}
+                                    onChange={(e) => setIdentityNameInput(e.target.value)}
+                                    fullWidth
+                                    size="small"
+                                    margin="normal"
+                                    placeholder="Enter name"
+                                />
+                                {identityNameError && (
+                                    <Alert severity="warning" sx={{ mt: 1 }}>
+                                        {identityNameError}
+                                    </Alert>
+                                )}
+                                <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 2 }}>
+                                    <Button
+                                        variant="contained"
+                                        onClick={setIdentityNameProperty}
+                                        disabled={!identityNameInput.trim()}
+                                    >
+                                        Set Name
+                                    </Button>
+                                    <Button
+                                        variant="contained"
+                                        color="error"
+                                        onClick={removeIdentityNameProperty}
+                                        disabled={!identityNameValue}
+                                    >
+                                        Remove Name
+                                    </Button>
+                                </Box>
                             </Box>
                         )}
                         {identityTab === "avatar" && (


### PR DESCRIPTION
## What changed
- adds a `Name` sub-tab under `Identities` in `gatekeeper-client`, `keymaster-client`, `react-wallet`, and the browser extension
- shows the current `name` property for the selected identity
- lets the user set or remove the `name` property directly from the identity UI
- reuses the existing resolved identity docs to populate the Name tab instead of issuing a second DID lookup on identity change

## Why
Avatar management now has a dedicated identity tab, and the `name` property needs the same kind of direct UI support instead of requiring generic property editing.

## Impact
Users can manage the current identity's `name` property from a focused identity-specific tab across all four wallet clients, without the extra DID-resolution request that review flagged.

## Validation
- `npm run build` in `apps/gatekeeper-client`
- `npm run build` in `apps/keymaster-client`
- `npm run build` in `apps/react-wallet`
- `npm run build` in `apps/browser-extension` (passes with existing webpack bundle-size warnings)
