### PR TITLE
feat: Add address publish actions across clients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ These rules apply to coding agents working in this repository.
 
 - Always save lessons learned in this file or another persistent repo instruction file. Do not rely on session memory for process corrections.
 - Herald avatar/image handlers that use `KeymasterClient` should normalize JSON-serialized Buffer payloads (`{ type: "Buffer", data: [...] }`) back into real `Buffer` instances before sending binary responses.
+- Keep `apps/gatekeeper-client/src/KeymasterUI.jsx` and `apps/keymaster-client/src/KeymasterUI.jsx` identical. When one changes, update the other to match rather than maintaining intentional drift.
 - For GitHub operations in this repo, prefer `gh` by default, especially for write actions. Do not try the GitHub app first and then fall back to `gh` unless there is a clear reason to use the app.
 - When generating or updating npm lockfiles, use the repo-pinned npm version from the root `package.json` so lockfiles stay compatible with CI.
 - Internal service-to-service admin auth should use `X-Archon-Admin-Key` consistently. Reserve `Authorization` for user/session/OAuth-style flows unless a file explicitly documents a different scheme.

--- a/apps/browser-extension/src/components/BrowserContent.tsx
+++ b/apps/browser-extension/src/components/BrowserContent.tsx
@@ -57,6 +57,7 @@ function BrowserContent() {
 
     const assetTabs = ["groups", "schemas", "images", "files", "vaults"];
     const displayComponent = validId && currentId !== "";
+    const browserPageWidth = menuOpen ? 890 : 790;
 
     useEffect(() => {
         const urlParams = new URLSearchParams(window.location.search);
@@ -191,7 +192,14 @@ function BrowserContent() {
             <Box className="rootContainer">
                 <BrowserHeader menuOpen={menuOpen} toggleMenuOpen={toggleMenuOpen} />
                 <TabContext value={activeTab}>
-                    <Box className="layoutContainer">
+                    <Box
+                        className="layoutContainer"
+                        sx={{
+                            width: browserPageWidth,
+                            maxWidth: browserPageWidth,
+                            transition: "width 0.2s ease-in-out",
+                        }}
+                    >
                         <Box className={`sidebar ${menuOpen ? "open" : ""}`}>
                             <TabList orientation="vertical" onChange={handleTabChange} className="tabList">
                                 <Tab

--- a/apps/browser-extension/src/components/IdentitiesTab.tsx
+++ b/apps/browser-extension/src/components/IdentitiesTab.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, useCallback, useEffect, useState } from "react";
 import JsonView from "@uiw/react-json-view";
 import { useWalletContext } from "../contexts/WalletProvider";
-import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormControlLabel, FormLabel, MenuItem, Paper, Radio, RadioGroup, Select, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, TextField, Typography } from "@mui/material";
+import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormControlLabel, FormLabel, MenuItem, Paper, Radio, RadioGroup, Select, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, TextField, Typography, useMediaQuery } from "@mui/material";
 import { Badge, Create, Image, Login, PermIdentity } from "@mui/icons-material";
 import { useUIContext } from "../contexts/UIContext";
 import { useSnackbar } from "../contexts/SnackbarProvider";
@@ -41,6 +41,7 @@ function formatAddedDate(value: string): string {
 }
 
 function IdentitiesTab() {
+    const isNarrowViewport = useMediaQuery("(max-width:560px)");
     const [identityTab, setIdentityTab] = useState<"details" | "addresses" | "name" | "avatar" | "nostr">("details");
     const [name, setName] = useState<string>("");
     const [warningModal, setWarningModal] = useState<boolean>(false);
@@ -80,6 +81,7 @@ function IdentitiesTab() {
         isBrowser,
         keymaster,
     } = useWalletContext();
+    const hideAddressAddedColumn = !isBrowser && isNarrowViewport;
     const { setError, setSuccess } = useSnackbar();
     const {
         refreshAll,
@@ -1083,25 +1085,25 @@ function IdentitiesTab() {
                                     <Table size="small" sx={{ tableLayout: "fixed" }}>
                                         <colgroup>
                                             <col />
-                                            <col style={{ width: "140px" }} />
+                                            {!hideAddressAddedColumn && <col style={{ width: "140px" }} />}
                                             <col style={{ width: "210px" }} />
                                         </colgroup>
                                         <TableHead>
                                             <TableRow>
                                                 <TableCell>Address</TableCell>
-                                                <TableCell>Added</TableCell>
+                                                {!hideAddressAddedColumn && <TableCell>Added</TableCell>}
                                                 <TableCell>Actions</TableCell>
                                             </TableRow>
                                         </TableHead>
                                         <TableBody>
                                             {Object.entries(addressList).sort(([a], [b]) => a.localeCompare(b)).map(([address, info]) => (
                                                 <TableRow key={address} selected={address === selectedAddress}>
-                                                    <TableCell sx={{ fontFamily: 'monospace', fontWeight: address === publishedAddress ? 700 : 400, whiteSpace: "normal", overflowWrap: "anywhere", wordBreak: "break-word" }}>
+                                                    <TableCell sx={{ fontFamily: 'monospace', fontWeight: address === publishedAddress ? 700 : 400, whiteSpace: hideAddressAddedColumn ? "nowrap" : "normal", overflow: "hidden", textOverflow: "ellipsis" }}>
                                                         {address}
                                                     </TableCell>
-                                                    <TableCell sx={{ fontFamily: 'monospace', whiteSpace: "nowrap" }}>{formatAddedDate(info.added)}</TableCell>
+                                                    {!hideAddressAddedColumn && <TableCell sx={{ fontFamily: 'monospace', whiteSpace: "nowrap" }}>{formatAddedDate(info.added)}</TableCell>}
                                                     <TableCell>
-                                                        <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+                                                        <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end", flexWrap: "wrap" }}>
                                                             <Button variant="contained" size="small" onClick={() => selectAddress(address)} disabled={addressBusy}>Select</Button>
                                                             <Button
                                                                 variant="contained"

--- a/apps/browser-extension/src/components/IdentitiesTab.tsx
+++ b/apps/browser-extension/src/components/IdentitiesTab.tsx
@@ -1082,44 +1082,83 @@ function IdentitiesTab() {
                                     <Button variant="contained" size="small" onClick={clearAddressFields} disabled={addressBusy || (!addressName && !addressDomain && !selectedAddress && !addressDetails)}>Clear</Button>
                                 </Box>
                                 <TableContainer component={Paper} sx={{ mb: 1 }}>
-                                    <Table size="small" sx={{ tableLayout: "fixed" }}>
-                                        <colgroup>
-                                            <col />
-                                            {!hideAddressAddedColumn && <col style={{ width: "140px" }} />}
-                                            <col style={{ width: "210px" }} />
-                                        </colgroup>
-                                        <TableHead>
-                                            <TableRow>
-                                                <TableCell>Address</TableCell>
-                                                {!hideAddressAddedColumn && <TableCell>Added</TableCell>}
-                                                <TableCell>Actions</TableCell>
-                                            </TableRow>
-                                        </TableHead>
-                                        <TableBody>
-                                            {Object.entries(addressList).sort(([a], [b]) => a.localeCompare(b)).map(([address, info]) => (
-                                                <TableRow key={address} selected={address === selectedAddress}>
-                                                    <TableCell sx={{ fontFamily: 'monospace', fontWeight: address === publishedAddress ? 700 : 400, whiteSpace: hideAddressAddedColumn ? "nowrap" : "normal", overflow: "hidden", textOverflow: "ellipsis" }}>
-                                                        {address}
-                                                    </TableCell>
-                                                    {!hideAddressAddedColumn && <TableCell sx={{ fontFamily: 'monospace', whiteSpace: "nowrap" }}>{formatAddedDate(info.added)}</TableCell>}
-                                                    <TableCell>
-                                                        <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end", flexWrap: "wrap" }}>
-                                                            <Button variant="contained" size="small" onClick={() => selectAddress(address)} disabled={addressBusy}>Select</Button>
-                                                            <Button
-                                                                variant="contained"
-                                                                size="small"
-                                                                color={address === publishedAddress ? "error" : "primary"}
-                                                                onClick={() => address === publishedAddress ? clearPublishedAddressValue() : setPublishedAddressValue(address)}
-                                                                disabled={addressBusy || !currentId}
-                                                            >
-                                                                {address === publishedAddress ? "Unpublish" : "Publish"}
-                                                            </Button>
-                                                        </Box>
-                                                    </TableCell>
+                                    {isBrowser ? (
+                                        <Table size="small" sx={{ tableLayout: "fixed" }}>
+                                            <colgroup>
+                                                <col />
+                                                <col style={{ width: "140px" }} />
+                                                <col style={{ width: "210px" }} />
+                                            </colgroup>
+                                            <TableHead>
+                                                <TableRow>
+                                                    <TableCell>Address</TableCell>
+                                                    <TableCell>Added</TableCell>
+                                                    <TableCell>Actions</TableCell>
                                                 </TableRow>
-                                            ))}
-                                        </TableBody>
-                                    </Table>
+                                            </TableHead>
+                                            <TableBody>
+                                                {Object.entries(addressList).sort(([a], [b]) => a.localeCompare(b)).map(([address, info]) => (
+                                                    <TableRow key={address} selected={address === selectedAddress}>
+                                                        <TableCell sx={{ fontFamily: 'monospace', fontWeight: address === publishedAddress ? 700 : 400 }}>{address}</TableCell>
+                                                        <TableCell sx={{ fontFamily: 'monospace' }}>{formatAddedDate(info.added)}</TableCell>
+                                                        <TableCell>
+                                                            <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+                                                                <Button variant="contained" size="small" onClick={() => selectAddress(address)} disabled={addressBusy}>Select</Button>
+                                                                <Button
+                                                                    variant="contained"
+                                                                    size="small"
+                                                                    color={address === publishedAddress ? "error" : "primary"}
+                                                                    onClick={() => address === publishedAddress ? clearPublishedAddressValue() : setPublishedAddressValue(address)}
+                                                                    disabled={addressBusy || !currentId}
+                                                                >
+                                                                    {address === publishedAddress ? "Unpublish" : "Publish"}
+                                                                </Button>
+                                                            </Box>
+                                                        </TableCell>
+                                                    </TableRow>
+                                                ))}
+                                            </TableBody>
+                                        </Table>
+                                    ) : (
+                                        <Table size="small" sx={{ tableLayout: "fixed" }}>
+                                            <colgroup>
+                                                <col />
+                                                {!hideAddressAddedColumn && <col style={{ width: "140px" }} />}
+                                                <col style={{ width: "210px" }} />
+                                            </colgroup>
+                                            <TableHead>
+                                                <TableRow>
+                                                    <TableCell>Address</TableCell>
+                                                    {!hideAddressAddedColumn && <TableCell>Added</TableCell>}
+                                                    <TableCell>Actions</TableCell>
+                                                </TableRow>
+                                            </TableHead>
+                                            <TableBody>
+                                                {Object.entries(addressList).sort(([a], [b]) => a.localeCompare(b)).map(([address, info]) => (
+                                                    <TableRow key={address} selected={address === selectedAddress}>
+                                                        <TableCell sx={{ fontFamily: 'monospace', fontWeight: address === publishedAddress ? 700 : 400, whiteSpace: hideAddressAddedColumn ? "nowrap" : "normal", overflow: "hidden", textOverflow: "ellipsis" }}>
+                                                            {address}
+                                                        </TableCell>
+                                                        {!hideAddressAddedColumn && <TableCell sx={{ fontFamily: 'monospace', whiteSpace: "nowrap" }}>{formatAddedDate(info.added)}</TableCell>}
+                                                        <TableCell>
+                                                            <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end", flexWrap: "wrap" }}>
+                                                                <Button variant="contained" size="small" onClick={() => selectAddress(address)} disabled={addressBusy}>Select</Button>
+                                                                <Button
+                                                                    variant="contained"
+                                                                    size="small"
+                                                                    color={address === publishedAddress ? "error" : "primary"}
+                                                                    onClick={() => address === publishedAddress ? clearPublishedAddressValue() : setPublishedAddressValue(address)}
+                                                                    disabled={addressBusy || !currentId}
+                                                                >
+                                                                    {address === publishedAddress ? "Unpublish" : "Publish"}
+                                                                </Button>
+                                                            </Box>
+                                                        </TableCell>
+                                                    </TableRow>
+                                                ))}
+                                            </TableBody>
+                                        </Table>
+                                    )}
                                 </TableContainer>
                                 <TextField multiline minRows={8} fullWidth value={addressDetails} InputProps={{ readOnly: true }} />
                             </Box>

--- a/apps/browser-extension/src/components/IdentitiesTab.tsx
+++ b/apps/browser-extension/src/components/IdentitiesTab.tsx
@@ -1096,8 +1096,10 @@ function IdentitiesTab() {
                                         <TableBody>
                                             {Object.entries(addressList).sort(([a], [b]) => a.localeCompare(b)).map(([address, info]) => (
                                                 <TableRow key={address} selected={address === selectedAddress}>
-                                                    <TableCell sx={{ fontFamily: 'monospace', fontWeight: address === publishedAddress ? 700 : 400 }}>{address}</TableCell>
-                                                    <TableCell sx={{ fontFamily: 'monospace' }}>{formatAddedDate(info.added)}</TableCell>
+                                                    <TableCell sx={{ fontFamily: 'monospace', fontWeight: address === publishedAddress ? 700 : 400, whiteSpace: "normal", overflowWrap: "anywhere", wordBreak: "break-word" }}>
+                                                        {address}
+                                                    </TableCell>
+                                                    <TableCell sx={{ fontFamily: 'monospace', whiteSpace: "nowrap" }}>{formatAddedDate(info.added)}</TableCell>
                                                     <TableCell>
                                                         <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
                                                             <Button variant="contained" size="small" onClick={() => selectAddress(address)} disabled={addressBusy}>Select</Button>

--- a/apps/browser-extension/src/components/IdentitiesTab.tsx
+++ b/apps/browser-extension/src/components/IdentitiesTab.tsx
@@ -57,6 +57,7 @@ function IdentitiesTab() {
     const [addressName, setAddressName] = useState<string>("");
     const [addressDomain, setAddressDomain] = useState<string>("");
     const [selectedAddress, setSelectedAddress] = useState<string>("");
+    const [publishedAddress, setPublishedAddress] = useState<string>("");
     const [addressDetails, setAddressDetails] = useState<string>("");
     const [addressBusy, setAddressBusy] = useState<boolean>(false);
     const [identityNameValue, setIdentityNameValue] = useState<string>("");
@@ -574,15 +575,21 @@ function IdentitiesTab() {
             setAddressName("");
             setAddressDomain("");
             setSelectedAddress("");
+            setPublishedAddress("");
             setAddressDetails("");
             return;
         }
         try {
             const addresses = await keymaster.listAddresses();
+            const docs = await keymaster.resolveDID(currentId);
+            const identityData = docs?.didDocumentData as Record<string, unknown> | undefined;
+            const rawAddress = identityData?.address;
+            const nextAddress = typeof rawAddress === "string" ? rawAddress.trim().toLowerCase() : "";
             setAddressList(addresses);
             setAddressName("");
             setAddressDomain("");
             setSelectedAddress("");
+            setPublishedAddress(nextAddress);
             setAddressDetails("");
         } catch (error: any) {
             setError(error);
@@ -758,6 +765,53 @@ function IdentitiesTab() {
         }
     }
 
+    async function setPublishedAddressValue(address: string) {
+        if (!keymaster) {
+            return;
+        }
+        setAddressBusy(true);
+        try {
+            const normalizedAddress = address.trim().toLowerCase();
+            if (!currentId) {
+                setError("Select an identity first");
+                return;
+            }
+            if (!normalizedAddress) {
+                setError("Select an address to publish");
+                return;
+            }
+            await keymaster.mergeData(currentId, { address: normalizedAddress });
+            setPublishedAddress(normalizedAddress);
+            await refreshCurrentIdDocs();
+            setSuccess(`${normalizedAddress} published`);
+        } catch (error: any) {
+            setError(error);
+        } finally {
+            setAddressBusy(false);
+        }
+    }
+
+    async function clearPublishedAddressValue() {
+        if (!keymaster) {
+            return;
+        }
+        setAddressBusy(true);
+        try {
+            if (!currentId) {
+                setError("Select an identity first");
+                return;
+            }
+            await keymaster.mergeData(currentId, { address: null });
+            setPublishedAddress("");
+            await refreshCurrentIdDocs();
+            setSuccess("Address unpublished");
+        } catch (error: any) {
+            setError(error);
+        } finally {
+            setAddressBusy(false);
+        }
+    }
+
     async function removeAddressValue(address = selectedAddress || composeAddress(addressName, addressDomain)) {
         if (!keymaster) {
             return;
@@ -770,6 +824,11 @@ function IdentitiesTab() {
                 return;
             }
             await keymaster.removeAddress(normalizedAddress);
+            if (publishedAddress === normalizedAddress && currentId) {
+                await keymaster.mergeData(currentId, { address: null });
+                setPublishedAddress("");
+                await refreshCurrentIdDocs();
+            }
             setAddressName("");
             setAddressDomain(parseAddressDomain(normalizedAddress));
             setSelectedAddress("");
@@ -1021,7 +1080,12 @@ function IdentitiesTab() {
                                     <Button variant="contained" size="small" onClick={clearAddressFields} disabled={addressBusy || (!addressName && !addressDomain && !selectedAddress && !addressDetails)}>Clear</Button>
                                 </Box>
                                 <TableContainer component={Paper} sx={{ mb: 1 }}>
-                                    <Table size="small">
+                                    <Table size="small" sx={{ tableLayout: "fixed" }}>
+                                        <colgroup>
+                                            <col />
+                                            <col style={{ width: "140px" }} />
+                                            <col style={{ width: "210px" }} />
+                                        </colgroup>
                                         <TableHead>
                                             <TableRow>
                                                 <TableCell>Address</TableCell>
@@ -1032,9 +1096,22 @@ function IdentitiesTab() {
                                         <TableBody>
                                             {Object.entries(addressList).sort(([a], [b]) => a.localeCompare(b)).map(([address, info]) => (
                                                 <TableRow key={address} selected={address === selectedAddress}>
-                                                    <TableCell sx={{ fontFamily: 'monospace' }}>{address}</TableCell>
+                                                    <TableCell sx={{ fontFamily: 'monospace', fontWeight: address === publishedAddress ? 700 : 400 }}>{address}</TableCell>
                                                     <TableCell sx={{ fontFamily: 'monospace' }}>{formatAddedDate(info.added)}</TableCell>
-                                                    <TableCell><Button variant="contained" size="small" onClick={() => selectAddress(address)} disabled={addressBusy}>Select</Button></TableCell>
+                                                    <TableCell>
+                                                        <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+                                                            <Button variant="contained" size="small" onClick={() => selectAddress(address)} disabled={addressBusy}>Select</Button>
+                                                            <Button
+                                                                variant="contained"
+                                                                size="small"
+                                                                color={address === publishedAddress ? "error" : "primary"}
+                                                                onClick={() => address === publishedAddress ? clearPublishedAddressValue() : setPublishedAddressValue(address)}
+                                                                disabled={addressBusy || !currentId}
+                                                            >
+                                                                {address === publishedAddress ? "Unpublish" : "Publish"}
+                                                            </Button>
+                                                        </Box>
+                                                    </TableCell>
                                                 </TableRow>
                                             ))}
                                         </TableBody>

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -1906,6 +1906,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                 if (publishedAddress === normalizedAddress && selectedId) {
                     await keymaster.mergeData(selectedId, { address: null });
                     setPublishedAddress('');
+                    await resolveId();
                 }
                 if (selectedAddress === normalizedAddress) {
                     setSelectedAddress('');

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -209,6 +209,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [addressInput, setAddressInput] = useState('');
     const [addressDomain, setAddressDomain] = useState('');
     const [selectedAddress, setSelectedAddress] = useState('');
+    const [publishedAddress, setPublishedAddress] = useState('');
     const [addressDocs, setAddressDocs] = useState('');
     const [addressBusy, setAddressBusy] = useState(false);
     const [registries, setRegistries] = useState(null);
@@ -661,6 +662,9 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                 setManifest(docs.didDocumentData.manifest);
                 setNostrKeys(docs.didDocumentData.nostr || null);
                 setDocsString(JSON.stringify(docs, null, 4));
+                const rawAddress = docs?.didDocumentData?.address;
+                const nextAddress = typeof rawAddress === 'string' ? rawAddress.trim().toLowerCase() : '';
+                setPublishedAddress(nextAddress);
 
                 const versions = docs.didDocumentMetadata.version ?? 1;
                 setDocsVersion(versions);
@@ -685,6 +689,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                 setAddressInput('');
                 setAddressDomain('');
                 setSelectedAddress('');
+                setPublishedAddress('');
                 setAddressDocs('');
                 setIdentityTab('details');
                 setNsecString('');
@@ -1188,10 +1193,13 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             setDocsString(JSON.stringify(docs, null, 4));
             const rawName = docs?.didDocumentData?.name;
             const nextName = typeof rawName === 'string' ? rawName : '';
+            const rawAddress = docs?.didDocumentData?.address;
+            const nextAddress = typeof rawAddress === 'string' ? rawAddress.trim().toLowerCase() : '';
             setIdentityNameValue(nextName);
             setIdentityNameInput(nextName);
             setIdentityNameError('');
             setIdentityNameLoading(false);
+            setPublishedAddress(nextAddress);
 
             const versions = docs.didDocumentMetadata.version ?? 1;
             setDocsVersion(versions);
@@ -1201,6 +1209,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             setIdentityNameInput('');
             setIdentityNameError(error.error || error.message || String(error));
             setIdentityNameLoading(false);
+            setPublishedAddress('');
             showError(error);
         }
     }
@@ -1837,6 +1846,51 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
     }
 
+    async function setPublishedAddressValue(address) {
+        setAddressBusy(true);
+        try {
+            const normalizedAddress = address.trim().toLowerCase();
+
+            if (!selectedId) {
+                showAlert('Select an identity first');
+                return;
+            }
+
+            if (!normalizedAddress) {
+                showAlert('Select an address to publish');
+                return;
+            }
+
+            await keymaster.mergeData(selectedId, { address: normalizedAddress });
+            setPublishedAddress(normalizedAddress);
+            showSuccess(`${normalizedAddress} published`);
+            await resolveId();
+        } catch (error) {
+            showError(error);
+        } finally {
+            setAddressBusy(false);
+        }
+    }
+
+    async function clearPublishedAddressValue() {
+        setAddressBusy(true);
+        try {
+            if (!selectedId) {
+                showAlert('Select an identity first');
+                return;
+            }
+
+            await keymaster.mergeData(selectedId, { address: null });
+            setPublishedAddress('');
+            showSuccess('Address unpublished');
+            await resolveId();
+        } catch (error) {
+            showError(error);
+        } finally {
+            setAddressBusy(false);
+        }
+    }
+
     async function removeAddressValue(address = selectedAddress || composeAddress(addressInput, addressDomain)) {
         setAddressBusy(true);
         try {
@@ -1849,6 +1903,10 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
 
             if (await showConfirm(`Are you sure you want to remove ${normalizedAddress}?`)) {
                 await keymaster.removeAddress(normalizedAddress);
+                if (publishedAddress === normalizedAddress && selectedId) {
+                    await keymaster.mergeData(selectedId, { address: null });
+                    setPublishedAddress('');
+                }
                 if (selectedAddress === normalizedAddress) {
                     setSelectedAddress('');
                     setAddressDocs('');
@@ -4631,11 +4689,11 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                         </Grid>
                                     </Grid>
                                     <TableContainer component={Paper} style={{ maxHeight: '260px', overflow: 'auto', marginBottom: '8px' }}>
-                                        <Table stickyHeader style={{ width: '100%', tableLayout: 'fixed' }}>
+                                            <Table stickyHeader style={{ width: '100%', tableLayout: 'fixed' }}>
                                             <colgroup>
                                                 <col />
                                                 <col style={{ width: '220px' }} />
-                                                <col style={{ width: '120px' }} />
+                                                <col style={{ width: '210px' }} />
                                             </colgroup>
                                             <TableHead>
                                                 <TableRow>
@@ -4648,7 +4706,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                 {filteredAddresses.map(([address, info]) => (
                                                     <TableRow key={address} selected={address === selectedAddress}>
                                                         <TableCell>
-                                                            <Typography style={{ fontFamily: 'Courier' }}>
+                                                            <Typography style={{ fontFamily: 'Courier', fontWeight: address === publishedAddress ? 700 : 400 }}>
                                                                 {address}
                                                             </Typography>
                                                         </TableCell>
@@ -4658,9 +4716,19 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                             </Typography>
                                                         </TableCell>
                                                         <TableCell>
-                                                            <Button variant="contained" color="primary" onClick={() => selectAddress(address)}>
-                                                                Select
-                                                            </Button>
+                                                            <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+                                                                <Button variant="contained" color="primary" onClick={() => selectAddress(address)} disabled={addressBusy}>
+                                                                    Select
+                                                                </Button>
+                                                                <Button
+                                                                    variant="contained"
+                                                                    color={address === publishedAddress ? 'error' : 'primary'}
+                                                                    onClick={() => address === publishedAddress ? clearPublishedAddressValue() : setPublishedAddressValue(address)}
+                                                                    disabled={addressBusy || !selectedId}
+                                                                >
+                                                                    {address === publishedAddress ? 'Unpublish' : 'Publish'}
+                                                                </Button>
+                                                            </Box>
                                                         </TableCell>
                                                     </TableRow>
                                                 ))}

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -1906,6 +1906,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                 if (publishedAddress === normalizedAddress && selectedId) {
                     await keymaster.mergeData(selectedId, { address: null });
                     setPublishedAddress('');
+                    await resolveId();
                 }
                 if (selectedAddress === normalizedAddress) {
                     setSelectedAddress('');

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -209,6 +209,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [addressInput, setAddressInput] = useState('');
     const [addressDomain, setAddressDomain] = useState('');
     const [selectedAddress, setSelectedAddress] = useState('');
+    const [publishedAddress, setPublishedAddress] = useState('');
     const [addressDocs, setAddressDocs] = useState('');
     const [addressBusy, setAddressBusy] = useState(false);
     const [registries, setRegistries] = useState(null);
@@ -661,6 +662,9 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                 setManifest(docs.didDocumentData.manifest);
                 setNostrKeys(docs.didDocumentData.nostr || null);
                 setDocsString(JSON.stringify(docs, null, 4));
+                const rawAddress = docs?.didDocumentData?.address;
+                const nextAddress = typeof rawAddress === 'string' ? rawAddress.trim().toLowerCase() : '';
+                setPublishedAddress(nextAddress);
 
                 const versions = docs.didDocumentMetadata.version ?? 1;
                 setDocsVersion(versions);
@@ -685,6 +689,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                 setAddressInput('');
                 setAddressDomain('');
                 setSelectedAddress('');
+                setPublishedAddress('');
                 setAddressDocs('');
                 setIdentityTab('details');
                 setNsecString('');
@@ -1188,10 +1193,13 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             setDocsString(JSON.stringify(docs, null, 4));
             const rawName = docs?.didDocumentData?.name;
             const nextName = typeof rawName === 'string' ? rawName : '';
+            const rawAddress = docs?.didDocumentData?.address;
+            const nextAddress = typeof rawAddress === 'string' ? rawAddress.trim().toLowerCase() : '';
             setIdentityNameValue(nextName);
             setIdentityNameInput(nextName);
             setIdentityNameError('');
             setIdentityNameLoading(false);
+            setPublishedAddress(nextAddress);
 
             const versions = docs.didDocumentMetadata.version ?? 1;
             setDocsVersion(versions);
@@ -1201,6 +1209,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             setIdentityNameInput('');
             setIdentityNameError(error.error || error.message || String(error));
             setIdentityNameLoading(false);
+            setPublishedAddress('');
             showError(error);
         }
     }
@@ -1837,6 +1846,51 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
     }
 
+    async function setPublishedAddressValue(address) {
+        setAddressBusy(true);
+        try {
+            const normalizedAddress = address.trim().toLowerCase();
+
+            if (!selectedId) {
+                showAlert('Select an identity first');
+                return;
+            }
+
+            if (!normalizedAddress) {
+                showAlert('Select an address to publish');
+                return;
+            }
+
+            await keymaster.mergeData(selectedId, { address: normalizedAddress });
+            setPublishedAddress(normalizedAddress);
+            showSuccess(`${normalizedAddress} published`);
+            await resolveId();
+        } catch (error) {
+            showError(error);
+        } finally {
+            setAddressBusy(false);
+        }
+    }
+
+    async function clearPublishedAddressValue() {
+        setAddressBusy(true);
+        try {
+            if (!selectedId) {
+                showAlert('Select an identity first');
+                return;
+            }
+
+            await keymaster.mergeData(selectedId, { address: null });
+            setPublishedAddress('');
+            showSuccess('Address unpublished');
+            await resolveId();
+        } catch (error) {
+            showError(error);
+        } finally {
+            setAddressBusy(false);
+        }
+    }
+
     async function removeAddressValue(address = selectedAddress || composeAddress(addressInput, addressDomain)) {
         setAddressBusy(true);
         try {
@@ -1849,6 +1903,10 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
 
             if (await showConfirm(`Are you sure you want to remove ${normalizedAddress}?`)) {
                 await keymaster.removeAddress(normalizedAddress);
+                if (publishedAddress === normalizedAddress && selectedId) {
+                    await keymaster.mergeData(selectedId, { address: null });
+                    setPublishedAddress('');
+                }
                 if (selectedAddress === normalizedAddress) {
                     setSelectedAddress('');
                     setAddressDocs('');
@@ -4635,7 +4693,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                             <colgroup>
                                                 <col />
                                                 <col style={{ width: '220px' }} />
-                                                <col style={{ width: '120px' }} />
+                                                <col style={{ width: '210px' }} />
                                             </colgroup>
                                             <TableHead>
                                                 <TableRow>
@@ -4648,7 +4706,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                 {filteredAddresses.map(([address, info]) => (
                                                     <TableRow key={address} selected={address === selectedAddress}>
                                                         <TableCell>
-                                                            <Typography style={{ fontFamily: 'Courier' }}>
+                                                            <Typography style={{ fontFamily: 'Courier', fontWeight: address === publishedAddress ? 700 : 400 }}>
                                                                 {address}
                                                             </Typography>
                                                         </TableCell>
@@ -4658,9 +4716,19 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                             </Typography>
                                                         </TableCell>
                                                         <TableCell>
-                                                            <Button variant="contained" color="primary" onClick={() => selectAddress(address)}>
-                                                                Select
-                                                            </Button>
+                                                            <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+                                                                <Button variant="contained" color="primary" onClick={() => selectAddress(address)} disabled={addressBusy}>
+                                                                    Select
+                                                                </Button>
+                                                                <Button
+                                                                    variant="contained"
+                                                                    color={address === publishedAddress ? 'error' : 'primary'}
+                                                                    onClick={() => address === publishedAddress ? clearPublishedAddressValue() : setPublishedAddressValue(address)}
+                                                                    disabled={addressBusy || !selectedId}
+                                                                >
+                                                                    {address === publishedAddress ? 'Unpublish' : 'Publish'}
+                                                                </Button>
+                                                            </Box>
                                                         </TableCell>
                                                     </TableRow>
                                                 ))}

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -4689,7 +4689,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                         </Grid>
                                     </Grid>
                                     <TableContainer component={Paper} style={{ maxHeight: '260px', overflow: 'auto', marginBottom: '8px' }}>
-                                        <Table stickyHeader style={{ width: '100%', tableLayout: 'fixed' }}>
+                                            <Table stickyHeader style={{ width: '100%', tableLayout: 'fixed' }}>
                                             <colgroup>
                                                 <col />
                                                 <col style={{ width: '220px' }} />

--- a/apps/react-wallet/src/components/IdentitiesTab.tsx
+++ b/apps/react-wallet/src/components/IdentitiesTab.tsx
@@ -60,6 +60,7 @@ function IdentitiesTab() {
     const [addressName, setAddressName] = useState<string>("");
     const [addressDomain, setAddressDomain] = useState<string>("");
     const [selectedAddress, setSelectedAddress] = useState<string>("");
+    const [publishedAddress, setPublishedAddress] = useState<string>("");
     const [addressDetails, setAddressDetails] = useState<string>("");
     const [addressBusy, setAddressBusy] = useState<boolean>(false);
     const [identityNameValue, setIdentityNameValue] = useState<string>("");
@@ -573,15 +574,21 @@ function IdentitiesTab() {
             setAddressName("");
             setAddressDomain("");
             setSelectedAddress("");
+            setPublishedAddress("");
             setAddressDetails("");
             return;
         }
         try {
             const addresses = await keymaster.listAddresses();
+            const docs = await keymaster.resolveDID(currentId);
+            const identityData = docs?.didDocumentData as Record<string, unknown> | undefined;
+            const rawAddress = identityData?.address;
+            const nextAddress = typeof rawAddress === "string" ? rawAddress.trim().toLowerCase() : "";
             setAddressList(addresses);
             setAddressName("");
             setAddressDomain("");
             setSelectedAddress("");
+            setPublishedAddress(nextAddress);
             setAddressDetails("");
         } catch (error: any) {
             setError(error);
@@ -757,6 +764,53 @@ function IdentitiesTab() {
         }
     }
 
+    async function setPublishedAddressValue(address: string) {
+        if (!keymaster) {
+            return;
+        }
+        setAddressBusy(true);
+        try {
+            const normalizedAddress = address.trim().toLowerCase();
+            if (!currentId) {
+                setError("Select an identity first");
+                return;
+            }
+            if (!normalizedAddress) {
+                setError("Select an address to publish");
+                return;
+            }
+            await keymaster.mergeData(currentId, { address: normalizedAddress });
+            setPublishedAddress(normalizedAddress);
+            await refreshCurrentIdDocs();
+            setSuccess(`${normalizedAddress} published`);
+        } catch (error: any) {
+            setError(error);
+        } finally {
+            setAddressBusy(false);
+        }
+    }
+
+    async function clearPublishedAddressValue() {
+        if (!keymaster) {
+            return;
+        }
+        setAddressBusy(true);
+        try {
+            if (!currentId) {
+                setError("Select an identity first");
+                return;
+            }
+            await keymaster.mergeData(currentId, { address: null });
+            setPublishedAddress("");
+            await refreshCurrentIdDocs();
+            setSuccess("Address unpublished");
+        } catch (error: any) {
+            setError(error);
+        } finally {
+            setAddressBusy(false);
+        }
+    }
+
     async function removeAddressValue(address = selectedAddress || composeAddress(addressName, addressDomain)) {
         if (!keymaster) {
             return;
@@ -769,6 +823,11 @@ function IdentitiesTab() {
                 return;
             }
             await keymaster.removeAddress(normalizedAddress);
+            if (publishedAddress === normalizedAddress && currentId) {
+                await keymaster.mergeData(currentId, { address: null });
+                setPublishedAddress("");
+                await refreshCurrentIdDocs();
+            }
             setAddressName("");
             setAddressDomain(parseAddressDomain(normalizedAddress));
             setSelectedAddress("");
@@ -1020,7 +1079,12 @@ function IdentitiesTab() {
                                     <Button variant="contained" size="small" onClick={clearAddressFields} disabled={addressBusy || (!addressName && !addressDomain && !selectedAddress && !addressDetails)}>Clear</Button>
                                 </Box>
                                 <TableContainer component={Paper} sx={{ mb: 1 }}>
-                                    <Table size="small">
+                                    <Table size="small" sx={{ tableLayout: "fixed" }}>
+                                        <colgroup>
+                                            <col />
+                                            <col style={{ width: "140px" }} />
+                                            <col style={{ width: "210px" }} />
+                                        </colgroup>
                                         <TableHead>
                                             <TableRow>
                                                 <TableCell>Address</TableCell>
@@ -1031,9 +1095,22 @@ function IdentitiesTab() {
                                         <TableBody>
                                             {Object.entries(addressList).sort(([a], [b]) => a.localeCompare(b)).map(([address, info]) => (
                                                 <TableRow key={address} selected={address === selectedAddress}>
-                                                    <TableCell sx={{ fontFamily: 'monospace' }}>{address}</TableCell>
+                                                    <TableCell sx={{ fontFamily: 'monospace', fontWeight: address === publishedAddress ? 700 : 400 }}>{address}</TableCell>
                                                     <TableCell sx={{ fontFamily: 'monospace' }}>{formatAddedDate(info.added)}</TableCell>
-                                                    <TableCell><Button variant="contained" size="small" onClick={() => selectAddress(address)} disabled={addressBusy}>Select</Button></TableCell>
+                                                    <TableCell>
+                                                        <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+                                                            <Button variant="contained" size="small" onClick={() => selectAddress(address)} disabled={addressBusy}>Select</Button>
+                                                            <Button
+                                                                variant="contained"
+                                                                size="small"
+                                                                color={address === publishedAddress ? "error" : "primary"}
+                                                                onClick={() => address === publishedAddress ? clearPublishedAddressValue() : setPublishedAddressValue(address)}
+                                                                disabled={addressBusy || !currentId}
+                                                            >
+                                                                {address === publishedAddress ? "Unpublish" : "Publish"}
+                                                            </Button>
+                                                        </Box>
+                                                    </TableCell>
                                                 </TableRow>
                                             ))}
                                         </TableBody>


### PR DESCRIPTION
## Summary
- add per-address Publish/Unpublish actions to the identity Addresses tab in the gatekeeper client, keymaster client, react wallet, and browser extension
- store the published address in the agent's `address` property and ensure only one address is published at a time
- keep published-address UI state in sync on startup, refresh, and address removal, and document that the two `KeymasterUI.jsx` copies must stay identical

## Testing
- npm run build --prefix apps/gatekeeper-client
- npm run build --prefix apps/keymaster-client
- npm run build --prefix apps/react-wallet
- npm run build --prefix apps/browser-extension