### PR TITLE
feat: Add Herald avatar endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ These rules apply to coding agents working in this repository.
 ## Hygiene
 
 - Always save lessons learned in this file or another persistent repo instruction file. Do not rely on session memory for process corrections.
+- Herald avatar/image handlers that use `KeymasterClient` should normalize JSON-serialized Buffer payloads (`{ type: "Buffer", data: [...] }`) back into real `Buffer` instances before sending binary responses.
 - For GitHub operations in this repo, prefer `gh` by default, especially for write actions. Do not try the GitHub app first and then fall back to `gh` unless there is a clear reason to use the app.
 - When generating or updating npm lockfiles, use the repo-pinned npm version from the root `package.json` so lockfiles stay compatible with CI.
 - Internal service-to-service admin auth should use `X-Archon-Admin-Key` consistently. Reserve `Authorization` for user/session/OAuth-style flows unless a file explicitly documents a different scheme.

--- a/services/herald/server/src/index.ts
+++ b/services/herald/server/src/index.ts
@@ -264,7 +264,7 @@ async function resolveAvatarImage(name: string): Promise<{
     did: string;
     avatarDid: string;
     file: {
-        data?: Buffer;
+        data: Buffer;
         type: string;
         filename?: string;
         bytes?: number;
@@ -300,6 +300,22 @@ async function resolveAvatarImage(name: string): Promise<{
             data,
         },
     };
+}
+
+function getSafeAvatarContentType(contentType: string): string {
+    const normalizedType = contentType.trim().toLowerCase();
+    const allowedAvatarContentTypes = new Set([
+        'image/avif',
+        'image/gif',
+        'image/jpeg',
+        'image/jpg',
+        'image/png',
+        'image/webp',
+    ]);
+
+    return allowedAvatarContentTypes.has(normalizedType)
+        ? normalizedType
+        : 'application/octet-stream';
 }
 
 function isAuthenticated(req: Request, res: Response, next: NextFunction): void {
@@ -863,10 +879,9 @@ app.get('/api/name/:name/avatar', async (req: Request, res: Response) => {
             return;
         }
 
-        res.set('Content-Type', avatar.file.type);
-        if (avatar.file.bytes) {
-            res.set('Content-Length', String(avatar.file.bytes));
-        }
+        res.set('X-Content-Type-Options', 'nosniff');
+        res.set('Content-Type', getSafeAvatarContentType(avatar.file.type));
+        res.set('Content-Length', String(avatar.file.data.length));
         if (avatar.file.filename) {
             res.set('Content-Disposition', `inline; filename="${encodeURIComponent(avatar.file.filename)}"`);
         }

--- a/services/herald/server/src/index.ts
+++ b/services/herald/server/src/index.ts
@@ -260,6 +260,48 @@ async function resolveLightningEndpoint(name: string): Promise<{ did: string; en
     return { did, endpoint: lightning.serviceEndpoint };
 }
 
+async function resolveAvatarImage(name: string): Promise<{
+    did: string;
+    avatarDid: string;
+    file: {
+        data?: Buffer;
+        type: string;
+        filename?: string;
+        bytes?: number;
+    };
+} | null> {
+    const did = await findNameDid(name);
+    if (!did) return null;
+
+    const memberDoc: any = await keymaster.resolveDID(did);
+    const avatarDid = typeof memberDoc?.didDocumentData?.avatar === 'string'
+        ? memberDoc.didDocumentData.avatar.trim()
+        : '';
+
+    if (!avatarDid) return null;
+
+    const image = await keymaster.getImage(avatarDid);
+    const rawData = image?.file?.data;
+    const data = Buffer.isBuffer(rawData)
+        ? rawData
+        : rawData && typeof rawData === 'object' && (rawData as any).type === 'Buffer' && Array.isArray((rawData as any).data)
+            ? Buffer.from((rawData as any).data)
+            : null;
+
+    if (!data || !image?.file?.type || !image.image) {
+        return null;
+    }
+
+    return {
+        did,
+        avatarDid,
+        file: {
+            ...image.file,
+            data,
+        },
+    };
+}
+
 function isAuthenticated(req: Request, res: Response, next: NextFunction): void {
     if (!req.session.user && req.session.challenge) {
         const challengeData = logins[req.session.challenge];
@@ -803,6 +845,33 @@ app.get('/api/member/:name', async (req: Request, res: Response) => {
         const didDoc = await keymaster.resolveDID(memberDid);
 
         res.json(didDoc);
+    }
+    catch (error: any) {
+        console.log(error);
+        res.status(500).json({ error: error.message || String(error) });
+    }
+});
+
+// Resolve a member name to their avatar image
+app.get('/api/name/:name/avatar', async (req: Request, res: Response) => {
+    try {
+        const name = (req.params.name as string).trim().toLowerCase();
+        const avatar = await resolveAvatarImage(name);
+
+        if (!avatar) {
+            res.status(404).json({ error: 'Avatar not found', name });
+            return;
+        }
+
+        res.set('Content-Type', avatar.file.type);
+        if (avatar.file.bytes) {
+            res.set('Content-Length', String(avatar.file.bytes));
+        }
+        if (avatar.file.filename) {
+            res.set('Content-Disposition', `inline; filename="${encodeURIComponent(avatar.file.filename)}"`);
+        }
+
+        res.send(avatar.file.data);
     }
     catch (error: any) {
         console.log(error);


### PR DESCRIPTION
## Summary
- add the missing `GET /api/name/:name/avatar` endpoint advertised by Herald WebFinger responses
- resolve a member's `avatar` DID to an image asset and serve the binary with the stored image content type
- normalize JSON-serialized Buffer payloads from `KeymasterClient` and record the lesson in `AGENTS.md`

## Testing
- npm run build --prefix services/herald/server
- curl http://localhost:4222/names/api/name/kermit/avatar returned a valid JPEG response
- curl http://localhost:4222/names/api/name/myagent3/avatar returned `404 {"error":"Avatar not found","name":"myagent3"}`