### PR TITLE
feat: Store imported nostr nsec in wallet

### DIFF
--- a/apps/browser-extension/src/components/IdentitiesTab.tsx
+++ b/apps/browser-extension/src/components/IdentitiesTab.tsx
@@ -50,6 +50,7 @@ function IdentitiesTab() {
     const [recoverModalOpen, setRecoverModalOpen] = useState<boolean>(false);
     const [nostrKeys, setNostrKeys] = useState<NostrKeys | null>(null);
     const [removeNostrModal, setRemoveNostrModal] = useState<boolean>(false);
+    const [importNostrModal, setImportNostrModal] = useState<boolean>(false);
     const [migrateOpen, setMigrateOpen] = useState<boolean>(false);
     const [createModalOpen, setCreateModalOpen] = useState<boolean>(false);
     const [nsecValue, setNsecValue] = useState<string | null>(null);
@@ -630,6 +631,24 @@ function IdentitiesTab() {
         }
     }
 
+    async function importNostr(nsec: string) {
+        if (!keymaster) {
+            return;
+        }
+        setImportNostrModal(false);
+        if (!nsec) {
+            return;
+        }
+        try {
+            const nostr = await keymaster.importNostr(nsec);
+            setNostrKeys(nostr);
+            setNsecValue(null);
+            setSuccess("Nostr keys imported");
+        } catch (error: any) {
+            setError(error);
+        }
+    }
+
     async function showNsec() {
         if (!keymaster) {
             return;
@@ -921,6 +940,16 @@ function IdentitiesTab() {
                 confirmText="Recover"
                 onSubmit={recoverId}
                 onClose={() => setRecoverModalOpen(false)}
+            />
+
+            <TextInputModal
+                isOpen={importNostrModal}
+                title="Import Nostr nsec"
+                description="Enter the bech32-encoded nsec private key to import for this identity."
+                label="nsec"
+                confirmText="Import"
+                onSubmit={importNostr}
+                onClose={() => setImportNostrModal(false)}
             />
 
             <SelectInputModal
@@ -1361,9 +1390,14 @@ function IdentitiesTab() {
                                             Remove Nostr
                                         </Button>
                                     ) : (
-                                        <Button variant="contained" color="primary" onClick={addNostr} sx={{ whiteSpace: 'nowrap' }}>
-                                            Add Nostr
-                                        </Button>
+                                        <>
+                                            <Button variant="contained" color="primary" onClick={addNostr} sx={{ whiteSpace: 'nowrap' }}>
+                                                Add Nostr
+                                            </Button>
+                                            <Button variant="contained" color="primary" onClick={() => setImportNostrModal(true)} sx={{ whiteSpace: 'nowrap' }}>
+                                                Import nsec
+                                            </Button>
+                                        </>
                                     )}
                                     {nostrKeys && (
                                         nsecValue ? (

--- a/apps/browser-extension/src/components/IdentitiesTab.tsx
+++ b/apps/browser-extension/src/components/IdentitiesTab.tsx
@@ -947,6 +947,8 @@ function IdentitiesTab() {
                 title="Import Nostr nsec"
                 description="Enter the bech32-encoded nsec private key to import for this identity."
                 label="nsec"
+                inputType="password"
+                allowReveal
                 confirmText="Import"
                 onSubmit={importNostr}
                 onClose={() => setImportNostrModal(false)}

--- a/apps/browser-extension/src/modals/TextInputModal.tsx
+++ b/apps/browser-extension/src/modals/TextInputModal.tsx
@@ -7,7 +7,10 @@ import {
     Button,
     DialogContentText,
     TextField,
+    IconButton,
+    InputAdornment,
 } from "@mui/material";
+import { Visibility, VisibilityOff } from "@mui/icons-material";
 
 interface TextInputModalProps {
     isOpen: boolean;
@@ -16,6 +19,8 @@ interface TextInputModalProps {
     label?: string;
     confirmText?: string;
     defaultValue?: string;
+    inputType?: string;
+    allowReveal?: boolean;
     onSubmit: (value: string) => void;
     onClose: () => void;
 }
@@ -28,14 +33,18 @@ const TextInputModal: React.FC<TextInputModalProps> = (
         label = "Name",
         confirmText = "Confirm",
         defaultValue = "",
+        inputType = "text",
+        allowReveal = false,
         onSubmit,
         onClose,
     }) => {
     const [value, setValue] = useState(defaultValue);
+    const [revealed, setRevealed] = useState(false);
 
     useEffect(() => {
         if (isOpen) {
             setValue(defaultValue);
+            setRevealed(false);
         }
     }, [isOpen, defaultValue]);
 
@@ -56,11 +65,26 @@ const TextInputModal: React.FC<TextInputModalProps> = (
                         autoFocus
                         margin="dense"
                         label={label}
-                        type="text"
+                        type={allowReveal && inputType === "password" && revealed ? "text" : inputType}
                         fullWidth
                         variant="outlined"
                         value={value}
                         onChange={(e) => setValue(e.target.value)}
+                        slotProps={{
+                            input: allowReveal && inputType === "password" ? {
+                                endAdornment: (
+                                    <InputAdornment position="end">
+                                        <IconButton
+                                            edge="end"
+                                            onClick={() => setRevealed((value) => !value)}
+                                            aria-label={revealed ? "Hide value" : "Show value"}
+                                        >
+                                            {revealed ? <VisibilityOff /> : <Visibility />}
+                                        </IconButton>
+                                    </InputAdornment>
+                                ),
+                            } : undefined,
+                        }}
                     />
                 </DialogContent>
                 <DialogActions>

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -4478,6 +4478,8 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                 title="Import Nostr nsec"
                 description="Enter the bech32-encoded nsec private key to import for this identity."
                 label="nsec"
+                inputType="password"
+                allowReveal
                 confirmText="Import"
                 onSubmit={importNostr}
                 onClose={() => setImportNostrOpen(false)}

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -328,6 +328,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [removePollName, setRemovePollName] = useState("");
     const [nostrKeys, setNostrKeys] = useState(null);
     const [nsecString, setNsecString] = useState('');
+    const [importNostrOpen, setImportNostrOpen] = useState(false);
     const [pollList, setPollList] = useState([]);
     const [canVote, setCanVote] = useState(false);
     const [eligiblePolls, setEligiblePolls] = useState({});
@@ -1363,6 +1364,23 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             setNostrKeys(nostr);
             resolveId();
             showSuccess('Nostr keys added');
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    async function importNostr(nsec) {
+        setImportNostrOpen(false);
+        if (!nsec) {
+            return;
+        }
+
+        try {
+            const nostr = await keymaster.importNostr(nsec);
+            setNostrKeys(nostr);
+            setNsecString('');
+            resolveId();
+            showSuccess('Nostr keys imported');
         } catch (error) {
             showError(error);
         }
@@ -4455,6 +4473,16 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                 </DialogActions>
             </Dialog>
 
+            <TextInputModal
+                isOpen={importNostrOpen}
+                title="Import Nostr nsec"
+                description="Enter the bech32-encoded nsec private key to import for this identity."
+                label="nsec"
+                confirmText="Import"
+                onSubmit={importNostr}
+                onClose={() => setImportNostrOpen(false)}
+            />
+
             <header className="App-header">
 
                 <h1>{title}</h1>
@@ -4936,9 +4964,14 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                     Remove Nostr
                                                 </Button>
                                                 :
-                                                <Button variant="contained" color="primary" onClick={addNostr}>
-                                                    Add Nostr
-                                                </Button>
+                                                <Box sx={{ display: 'flex', gap: 1 }}>
+                                                    <Button variant="contained" color="primary" onClick={addNostr}>
+                                                        Add Nostr
+                                                    </Button>
+                                                    <Button variant="contained" color="primary" onClick={() => setImportNostrOpen(true)}>
+                                                        Import nsec
+                                                    </Button>
+                                                </Box>
                                             }
                                         </Grid>
                                         {nostrKeys &&

--- a/apps/gatekeeper-client/src/TextInputModal.jsx
+++ b/apps/gatekeeper-client/src/TextInputModal.jsx
@@ -7,7 +7,10 @@ import {
     Button,
     DialogContentText,
     TextField,
+    IconButton,
+    InputAdornment,
 } from "@mui/material";
+import { Visibility, VisibilityOff } from "@mui/icons-material";
 
 const TextInputModal = (
     {
@@ -17,14 +20,18 @@ const TextInputModal = (
         label = "Name",
         confirmText = "Confirm",
         defaultValue = "",
+        inputType = "text",
+        allowReveal = false,
         onSubmit,
         onClose,
     }) => {
     const [value, setValue] = useState(defaultValue);
+    const [revealed, setRevealed] = useState(false);
 
     useEffect(() => {
         if (isOpen) {
             setValue(defaultValue);
+            setRevealed(false);
         }
     }, [isOpen, defaultValue]);
 
@@ -45,11 +52,24 @@ const TextInputModal = (
                         autoFocus
                         margin="dense"
                         label={label}
-                        type="text"
+                        type={allowReveal && inputType === "password" && revealed ? "text" : inputType}
                         fullWidth
                         variant="outlined"
                         value={value}
                         onChange={(e) => setValue(e.target.value)}
+                        InputProps={allowReveal && inputType === "password" ? {
+                            endAdornment: (
+                                <InputAdornment position="end">
+                                    <IconButton
+                                        edge="end"
+                                        onClick={() => setRevealed((value) => !value)}
+                                        aria-label={revealed ? "Hide value" : "Show value"}
+                                    >
+                                        {revealed ? <VisibilityOff /> : <Visibility />}
+                                    </IconButton>
+                                </InputAdornment>
+                            ),
+                        } : undefined}
                     />
                 </DialogContent>
                 <DialogActions>

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -4478,6 +4478,8 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                 title="Import Nostr nsec"
                 description="Enter the bech32-encoded nsec private key to import for this identity."
                 label="nsec"
+                inputType="password"
+                allowReveal
                 confirmText="Import"
                 onSubmit={importNostr}
                 onClose={() => setImportNostrOpen(false)}

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -328,6 +328,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [removePollName, setRemovePollName] = useState("");
     const [nostrKeys, setNostrKeys] = useState(null);
     const [nsecString, setNsecString] = useState('');
+    const [importNostrOpen, setImportNostrOpen] = useState(false);
     const [pollList, setPollList] = useState([]);
     const [canVote, setCanVote] = useState(false);
     const [eligiblePolls, setEligiblePolls] = useState({});
@@ -1363,6 +1364,23 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             setNostrKeys(nostr);
             resolveId();
             showSuccess('Nostr keys added');
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    async function importNostr(nsec) {
+        setImportNostrOpen(false);
+        if (!nsec) {
+            return;
+        }
+
+        try {
+            const nostr = await keymaster.importNostr(nsec);
+            setNostrKeys(nostr);
+            setNsecString('');
+            resolveId();
+            showSuccess('Nostr keys imported');
         } catch (error) {
             showError(error);
         }
@@ -4455,6 +4473,16 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                 </DialogActions>
             </Dialog>
 
+            <TextInputModal
+                isOpen={importNostrOpen}
+                title="Import Nostr nsec"
+                description="Enter the bech32-encoded nsec private key to import for this identity."
+                label="nsec"
+                confirmText="Import"
+                onSubmit={importNostr}
+                onClose={() => setImportNostrOpen(false)}
+            />
+
             <header className="App-header">
 
                 <h1>{title}</h1>
@@ -4936,9 +4964,14 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                     Remove Nostr
                                                 </Button>
                                                 :
-                                                <Button variant="contained" color="primary" onClick={addNostr}>
-                                                    Add Nostr
-                                                </Button>
+                                                <Box sx={{ display: 'flex', gap: 1 }}>
+                                                    <Button variant="contained" color="primary" onClick={addNostr}>
+                                                        Add Nostr
+                                                    </Button>
+                                                    <Button variant="contained" color="primary" onClick={() => setImportNostrOpen(true)}>
+                                                        Import nsec
+                                                    </Button>
+                                                </Box>
                                             }
                                         </Grid>
                                         {nostrKeys &&

--- a/apps/keymaster-client/src/TextInputModal.jsx
+++ b/apps/keymaster-client/src/TextInputModal.jsx
@@ -7,7 +7,10 @@ import {
     Button,
     DialogContentText,
     TextField,
+    IconButton,
+    InputAdornment,
 } from "@mui/material";
+import { Visibility, VisibilityOff } from "@mui/icons-material";
 
 const TextInputModal = (
     {
@@ -17,14 +20,18 @@ const TextInputModal = (
         label = "Name",
         confirmText = "Confirm",
         defaultValue = "",
+        inputType = "text",
+        allowReveal = false,
         onSubmit,
         onClose,
     }) => {
     const [value, setValue] = useState(defaultValue);
+    const [revealed, setRevealed] = useState(false);
 
     useEffect(() => {
         if (isOpen) {
             setValue(defaultValue);
+            setRevealed(false);
         }
     }, [isOpen, defaultValue]);
 
@@ -45,11 +52,24 @@ const TextInputModal = (
                         autoFocus
                         margin="dense"
                         label={label}
-                        type="text"
+                        type={allowReveal && inputType === "password" && revealed ? "text" : inputType}
                         fullWidth
                         variant="outlined"
                         value={value}
                         onChange={(e) => setValue(e.target.value)}
+                        InputProps={allowReveal && inputType === "password" ? {
+                            endAdornment: (
+                                <InputAdornment position="end">
+                                    <IconButton
+                                        edge="end"
+                                        onClick={() => setRevealed((value) => !value)}
+                                        aria-label={revealed ? "Hide value" : "Show value"}
+                                    >
+                                        {revealed ? <VisibilityOff /> : <Visibility />}
+                                    </IconButton>
+                                </InputAdornment>
+                            ),
+                        } : undefined}
                     />
                 </DialogContent>
                 <DialogActions>

--- a/apps/react-wallet/src/components/IdentitiesTab.tsx
+++ b/apps/react-wallet/src/components/IdentitiesTab.tsx
@@ -944,6 +944,8 @@ function IdentitiesTab() {
                 title="Import Nostr nsec"
                 description="Enter the bech32-encoded nsec private key to import for this identity."
                 label="nsec"
+                inputType="password"
+                allowReveal
                 confirmText="Import"
                 onSubmit={importNostr}
                 onClose={() => setImportNostrModal(false)}

--- a/apps/react-wallet/src/components/IdentitiesTab.tsx
+++ b/apps/react-wallet/src/components/IdentitiesTab.tsx
@@ -52,6 +52,7 @@ function IdentitiesTab() {
     const [recoverModalOpen, setRecoverModalOpen] = useState<boolean>(false);
     const [nostrKeys, setNostrKeys] = useState<NostrKeys | null>(null);
     const [removeNostrModal, setRemoveNostrModal] = useState<boolean>(false);
+    const [importNostrModal, setImportNostrModal] = useState<boolean>(false);
     const [migrateOpen, setMigrateOpen] = useState<boolean>(false);
     const [createModalOpen, setCreateModalOpen] = useState<boolean>(false);
     const [nsecValue, setNsecValue] = useState<string | null>(null);
@@ -627,6 +628,24 @@ function IdentitiesTab() {
         }
     }
 
+    async function importNostr(nsec: string) {
+        if (!keymaster) {
+            return;
+        }
+        setImportNostrModal(false);
+        if (!nsec) {
+            return;
+        }
+        try {
+            const nostr = await keymaster.importNostr(nsec);
+            setNostrKeys(nostr);
+            setNsecValue(null);
+            setSuccess("Nostr keys imported");
+        } catch (error: any) {
+            setError(error);
+        }
+    }
+
     async function showNsec() {
         if (!keymaster) {
             return;
@@ -918,6 +937,16 @@ function IdentitiesTab() {
                 confirmText="Recover"
                 onSubmit={recoverId}
                 onClose={() => setRecoverModalOpen(false)}
+            />
+
+            <TextInputModal
+                isOpen={importNostrModal}
+                title="Import Nostr nsec"
+                description="Enter the bech32-encoded nsec private key to import for this identity."
+                label="nsec"
+                confirmText="Import"
+                onSubmit={importNostr}
+                onClose={() => setImportNostrModal(false)}
             />
 
             <SelectInputModal
@@ -1317,9 +1346,14 @@ function IdentitiesTab() {
                                             Remove Nostr
                                         </Button>
                                     ) : (
-                                        <Button variant="contained" color="primary" onClick={addNostr} sx={{ whiteSpace: 'nowrap' }}>
-                                            Add Nostr
-                                        </Button>
+                                        <>
+                                            <Button variant="contained" color="primary" onClick={addNostr} sx={{ whiteSpace: 'nowrap' }}>
+                                                Add Nostr
+                                            </Button>
+                                            <Button variant="contained" color="primary" onClick={() => setImportNostrModal(true)} sx={{ whiteSpace: 'nowrap' }}>
+                                                Import nsec
+                                            </Button>
+                                        </>
                                     )}
                                     {nostrKeys && (
                                         nsecValue ? (

--- a/apps/react-wallet/src/modals/TextInputModal.tsx
+++ b/apps/react-wallet/src/modals/TextInputModal.tsx
@@ -7,7 +7,10 @@ import {
     Button,
     DialogContentText,
     TextField,
+    IconButton,
+    InputAdornment,
 } from "@mui/material";
+import { Visibility, VisibilityOff } from "@mui/icons-material";
 import { useThemeContext } from "../contexts/ContextProviders";
 
 interface TextInputModalProps {
@@ -17,6 +20,8 @@ interface TextInputModalProps {
     label?: string;
     confirmText?: string;
     defaultValue?: string;
+    inputType?: string;
+    allowReveal?: boolean;
     onSubmit: (value: string) => void;
     onClose: () => void;
 }
@@ -29,15 +34,19 @@ const TextInputModal: React.FC<TextInputModalProps> = (
         label = "Name",
         confirmText = "Confirm",
         defaultValue = "",
+        inputType = "text",
+        allowReveal = false,
         onSubmit,
         onClose,
     }) => {
     const [value, setValue] = useState(defaultValue);
+    const [revealed, setRevealed] = useState(false);
     const { isTabletUp } = useThemeContext();
 
     useEffect(() => {
         if (isOpen) {
             setValue(defaultValue);
+            setRevealed(false);
         }
     }, [isOpen, defaultValue]);
 
@@ -70,11 +79,26 @@ const TextInputModal: React.FC<TextInputModalProps> = (
                         autoFocus
                         margin="dense"
                         label={label}
-                        type="text"
+                        type={allowReveal && inputType === "password" && revealed ? "text" : inputType}
                         fullWidth
                         variant="outlined"
                         value={value}
                         onChange={(e) => setValue(e.target.value)}
+                        slotProps={{
+                            input: allowReveal && inputType === "password" ? {
+                                endAdornment: (
+                                    <InputAdornment position="end">
+                                        <IconButton
+                                            edge="end"
+                                            onClick={() => setRevealed((value) => !value)}
+                                            aria-label={revealed ? "Hide value" : "Show value"}
+                                        >
+                                            {revealed ? <VisibilityOff /> : <Visibility />}
+                                        </IconButton>
+                                    </InputAdornment>
+                                ),
+                            } : undefined,
+                        }}
                     />
                 </DialogContent>
                 <DialogActions>

--- a/packages/cipher/src/cipher-base.ts
+++ b/packages/cipher/src/cipher-base.ts
@@ -65,6 +65,18 @@ export default abstract class CipherBase implements Cipher {
         return { npub, pubkey };
     }
 
+    nsecToJwk(nsec: string): EcdsaJwkPair {
+        const decoded = bech32.decode(nsec, 1000);
+        if (decoded.prefix !== 'nsec') {
+            throw new Error('Invalid nsec prefix');
+        }
+        const privateKeyBytes = Buffer.from(bech32.fromWords(decoded.words));
+        if (privateKeyBytes.length !== 32) {
+            throw new Error('Invalid nsec payload');
+        }
+        return this.generateJwk(privateKeyBytes);
+    }
+
     hashMessage(msg: string | Uint8Array): string {
         const hash = sha256(msg);
         return Buffer.from(hash).toString('hex');

--- a/packages/cipher/src/types.ts
+++ b/packages/cipher/src/types.ts
@@ -56,6 +56,7 @@ export interface Cipher {
     generateRandomJwk(): EcdsaJwkPair,
     convertJwkToCompressedBytes(jwk: EcdsaJwkPublic): Uint8Array,
     jwkToNostr(publicJwk: EcdsaJwkPublic): NostrKeys,
+    nsecToJwk(nsec: string): EcdsaJwkPair,
 
     hashMessage(msg: string | Uint8Array): string,
     hashJSON(obj: unknown): string,

--- a/packages/keymaster/src/cli.ts
+++ b/packages/keymaster/src/cli.ts
@@ -913,6 +913,19 @@ program
     });
 
 program
+    .command('import-nostr <nsec> [id]')
+    .description('Import nostr keys for an agent DID from an nsec private key')
+    .action(async (nsec, id) => {
+        try {
+            const nostr = await keymaster.importNostr(nsec, id);
+            console.log(JSON.stringify(nostr, null, 4));
+        }
+        catch (error: any) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+program
     .command('remove-nostr [id]')
     .description('Remove nostr keys from an agent DID')
     .action(async (id) => {

--- a/packages/keymaster/src/keymaster-client.ts
+++ b/packages/keymaster/src/keymaster-client.ts
@@ -535,6 +535,16 @@ export default class KeymasterClient implements KeymasterInterface {
         }
     }
 
+    async importNostr(nsec: string, id?: string): Promise<NostrKeys> {
+        try {
+            const response = await this.axios.post(`${this.API}/nostr/import`, { nsec, id });
+            return response.data;
+        }
+        catch (error) {
+            throwError(error);
+        }
+    }
+
     async removeNostr(id?: string): Promise<boolean> {
         try {
             const response = await this.axios.delete(`${this.API}/nostr`, { data: { id } });

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2186,35 +2186,96 @@ export default class Keymaster implements KeymasterInterface {
         return true;
     }
 
+    private async storeNostrNsec(nsec: string, name?: string): Promise<void> {
+        await this.mutateWallet(async (wallet) => {
+            const id = await this.fetchIdInfo(name, wallet);
+            id.nostr = {
+                ...id.nostr,
+                nsec,
+            };
+        });
+    }
+
+    private async removeStoredNostr(name?: string): Promise<void> {
+        await this.mutateWallet(async (wallet) => {
+            const id = await this.fetchIdInfo(name, wallet);
+            delete id.nostr;
+        });
+    }
+
+    private async fetchNostrKeyPair(name?: string): Promise<EcdsaJwkPair> {
+        const wallet = await this.loadWallet();
+        const id = await this.fetchIdInfo(name, wallet);
+
+        if (typeof id.nostr?.nsec === 'string' && id.nostr.nsec) {
+            return this.cipher.nsecToJwk(id.nostr.nsec);
+        }
+
+        const keypair = await this.fetchKeyPair(name);
+        if (!keypair) {
+            throw new InvalidParameterError('id');
+        }
+
+        return keypair;
+    }
+
     async addNostr(name?: string): Promise<NostrKeys> {
         const keypair = await this.fetchKeyPair(name);
         if (!keypair) {
             throw new InvalidParameterError('id');
         }
         const nostr = this.cipher.jwkToNostr(keypair.publicJwk);
+        const nsec = this.cipher.jwkToNsec(keypair.privateJwk);
         const id = await this.fetchIdInfo(name);
+        await this.storeNostrNsec(nsec, name);
+        await this.mergeData(id.did, { nostr });
+        return nostr;
+    }
+
+    async importNostr(nsec: string, name?: string): Promise<NostrKeys> {
+        if (!nsec || typeof nsec !== 'string') {
+            throw new InvalidParameterError('nsec');
+        }
+
+        let keypair: EcdsaJwkPair;
+        try {
+            keypair = this.cipher.nsecToJwk(nsec);
+        }
+        catch {
+            throw new InvalidParameterError('nsec');
+        }
+
+        const nostr = this.cipher.jwkToNostr(keypair.publicJwk);
+        const id = await this.fetchIdInfo(name);
+        await this.storeNostrNsec(nsec, name);
         await this.mergeData(id.did, { nostr });
         return nostr;
     }
 
     async removeNostr(name?: string): Promise<boolean> {
         const id = await this.fetchIdInfo(name);
+        await this.removeStoredNostr(name);
         return this.mergeData(id.did, { nostr: null });
     }
 
     async exportNsec(name?: string): Promise<string> {
+        const wallet = await this.loadWallet();
+        const id = await this.fetchIdInfo(name, wallet);
+
+        if (typeof id.nostr?.nsec === 'string' && id.nostr.nsec) {
+            return id.nostr.nsec;
+        }
+
         const keypair = await this.fetchKeyPair(name);
         if (!keypair) {
             throw new InvalidParameterError('id');
         }
+
         return this.cipher.jwkToNsec(keypair.privateJwk);
     }
 
     async signNostrEvent(event: NostrEvent): Promise<NostrEvent> {
-        const keypair = await this.fetchKeyPair();
-        if (!keypair) {
-            throw new InvalidParameterError('id');
-        }
+        const keypair = await this.fetchNostrKeyPair();
         const nostr = this.cipher.jwkToNostr(keypair.publicJwk);
         const serialized = JSON.stringify([
             0,

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2227,8 +2227,8 @@ export default class Keymaster implements KeymasterInterface {
         const nostr = this.cipher.jwkToNostr(keypair.publicJwk);
         const nsec = this.cipher.jwkToNsec(keypair.privateJwk);
         const id = await this.fetchIdInfo(name);
-        await this.storeNostrNsec(nsec, name);
         await this.mergeData(id.did, { nostr });
+        await this.storeNostrNsec(nsec, name);
         return nostr;
     }
 
@@ -2247,15 +2247,16 @@ export default class Keymaster implements KeymasterInterface {
 
         const nostr = this.cipher.jwkToNostr(keypair.publicJwk);
         const id = await this.fetchIdInfo(name);
-        await this.storeNostrNsec(nsec, name);
         await this.mergeData(id.did, { nostr });
+        await this.storeNostrNsec(nsec, name);
         return nostr;
     }
 
     async removeNostr(name?: string): Promise<boolean> {
         const id = await this.fetchIdInfo(name);
+        const removed = await this.mergeData(id.did, { nostr: null });
         await this.removeStoredNostr(name);
-        return this.mergeData(id.did, { nostr: null });
+        return removed;
     }
 
     async exportNsec(name?: string): Promise<string> {

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -30,9 +30,15 @@ export interface IDInfo {
     held?: string[];
     owned?: string[];
     addresses?: Record<string, StoredAddressInfo>;
+    nostr?: StoredNostrInfo;
     dmail?: Record<string, any>;
     notices?: Record<string, any>;
     [key: string]: any; // Allow custom metadata fields
+}
+
+export interface StoredNostrInfo {
+    nsec: string;
+    [key: string]: any;
 }
 
 export interface StoredAddressInfo {
@@ -392,6 +398,7 @@ export interface KeymasterInterface {
 
     // Nostr
     addNostr(id?: string): Promise<NostrKeys>;
+    importNostr(nsec: string, id?: string): Promise<NostrKeys>;
     removeNostr(id?: string): Promise<boolean>;
     exportNsec(id?: string): Promise<string>;
     signNostrEvent(event: NostrEvent): Promise<NostrEvent>;

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -2131,6 +2131,58 @@ v1router.delete('/nostr', async (req, res) => {
 
 /**
  * @swagger
+ * /nostr/import:
+ *   post:
+ *     summary: Import a Nostr private key (nsec) for the current identity.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               nsec:
+ *                 type: string
+ *                 description: Bech32-encoded Nostr private key.
+ *               id:
+ *                 type: string
+ *                 description: "Identity name (optional, defaults to current)."
+ *             required:
+ *               - nsec
+ *     responses:
+ *       200:
+ *         description: The imported Nostr public keys.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 npub:
+ *                   type: string
+ *                 pubkey:
+ *                   type: string
+ *       400:
+ *         description: Bad request.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ */
+v1router.post('/nostr/import', async (req, res) => {
+    try {
+        const { nsec, id } = req.body;
+        const nostr = await keymaster.importNostr(nsec, id);
+        res.json(nostr);
+    } catch (error: any) {
+        res.status(400).send({ error: error.toString() });
+    }
+});
+
+/**
+ * @swagger
  * /nostr/nsec:
  *   post:
  *     summary: Export the Nostr private key (nsec) for the current identity.

--- a/tests/keymaster/client.test.ts
+++ b/tests/keymaster/client.test.ts
@@ -26,6 +26,10 @@ const Endpoints = {
     keys_decrypt_json: '/api/v1/keys/decrypt/json',
     aliases: '/api/v1/aliases',
     addresses: '/api/v1/addresses',
+    nostr: '/api/v1/nostr',
+    nostr_import: '/api/v1/nostr/import',
+    nostr_nsec: '/api/v1/nostr/nsec',
+    nostr_sign: '/api/v1/nostr/sign',
     did: '/api/v1/did',
     assets: '/api/v1/assets',
     challenge: '/api/v1/challenge',
@@ -1310,7 +1314,7 @@ describe('addNostr', () => {
 
     it('should add nostr keys', async () => {
         nock(KeymasterURL)
-            .post('/api/v1/nostr')
+            .post(Endpoints.nostr)
             .reply(200, mockKeys);
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
@@ -1321,7 +1325,7 @@ describe('addNostr', () => {
 
     it('should throw exception on addNostr server error', async () => {
         nock(KeymasterURL)
-            .post('/api/v1/nostr')
+            .post(Endpoints.nostr)
             .reply(500, ServerError);
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
@@ -1339,7 +1343,7 @@ describe('addNostr', () => {
 describe('removeNostr', () => {
     it('should remove nostr keys', async () => {
         nock(KeymasterURL)
-            .delete('/api/v1/nostr', { id: 'alice' })
+            .delete(Endpoints.nostr, { id: 'alice' })
             .reply(200, { ok: true });
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
@@ -1350,7 +1354,7 @@ describe('removeNostr', () => {
 
     it('should throw exception on removeNostr server error', async () => {
         nock(KeymasterURL)
-            .delete('/api/v1/nostr', { id: 'alice' })
+            .delete(Endpoints.nostr, { id: 'alice' })
             .reply(500, ServerError);
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
@@ -1370,7 +1374,7 @@ describe('importNostr', () => {
 
     it('should import nostr keys', async () => {
         nock(KeymasterURL)
-            .post('/api/v1/nostr/import')
+            .post(Endpoints.nostr_import)
             .reply(200, mockKeys);
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
@@ -1381,7 +1385,7 @@ describe('importNostr', () => {
 
     it('should throw exception on importNostr server error', async () => {
         nock(KeymasterURL)
-            .post('/api/v1/nostr/import')
+            .post(Endpoints.nostr_import)
             .reply(500, ServerError);
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
@@ -1399,7 +1403,7 @@ describe('importNostr', () => {
 describe('exportNsec', () => {
     it('should export nsec', async () => {
         nock(KeymasterURL)
-            .post('/api/v1/nostr/nsec')
+            .post(Endpoints.nostr_nsec)
             .reply(200, { nsec: 'nsec1test' });
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
@@ -1410,7 +1414,7 @@ describe('exportNsec', () => {
 
     it('should throw exception on exportNsec server error', async () => {
         nock(KeymasterURL)
-            .post('/api/v1/nostr/nsec')
+            .post(Endpoints.nostr_nsec)
             .reply(500, ServerError);
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
@@ -1431,7 +1435,7 @@ describe('signNostrEvent', () => {
 
     it('should sign a nostr event', async () => {
         nock(KeymasterURL)
-            .post('/api/v1/nostr/sign')
+            .post(Endpoints.nostr_sign)
             .reply(200, signedEvent);
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
@@ -1442,7 +1446,7 @@ describe('signNostrEvent', () => {
 
     it('should throw exception on signNostrEvent server error', async () => {
         nock(KeymasterURL)
-            .post('/api/v1/nostr/sign')
+            .post(Endpoints.nostr_sign)
             .reply(500, ServerError);
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });

--- a/tests/keymaster/client.test.ts
+++ b/tests/keymaster/client.test.ts
@@ -1365,6 +1365,37 @@ describe('removeNostr', () => {
     });
 });
 
+describe('importNostr', () => {
+    const mockKeys = { npub: 'npub1test', pubkey: 'a'.repeat(64) };
+
+    it('should import nostr keys', async () => {
+        nock(KeymasterURL)
+            .post('/api/v1/nostr/import')
+            .reply(200, mockKeys);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const keys = await keymaster.importNostr('nsec1test', 'alice');
+
+        expect(keys).toStrictEqual(mockKeys);
+    });
+
+    it('should throw exception on importNostr server error', async () => {
+        nock(KeymasterURL)
+            .post('/api/v1/nostr/import')
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.importNostr('nsec1test', 'alice');
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
 describe('exportNsec', () => {
     it('should export nsec', async () => {
         nock(KeymasterURL)

--- a/tests/keymaster/nostr.test.ts
+++ b/tests/keymaster/nostr.test.ts
@@ -55,6 +55,15 @@ describe('addNostr', () => {
         expect(data.nostr).toStrictEqual(nostr);
     });
 
+    it('should store generated nsec in wallet metadata', async () => {
+        await keymaster.createId('Bob');
+
+        await keymaster.addNostr();
+
+        const walletData = await keymaster.loadWallet();
+        expect(walletData.ids.Bob.nostr?.nsec).toMatch(/^nsec1/);
+    });
+
     it('should derive nostr keys for a named ID', async () => {
         await keymaster.createId('Alice');
         await keymaster.createId('Bob');
@@ -137,6 +146,9 @@ describe('removeNostr', () => {
         doc = await keymaster.resolveDID(did);
         data = doc.didDocumentData as Record<string, unknown>;
         expect(data.nostr).toBeUndefined();
+
+        const walletData = await keymaster.loadWallet();
+        expect(walletData.ids.Bob.nostr).toBeUndefined();
     });
 
     it('should remove nostr keys for a named ID', async () => {
@@ -169,6 +181,49 @@ describe('removeNostr', () => {
         catch (error: any) {
             expect(error.type).toBe(UnknownIDError.type);
         }
+    });
+});
+
+describe('importNostr', () => {
+    it('should import nsec into wallet metadata and DID document data', async () => {
+        const did = await keymaster.createId('Bob');
+        const keypair = cipher.generateRandomJwk();
+        const nsec = cipher.jwkToNsec(keypair.privateJwk);
+        const expectedNostr = cipher.jwkToNostr(keypair.publicJwk);
+
+        const nostr = await keymaster.importNostr(nsec);
+
+        expect(nostr).toStrictEqual(expectedNostr);
+
+        const walletData = await keymaster.loadWallet();
+        expect(walletData.ids.Bob.nostr).toStrictEqual({ nsec });
+
+        const doc = await keymaster.resolveDID(did);
+        const data = doc.didDocumentData as Record<string, any>;
+        expect(data.nostr).toStrictEqual(expectedNostr);
+    });
+
+    it('should import nsec for a named ID', async () => {
+        await keymaster.createId('Alice');
+        await keymaster.createId('Bob');
+        const keypair = cipher.generateRandomJwk();
+        const nsec = cipher.jwkToNsec(keypair.privateJwk);
+
+        const nostr = await keymaster.importNostr(nsec, 'Alice');
+
+        const walletData = await keymaster.loadWallet();
+        expect(walletData.ids.Alice.nostr).toStrictEqual({ nsec });
+        expect(walletData.ids.Bob.nostr).toBeUndefined();
+        expect(nostr.pubkey).toBe(cipher.jwkToNostr(keypair.publicJwk).pubkey);
+    });
+
+    it('should throw for invalid nsec', async () => {
+        await keymaster.createId('Bob');
+
+        await expect(keymaster.importNostr('not-an-nsec')).rejects.toMatchObject({
+            type: 'Invalid parameter',
+            detail: 'nsec',
+        });
     });
 });
 
@@ -311,6 +366,19 @@ describe('jwkToNsec', () => {
     });
 });
 
+describe('nsecToJwk', () => {
+    it('should round-trip an nsec back to the same public key', () => {
+        const keypair = cipher.generateRandomJwk();
+        const nsec = cipher.jwkToNsec(keypair.privateJwk);
+
+        const decodedKeypair = cipher.nsecToJwk(nsec);
+
+        expect(cipher.jwkToNostr(decodedKeypair.publicJwk)).toStrictEqual(
+            cipher.jwkToNostr(keypair.publicJwk)
+        );
+    });
+});
+
 describe('exportNsec', () => {
     it('should return a valid nsec for the current ID', async () => {
         await keymaster.createId('Bob');
@@ -319,6 +387,16 @@ describe('exportNsec', () => {
         const nsec = await keymaster.exportNsec();
 
         expect(nsec.startsWith('nsec1')).toBe(true);
+    });
+
+    it('should return stored imported nsec when present', async () => {
+        await keymaster.createId('Bob');
+        const imported = cipher.jwkToNsec(cipher.generateRandomJwk().privateJwk);
+        await keymaster.importNostr(imported);
+
+        const nsec = await keymaster.exportNsec();
+
+        expect(nsec).toBe(imported);
     });
 
     it('should return a valid nsec for a named ID', async () => {
@@ -406,6 +484,24 @@ describe('signNostrEvent', () => {
         const signed = await keymaster.signNostrEvent(event);
 
         expect(signed.pubkey).toBe(nostr.pubkey);
+    });
+
+    it('should sign with an imported nsec when one is stored', async () => {
+        await keymaster.createId('Bob');
+        const importedKeypair = cipher.generateRandomJwk();
+        const importedNostr = cipher.jwkToNostr(importedKeypair.publicJwk);
+        await keymaster.importNostr(cipher.jwkToNsec(importedKeypair.privateJwk));
+
+        const event = {
+            created_at: Math.floor(Date.now() / 1000),
+            kind: 1,
+            tags: [],
+            content: 'imported signer',
+        };
+
+        const signed = await keymaster.signNostrEvent(event);
+
+        expect(signed.pubkey).toBe(importedNostr.pubkey);
     });
 
     it('should produce a verifiable Schnorr signature', async () => {


### PR DESCRIPTION
## Summary
- store generated and imported Nostr `nsec` values in wallet ID metadata
- add keymaster server, client, and CLI support for importing an `nsec`
- make Nostr export and signing use stored imported keys when present
- add client UI flows to import an `nsec` across the gatekeeper client, keymaster client, react wallet, and browser extension
- mask `nsec` import inputs by default with an optional reveal toggle

## Verification
- `npm test -- --runTestsByPath tests/keymaster/nostr.test.ts tests/keymaster/client.test.ts`
- `npm run build -w @didcid/cipher && npm run build -w @didcid/keymaster`
- `npm run build` in `apps/react-wallet`
- `npm run build` in `apps/gatekeeper-client`
- `npm run build` in `apps/keymaster-client`
- `npm run build` in `apps/browser-extension`

## Scope
This PR includes both the keymaster/cipher foundation and the related client UI import flows.
