### PR TITLE
feat(herald-client): show member avatars

### DIFF
--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -1135,6 +1135,13 @@ function ViewMember() {
                 }}>
                     {memberData?.didDocument?.id && aliasWalletUrl && (
                         <Box>
+                            <Avatar
+                                src={`${api.defaults.baseURL}/name/${name}/avatar`}
+                                alt={name}
+                                sx={{ width: 96, height: 96, mx: 'auto', mb: 2, fontSize: '2.5rem' }}
+                            >
+                                {name?.[0]?.toUpperCase()}
+                            </Avatar>
                             <a href={aliasWalletUrl} target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'none' }}>
                                 <QRCodeSVG value={aliasWalletUrl} />
                             </a>

--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -1122,7 +1122,20 @@ function ViewMember() {
 
     return (
         <div className="App">
-            <Header title={`${name}@${serviceDomain}`} />
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 2, mb: 3 }}>
+                <Avatar
+                    src={`${api.defaults.baseURL}/name/${name}/avatar`}
+                    alt={name}
+                    sx={{ width: 64, height: 64, fontSize: '1.75rem' }}
+                >
+                    {name?.[0]?.toUpperCase()}
+                </Avatar>
+                <Link to="/" style={{ textDecoration: 'none' }}>
+                    <Typography variant="h3" component="h1" sx={{ fontWeight: 700, color: '#1a1a1a' }}>
+                        {name}@{serviceDomain}
+                    </Typography>
+                </Link>
+            </Box>
 
             <Box sx={{ maxWidth: 800, mx: 'auto' }}>
                 <Box sx={{
@@ -1135,13 +1148,6 @@ function ViewMember() {
                 }}>
                     {memberData?.didDocument?.id && aliasWalletUrl && (
                         <Box>
-                            <Avatar
-                                src={`${api.defaults.baseURL}/name/${name}/avatar`}
-                                alt={name}
-                                sx={{ width: 96, height: 96, mx: 'auto', mb: 2, fontSize: '2.5rem' }}
-                            >
-                                {name?.[0]?.toUpperCase()}
-                            </Avatar>
                             <a href={aliasWalletUrl} target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'none' }}>
                                 <QRCodeSVG value={aliasWalletUrl} />
                             </a>

--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -7,7 +7,7 @@ import {
     Routes,
     Route,
 } from "react-router-dom";
-import { Alert, Box, Button, CircularProgress, Dialog, DialogActions, DialogContent, TextField, Typography } from '@mui/material';
+import { Alert, Avatar, Box, Button, CircularProgress, Dialog, DialogActions, DialogContent, TextField, Typography } from '@mui/material';
 import { Table, TableBody, TableRow, TableCell } from '@mui/material';
 import axios from 'axios';
 import { format, differenceInDays } from 'date-fns';
@@ -65,7 +65,7 @@ function buildWalletUrl(walletUrl: string, params: Record<string, string>) {
     }
 }
 
-function Header({ title, showTagline = false } : { title: string, showTagline?: boolean }) {
+function Header({ title, showTagline = false }: { title: string, showTagline?: boolean }) {
     return (
         <Box
             sx={{
@@ -568,7 +568,16 @@ function ViewMembers() {
                                 onClick={() => navigate(`/profile/${entry.did}`)}
                             >
                                 <TableCell sx={{ fontWeight: 600, fontSize: '1.1rem', color: '#2c3e50' }}>
-                                    {entry.name}@{serviceDomain}
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                                        <Avatar
+                                            src={`${api.defaults.baseURL}/name/${entry.name}/avatar`}
+                                            alt={entry.name}
+                                            sx={{ width: 36, height: 36 }}
+                                        >
+                                            {entry.name[0]?.toUpperCase()}
+                                        </Avatar>
+                                        {entry.name}@{serviceDomain}
+                                    </Box>
                                 </TableCell>
                                 <TableCell sx={{ color: '#666', fontFamily: 'monospace', fontSize: '0.85rem' }}>
                                     {entry.did.substring(0, 20)}...{entry.did.substring(entry.did.length - 8)}
@@ -825,7 +834,7 @@ function ViewProfile() {
                                                 onClick={checkName}
                                                 disabled={!newName.trim() || newName === currentName}
                                             >
-                                            Check
+                                                Check
                                             </Button>
                                             <Button
                                                 variant="outlined"
@@ -833,7 +842,7 @@ function ViewProfile() {
                                                 onClick={saveName}
                                                 disabled={newName === currentName}
                                             >
-                                            Save
+                                                Save
                                             </Button>
                                             {currentName && (
                                                 <Button
@@ -841,7 +850,7 @@ function ViewProfile() {
                                                     color="error"
                                                     onClick={deleteName}
                                                 >
-                                                Delete
+                                                    Delete
                                                 </Button>
                                             )}
                                         </Box>
@@ -861,7 +870,7 @@ function ViewProfile() {
                 </Table>
                 <Box sx={{ mt: 3 }}>
                     <Button component={Link} to="/" variant="outlined">
-                    ← Back to Home
+                        ← Back to Home
                     </Button>
                 </Box>
             </Box>


### PR DESCRIPTION
Display avatar images next to member names in the Member Directory.

Uses the existing `/api/name/:name/avatar` endpoint via MUI `<Avatar>` component, with a letter fallback when no avatar is set.