### PR TITLE
fix: Normalize dynamic route labels in metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,4 @@ These rules apply to coding agents working in this repository.
 - Never run mutating git operations in parallel. Serialize `git add`, `git commit`, `git push`, branch moves, stash operations, and any command that writes to `.git`.
 - Prefer a clean branch cut over moving changes around after the fact.
 - If branch state becomes confusing, stop and cleanly reestablish scope before making more commits.
+- When adding Prometheus HTTP route labels, normalize dynamic path segments like DIDs, hashes, txids, and CIDs before recording metrics so dashboards do not create one time series per identifier.

--- a/services/drawbridge/server/src/drawbridge-api.ts
+++ b/services/drawbridge/server/src/drawbridge-api.ts
@@ -66,7 +66,8 @@ readFile(new URL('../package.json', import.meta.url), 'utf-8').then(data => {
 
 function normalizePath(path: string): string {
     return path
-        .replace(/\/did\/did:[^/]+/, '/did/:did')
+        .replace(/\/did\/(?:did:[^/]+|did%3[aA][^/]+)/, '/did/:did')
+        .replace(/\/invoice\/(?:did:[^/]+|did%3[aA][^/]+)/, '/invoice/:did')
         .replace(/\/ipfs\/json\/[^/]+/, '/ipfs/json/:cid')
         .replace(/\/ipfs\/text\/[^/]+/, '/ipfs/text/:cid')
         .replace(/\/ipfs\/data\/[^/]+/, '/ipfs/data/:cid')

--- a/services/gatekeeper/server/src/gatekeeper-api.ts
+++ b/services/gatekeeper/server/src/gatekeeper-api.ts
@@ -79,7 +79,7 @@ function normalizePath(path: string): string {
     const basePath = path.split('?')[0];
     // Normalize known dynamic segments
     return basePath
-        .replace(/\/did\/did:[^/]+/g, '/did/:did')
+        .replace(/\/did\/(?:did:[^/]+|did%3[aA][^/]+)/g, '/did/:did')
         .replace(/\/block\/[^/]+\/latest/g, '/block/:registry/latest')
         .replace(/\/block\/[^/]+/g, '/block/:registry')
         .replace(/\/queue\/[^/]+\/clear/g, '/queue/:registry/clear')

--- a/services/mediators/lightning/src/lightning-mediator.ts
+++ b/services/mediators/lightning/src/lightning-mediator.ts
@@ -83,6 +83,13 @@ function getGatekeeper() {
     return gatekeeperPromise;
 }
 
+function normalizePath(path: string): string {
+    return path
+        .replace(/\/lightning\/publish\/(?:did:[^/]+|did%3[aA][^/]+)/g, '/lightning/publish/:did')
+        .replace(/\/l402\/pending\/[^/]+/g, '/l402/pending/:paymentHash')
+        .replace(/\/invoice\/(?:did:[^/]+|did%3[aA][^/]+)/g, '/invoice/:did');
+}
+
 function isPrivateHost(hostname: string): boolean {
     return /^(localhost|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/.test(hostname);
 }
@@ -177,7 +184,7 @@ async function main(): Promise<void> {
         res.on('finish', () => {
             httpRequestsTotal.inc({
                 method: req.method,
-                route: req.path,
+                route: normalizePath(req.path),
                 status: String(res.statusCode),
             });
         });

--- a/services/mediators/satoshi-wallet/src/wallet-api.ts
+++ b/services/mediators/satoshi-wallet/src/wallet-api.ts
@@ -96,6 +96,11 @@ readFile(new URL('../package.json', import.meta.url), 'utf-8').then(data => {
 
 const ARCHON_ADMIN_HEADER = 'x-archon-admin-key';
 
+function normalizePath(path: string): string {
+    return path
+        .replace(/\/wallet\/transaction\/[^/]+/g, '/wallet/transaction/:txid');
+}
+
 function requireAdminKey(req: express.Request, res: express.Response, next: express.NextFunction) {
     if (!config.adminApiKey) {
         res.status(403).json({ error: 'Admin API key not configured' });
@@ -154,8 +159,9 @@ async function main() {
         const start = process.hrtime.bigint();
         res.on('finish', () => {
             const duration = Number(process.hrtime.bigint() - start) / 1e9;
-            httpRequestsTotal.inc({ method: req.method, route: req.path, status: res.statusCode });
-            httpRequestDuration.observe({ method: req.method, route: req.path }, duration);
+            const route = normalizePath(req.path);
+            httpRequestsTotal.inc({ method: req.method, route, status: res.statusCode });
+            httpRequestDuration.observe({ method: req.method, route }, duration);
         });
         next();
     });


### PR DESCRIPTION
## What changed
- normalize encoded and plain DID paths in Gatekeeper and Drawbridge metrics labels so `/did/<value>` requests collapse into a single route series
- normalize additional dynamic metrics routes in Drawbridge, Lightning mediator, and Satoshi wallet
- add a repo instruction to normalize dynamic Prometheus HTTP route labels before recording metrics

## Why
Grafana and Prometheus were treating identifier-bearing paths as distinct routes, especially when DIDs were URL-encoded like `did%3A...`. That created one time series per DID instead of a single `/did/:did` endpoint series.

## Impact
- dashboards should show stable route-level series instead of one line per DID, payment hash, or txid
- Prometheus cardinality stays lower for these HTTP request metrics
- request handling and API behavior are unchanged; this only affects metrics labeling

## Root cause
Some services normalized only literal `did:` segments, while live traffic used URL-encoded DIDs. Other services recorded `req.path` directly for dynamic routes.

## Validation
- `npm run build` in `services/gatekeeper/server`
- `npm run build` in `services/drawbridge/server`
- `npm run build` in `services/mediators/lightning`
- `npm run build` in `services/mediators/satoshi-wallet`
