### PR TITLE
feat: Auto-respond to URL challenges with one-click login

### DIFF
--- a/apps/browser-extension/src/components/AuthTab.tsx
+++ b/apps/browser-extension/src/components/AuthTab.tsx
@@ -85,9 +85,7 @@ function AuthTab() {
             });
 
             await setCallback(callbackUrl);
-            if (callbackUrl) {
-                await setDisableSendResponse(false);
-            }
+            await setDisableSendResponse(!callbackUrl);
         } catch (error: any) {
             setError(error);
         } finally {
@@ -96,10 +94,10 @@ function AuthTab() {
     }
 
     async function autoLoginSend() {
-        if (!autoLogin?.callbackUrl) return;
+        if (!autoLogin?.callbackUrl || !autoLogin.responseDID) return;
         try {
             await setDisableSendResponse(true);
-            await axios.post(autoLogin.callbackUrl, { response });
+            await axios.post(autoLogin.callbackUrl, { response: autoLogin.responseDID });
             setAutoLoginSent(true);
             setSuccess("Response sent successfully");
             await setCallback("");

--- a/apps/browser-extension/src/components/AuthTab.tsx
+++ b/apps/browser-extension/src/components/AuthTab.tsx
@@ -362,169 +362,169 @@ function AuthTab() {
             {!autoLogin && !autoLoginLoading && (
                 <>
                     <Box className="flex-box mt-2">
-                <TextField
-                    label="Challenge"
-                    variant="outlined"
-                    value={challenge}
-                    onChange={(e) => setChallenge(e.target.value.trim())}
-                    size="small"
-                    className="text-field top"
-                    slotProps={{
-                        htmlInput: {
-                            maxLength: 85,
-                        },
-                    }}
-                />
-            </Box>
-
-            <Box className="flex-box">
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={openChallengeDialog}
-                    className="button large bottom"
-                >
-                    New...
-                </Button>
-
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={() => resolveChallenge(challenge)}
-                    className="button large bottom"
-                    disabled={!challenge || challenge === authDID}
-                >
-                    Resolve
-                </Button>
-
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={createResponse}
-                    className="button large bottom"
-                    disabled={!challenge}
-                >
-                    Respond
-                </Button>
-
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={clearChallenge}
-                    className="button large bottom"
-                    disabled={!challenge}
-                >
-                    Clear
-                </Button>
-            </Box>
-
-            <Box className="flex-box mt-2">
-                <TextField
-                    label="Response"
-                    variant="outlined"
-                    value={response}
-                    onChange={(e) => setResponse(e.target.value.trim())}
-                    size="small"
-                    className="text-field top"
-                />
-            </Box>
-
-            <Box className="flex-box">
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={() => decryptResponse(response)}
-                    className="button large bottom"
-                    disabled={!response || response === authDID}
-                >
-                    Decrypt
-                </Button>
-
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={verifyResponse}
-                    className="button large bottom"
-                    disabled={!response}
-                >
-                    Verify
-                </Button>
-
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={sendResponse}
-                    className="button large bottom"
-                    disabled={disableSendResponse}
-                >
-                    Send
-                </Button>
-
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={clearResponse}
-                    className="button large bottom"
-                    disabled={!response}
-                >
-                    Clear
-                </Button>
-            </Box>
-
-            <Dialog open={showChallengeDialog} onClose={closeChallengeDialog}>
-                <DialogTitle>New Challenge</DialogTitle>
-                <DialogContent>
-                    <Typography variant="body2" sx={{ mb: 2 }}>
-                        Add credential requirements. Leave empty for an open challenge.
-                    </Typography>
-                    <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', mb: 2 }}>
-                        <Select
-                            value={challengeSchemaSelection}
-                            onChange={(e) => setChallengeSchemaSelection(e.target.value)}
-                            displayEmpty
+                        <TextField
+                            label="Challenge"
+                            variant="outlined"
+                            value={challenge}
+                            onChange={(e) => setChallenge(e.target.value.trim())}
                             size="small"
-                            sx={{ minWidth: 180 }}
+                            className="text-field top"
+                            slotProps={{
+                                htmlInput: {
+                                    maxLength: 85,
+                                },
+                            }}
+                        />
+                    </Box>
+
+                    <Box className="flex-box">
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={openChallengeDialog}
+                            className="button large bottom"
                         >
-                            <MenuItem value="" disabled>Schema</MenuItem>
-                            {schemaList.map((s: string) => (
-                                <MenuItem key={s} value={s}>{s}</MenuItem>
-                            ))}
-                        </Select>
-                        <Select
-                            value={challengeIssuerSelection}
-                            onChange={(e) => setChallengeIssuerSelection(e.target.value)}
-                            displayEmpty
-                            size="small"
-                            sx={{ minWidth: 180 }}
+                            New...
+                        </Button>
+
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={() => resolveChallenge(challenge)}
+                            className="button large bottom"
+                            disabled={!challenge || challenge === authDID}
                         >
-                            <MenuItem value="">Any issuer</MenuItem>
-                            {agentList.map((s: string) => (
-                                <MenuItem key={s} value={s}>{s}</MenuItem>
-                            ))}
-                        </Select>
-                        <Button variant="contained" size="small" onClick={addChallengeCredential} disabled={!challengeSchemaSelection}>
-                            Add
+                            Resolve
+                        </Button>
+
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={createResponse}
+                            className="button large bottom"
+                            disabled={!challenge}
+                        >
+                            Respond
+                        </Button>
+
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={clearChallenge}
+                            className="button large bottom"
+                            disabled={!challenge}
+                        >
+                            Clear
                         </Button>
                     </Box>
-                    {challengeCredentials.length > 0 &&
-                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                            {challengeCredentials.map((cred, i) => (
-                                <Chip
-                                    key={i}
-                                    label={cred.issuer ? `${cred.schema} (${cred.issuer})` : cred.schema}
-                                    onDelete={() => removeChallengeCredential(i)}
-                                />
-                            ))}
-                        </Box>
-                    }
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={closeChallengeDialog}>Cancel</Button>
-                    <Button variant="contained" onClick={newChallenge}>
-                        Create
-                    </Button>
-                </DialogActions>
-            </Dialog>
+
+                    <Box className="flex-box mt-2">
+                        <TextField
+                            label="Response"
+                            variant="outlined"
+                            value={response}
+                            onChange={(e) => setResponse(e.target.value.trim())}
+                            size="small"
+                            className="text-field top"
+                        />
+                    </Box>
+
+                    <Box className="flex-box">
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={() => decryptResponse(response)}
+                            className="button large bottom"
+                            disabled={!response || response === authDID}
+                        >
+                            Decrypt
+                        </Button>
+
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={verifyResponse}
+                            className="button large bottom"
+                            disabled={!response}
+                        >
+                            Verify
+                        </Button>
+
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={sendResponse}
+                            className="button large bottom"
+                            disabled={disableSendResponse}
+                        >
+                            Send
+                        </Button>
+
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={clearResponse}
+                            className="button large bottom"
+                            disabled={!response}
+                        >
+                            Clear
+                        </Button>
+                    </Box>
+
+                    <Dialog open={showChallengeDialog} onClose={closeChallengeDialog}>
+                        <DialogTitle>New Challenge</DialogTitle>
+                        <DialogContent>
+                            <Typography variant="body2" sx={{ mb: 2 }}>
+                                Add credential requirements. Leave empty for an open challenge.
+                            </Typography>
+                            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', mb: 2 }}>
+                                <Select
+                                    value={challengeSchemaSelection}
+                                    onChange={(e) => setChallengeSchemaSelection(e.target.value)}
+                                    displayEmpty
+                                    size="small"
+                                    sx={{ minWidth: 180 }}
+                                >
+                                    <MenuItem value="" disabled>Schema</MenuItem>
+                                    {schemaList.map((s: string) => (
+                                        <MenuItem key={s} value={s}>{s}</MenuItem>
+                                    ))}
+                                </Select>
+                                <Select
+                                    value={challengeIssuerSelection}
+                                    onChange={(e) => setChallengeIssuerSelection(e.target.value)}
+                                    displayEmpty
+                                    size="small"
+                                    sx={{ minWidth: 180 }}
+                                >
+                                    <MenuItem value="">Any issuer</MenuItem>
+                                    {agentList.map((s: string) => (
+                                        <MenuItem key={s} value={s}>{s}</MenuItem>
+                                    ))}
+                                </Select>
+                                <Button variant="contained" size="small" onClick={addChallengeCredential} disabled={!challengeSchemaSelection}>
+                                    Add
+                                </Button>
+                            </Box>
+                            {challengeCredentials.length > 0 &&
+                                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                                    {challengeCredentials.map((cred, i) => (
+                                        <Chip
+                                            key={i}
+                                            label={cred.issuer ? `${cred.schema} (${cred.issuer})` : cred.schema}
+                                            onDelete={() => removeChallengeCredential(i)}
+                                        />
+                                    ))}
+                                </Box>
+                            }
+                        </DialogContent>
+                        <DialogActions>
+                            <Button onClick={closeChallengeDialog}>Cancel</Button>
+                            <Button variant="contained" onClick={newChallenge}>
+                                Create
+                            </Button>
+                        </DialogActions>
+                    </Dialog>
                 </>
             )}
         </Box>

--- a/apps/browser-extension/src/components/AuthTab.tsx
+++ b/apps/browser-extension/src/components/AuthTab.tsx
@@ -1,14 +1,24 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
-    Box, Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle,
-    MenuItem, Select, TextField, Typography
+    Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle,
+    Divider, MenuItem, Paper, Select, TextField, Typography
 } from "@mui/material";
+import { CheckCircle, Login, Warning } from "@mui/icons-material";
 import axios from "axios";
 import { useWalletContext } from "../contexts/WalletProvider";
 import { useAuthContext } from "../contexts/AuthContext";
 import { useUIContext } from "../contexts/UIContext";
 import { useSnackbar } from "../contexts/SnackbarProvider";
 import { useVariablesContext } from "../contexts/VariablesProvider";
+
+interface AutoLoginState {
+    responseDID: string;
+    callbackUrl: string;
+    fulfilled: number;
+    requested: number;
+    match: boolean;
+    credentials: { vc: string; vp: string }[];
+}
 
 function AuthTab() {
     const { keymaster } = useWalletContext();
@@ -24,6 +34,8 @@ function AuthTab() {
         setCallback,
         disableSendResponse,
         setDisableSendResponse,
+        pendingAutoResponse,
+        setPendingAutoResponse,
     } = useAuthContext();
     const { openBrowserWindow } = useUIContext();
     const { schemaList, agentList } = useVariablesContext();
@@ -31,6 +43,77 @@ function AuthTab() {
     const [challengeCredentials, setChallengeCredentials] = useState<{ schema: string; issuer: string }[]>([]);
     const [challengeSchemaSelection, setChallengeSchemaSelection] = useState<string>("");
     const [challengeIssuerSelection, setChallengeIssuerSelection] = useState<string>("");
+    const [autoLogin, setAutoLogin] = useState<AutoLoginState | null>(null);
+    const [autoLoginLoading, setAutoLoginLoading] = useState(false);
+    const [autoLoginSent, setAutoLoginSent] = useState(false);
+
+    useEffect(() => {
+        if (pendingAutoResponse && challenge && keymaster) {
+            setPendingAutoResponse(false);
+            handleAutoResponse(challenge);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [pendingAutoResponse, challenge, keymaster]);
+
+    async function handleAutoResponse(challengeDID: string) {
+        if (!keymaster) return;
+
+        setAutoLoginLoading(true);
+        setAutoLogin(null);
+        setAutoLoginSent(false);
+
+        try {
+            const asset = await keymaster.resolveAsset(challengeDID);
+            const challengeData = (asset as { challenge: { callback?: string; credentials?: { schema: string; issuers?: string[] }[] } }).challenge;
+            const callbackUrl = challengeData?.callback || "";
+
+            const responseDID = await keymaster.createResponse(challengeDID, { retries: 10 });
+            await setResponse(responseDID);
+
+            const decrypted = await keymaster.decryptJSON(responseDID) as {
+                response: { challenge: string; credentials: { vc: string; vp: string }[]; requested: number; fulfilled: number; match: boolean }
+            };
+            const responseData = decrypted.response;
+
+            setAutoLogin({
+                responseDID,
+                callbackUrl,
+                fulfilled: responseData.fulfilled,
+                requested: responseData.requested,
+                match: responseData.match,
+                credentials: responseData.credentials,
+            });
+
+            await setCallback(callbackUrl);
+            if (callbackUrl) {
+                await setDisableSendResponse(false);
+            }
+        } catch (error: any) {
+            setError(error);
+        } finally {
+            setAutoLoginLoading(false);
+        }
+    }
+
+    async function autoLoginSend() {
+        if (!autoLogin?.callbackUrl) return;
+        try {
+            await setDisableSendResponse(true);
+            await axios.post(autoLogin.callbackUrl, { response });
+            setAutoLoginSent(true);
+            setSuccess("Response sent successfully");
+            await setCallback("");
+        } catch (error: any) {
+            await setDisableSendResponse(false);
+            setError(error);
+        }
+    }
+
+    function dismissAutoLogin() {
+        setAutoLogin(null);
+        setAutoLoginLoading(false);
+        setAutoLoginSent(false);
+    }
 
     function openChallengeDialog() {
         setChallengeCredentials([]);
@@ -173,7 +256,112 @@ function AuthTab() {
 
     return (
         <Box>
-            <Box className="flex-box mt-2">
+            {autoLoginLoading && (
+                <Paper elevation={2} sx={{ p: 3, m: 2, textAlign: 'center' }}>
+                    <CircularProgress size={40} />
+                    <Typography sx={{ mt: 2 }}>Processing challenge...</Typography>
+                </Paper>
+            )}
+
+            {autoLogin && !autoLoginLoading && (
+                <Paper elevation={2} sx={{ p: 3, m: 2 }}>
+                    <Typography variant="h6" sx={{ mb: 2, display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Login /> Login Request
+                    </Typography>
+
+                    <Divider sx={{ mb: 2 }} />
+
+                    {autoLogin.callbackUrl && (
+                        <Box sx={{ mb: 2 }}>
+                            <Typography variant="body2" color="text.secondary">
+                                Destination
+                            </Typography>
+                            <Typography variant="body1" sx={{ wordBreak: 'break-all' }}>
+                                {autoLogin.callbackUrl}
+                            </Typography>
+                        </Box>
+                    )}
+
+                    <Box sx={{ mb: 2 }}>
+                        <Typography variant="body2" color="text.secondary">
+                            Credentials
+                        </Typography>
+                        {autoLogin.requested === 0 ? (
+                            <Typography variant="body1">
+                                Identity verification only (no credentials requested)
+                            </Typography>
+                        ) : (
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5 }}>
+                                {autoLogin.match ? (
+                                    <Chip
+                                        icon={<CheckCircle />}
+                                        label={`${autoLogin.fulfilled} of ${autoLogin.requested} credential(s) matched`}
+                                        color="success"
+                                        size="small"
+                                    />
+                                ) : (
+                                    <Chip
+                                        icon={<Warning />}
+                                        label={`${autoLogin.fulfilled} of ${autoLogin.requested} credential(s) matched`}
+                                        color="warning"
+                                        size="small"
+                                    />
+                                )}
+                            </Box>
+                        )}
+                    </Box>
+
+                    <Box sx={{ mb: 2 }}>
+                        <Typography variant="body2" color="text.secondary">
+                            Response
+                        </Typography>
+                        <Typography variant="body2" sx={{ wordBreak: 'break-all', fontFamily: 'monospace', fontSize: '0.75rem' }}>
+                            {autoLogin.responseDID}
+                        </Typography>
+                    </Box>
+
+                    <Divider sx={{ mb: 2 }} />
+
+                    {autoLoginSent ? (
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <CheckCircle color="success" />
+                            <Typography color="success.main">Response sent</Typography>
+                            <Button
+                                variant="outlined"
+                                onClick={dismissAutoLogin}
+                                sx={{ ml: 'auto' }}
+                            >
+                                Done
+                            </Button>
+                        </Box>
+                    ) : (
+                        <Box sx={{ display: 'flex', gap: 1 }}>
+                            {autoLogin.callbackUrl && (
+                                <Button
+                                    variant="contained"
+                                    color="primary"
+                                    onClick={autoLoginSend}
+                                    disabled={disableSendResponse}
+                                    startIcon={<Login />}
+                                    size="large"
+                                >
+                                    Login
+                                </Button>
+                            )}
+                            <Button
+                                variant="outlined"
+                                onClick={dismissAutoLogin}
+                            >
+                                Cancel
+                            </Button>
+                        </Box>
+                    )}
+                </Paper>
+            )}
+
+            {!autoLogin && !autoLoginLoading && (
+                <>
+                    <Box className="flex-box mt-2">
                 <TextField
                     label="Challenge"
                     variant="outlined"
@@ -337,6 +525,8 @@ function AuthTab() {
                     </Button>
                 </DialogActions>
             </Dialog>
+                </>
+            )}
         </Box>
     );
 }

--- a/apps/browser-extension/src/contexts/AuthContext.tsx
+++ b/apps/browser-extension/src/contexts/AuthContext.tsx
@@ -12,6 +12,8 @@ interface AuthContextValue {
     setDisableSendResponse: (value: boolean) => Promise<void>;
     challenge: string;
     setChallenge: (value: string) => Promise<void>;
+    pendingAutoResponse: boolean;
+    setPendingAutoResponse: (value: boolean) => void;
     refreshAuthStored: (state: Record<string, any>) => Promise<void>;
 }
 
@@ -23,6 +25,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const [challenge, setChallengeState] = useState<string>("");
     const [response, setResponseState] = useState<string>("");
     const [disableSendResponse, setDisableSendResponseState] = useState<boolean>(true);
+    const [pendingAutoResponse, setPendingAutoResponse] = useState<boolean>(false);
     const { storeState } = useVariablesContext();
 
     async function setCallback(value: string) {
@@ -83,6 +86,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setDisableSendResponse,
         challenge,
         setChallenge,
+        pendingAutoResponse,
+        setPendingAutoResponse,
         refreshAuthStored,
     }
 

--- a/apps/browser-extension/src/contexts/UIContext.tsx
+++ b/apps/browser-extension/src/contexts/UIContext.tsx
@@ -111,6 +111,7 @@ export function UIProvider(
         setCallback,
         setChallenge,
         setDisableSendResponse,
+        setPendingAutoResponse,
         refreshAuthStored,
     } = useAuthContext();
     const {
@@ -355,6 +356,7 @@ export function UIProvider(
                 await setResponse("");
                 await setCallback("");
                 await setDisableSendResponse(true);
+                setPendingAutoResponse(true);
             })();
 
             // Prevent challenge repopulating after clear on ID change

--- a/apps/react-wallet/src/components/AuthTab.tsx
+++ b/apps/react-wallet/src/components/AuthTab.tsx
@@ -393,185 +393,185 @@ function AuthTab() {
             {!autoLogin && !autoLoginLoading && (
                 <>
                     <Box className="flex-box mt-2">
-                <TextField
-                    label="Challenge"
-                    variant="outlined"
-                    value={challenge}
-                    onChange={(e) => setChallenge(e.target.value.trim())}
-                    size="small"
-                    className="text-field top"
-                    slotProps={{
-                        htmlInput: {
-                            maxLength: 80,
-                        },
-                        input: {
-                            endAdornment: (
-                                <InputAdornment position="end">
-                                    <Tooltip title="Scan QR" placement="top">
-                                        <span>
-                                            <IconButton
-                                                edge="end"
-                                                onClick={scanChallengeQR}
-                                            >
-                                                <CameraAlt />
-                                            </IconButton>
-                                        </span>
-                                    </Tooltip>
-                                </InputAdornment>
-                            ),
-                        }
-                    }}
-                />
-            </Box>
-
-            <Box className="flex-box">
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={openChallengeDialog}
-                    className="button large bottom"
-                >
-                    New...
-                </Button>
-
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={() => resolveChallenge(challenge)}
-                    className="button large bottom"
-                    disabled={!challenge || challenge === authDID}
-                >
-                    Resolve
-                </Button>
-
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={createResponse}
-                    className="button large bottom"
-                    disabled={!challenge}
-                >
-                    Respond
-                </Button>
-
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={clearChallenge}
-                    className="button large bottom"
-                    disabled={!challenge}
-                >
-                    Clear
-                </Button>
-            </Box>
-
-            <Box className="flex-box mt-2">
-                <TextField
-                    label="Response"
-                    variant="outlined"
-                    value={response}
-                    onChange={(e) => setResponse(e.target.value.trim())}
-                    size="small"
-                    className="text-field top"
-                />
-            </Box>
-
-            <Box className="flex-box">
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={() => decryptResponse(response)}
-                    className="button large bottom"
-                    disabled={!response || response === authDID}
-                >
-                    Decrypt
-                </Button>
-
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={verifyResponse}
-                    className="button large bottom"
-                    disabled={!response}
-                >
-                    Verify
-                </Button>
-
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={sendResponse}
-                    className="button large bottom"
-                    disabled={disableSendResponse}
-                >
-                    Send
-                </Button>
-
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={clearResponse}
-                    className="button large bottom"
-                    disabled={!response}
-                >
-                    Clear
-                </Button>
-            </Box>
-
-            <Dialog open={showChallengeDialog} onClose={closeChallengeDialog}>
-                <DialogTitle>New Challenge</DialogTitle>
-                <DialogContent>
-                    <Typography variant="body2" sx={{ mb: 2 }}>
-                        Add credential requirements. Leave empty for an open challenge.
-                    </Typography>
-                    <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', mb: 2 }}>
-                        <Select
-                            value={challengeSchemaSelection}
-                            onChange={(e) => setChallengeSchemaSelection(e.target.value)}
-                            displayEmpty
+                        <TextField
+                            label="Challenge"
+                            variant="outlined"
+                            value={challenge}
+                            onChange={(e) => setChallenge(e.target.value.trim())}
                             size="small"
-                            sx={{ minWidth: 180 }}
+                            className="text-field top"
+                            slotProps={{
+                                htmlInput: {
+                                    maxLength: 80,
+                                },
+                                input: {
+                                    endAdornment: (
+                                        <InputAdornment position="end">
+                                            <Tooltip title="Scan QR" placement="top">
+                                                <span>
+                                                    <IconButton
+                                                        edge="end"
+                                                        onClick={scanChallengeQR}
+                                                    >
+                                                        <CameraAlt />
+                                                    </IconButton>
+                                                </span>
+                                            </Tooltip>
+                                        </InputAdornment>
+                                    ),
+                                }
+                            }}
+                        />
+                    </Box>
+
+                    <Box className="flex-box">
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={openChallengeDialog}
+                            className="button large bottom"
                         >
-                            <MenuItem value="" disabled>Schema</MenuItem>
-                            {schemaList.map((s: string) => (
-                                <MenuItem key={s} value={s}>{s}</MenuItem>
-                            ))}
-                        </Select>
-                        <Select
-                            value={challengeIssuerSelection}
-                            onChange={(e) => setChallengeIssuerSelection(e.target.value)}
-                            displayEmpty
-                            size="small"
-                            sx={{ minWidth: 180 }}
+                            New...
+                        </Button>
+
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={() => resolveChallenge(challenge)}
+                            className="button large bottom"
+                            disabled={!challenge || challenge === authDID}
                         >
-                            <MenuItem value="">Any issuer</MenuItem>
-                            {agentList.map((s: string) => (
-                                <MenuItem key={s} value={s}>{s}</MenuItem>
-                            ))}
-                        </Select>
-                        <Button variant="contained" size="small" onClick={addChallengeCredential} disabled={!challengeSchemaSelection}>
-                            Add
+                            Resolve
+                        </Button>
+
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={createResponse}
+                            className="button large bottom"
+                            disabled={!challenge}
+                        >
+                            Respond
+                        </Button>
+
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={clearChallenge}
+                            className="button large bottom"
+                            disabled={!challenge}
+                        >
+                            Clear
                         </Button>
                     </Box>
-                    {challengeCredentials.length > 0 &&
-                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                            {challengeCredentials.map((cred, i) => (
-                                <Chip
-                                    key={i}
-                                    label={cred.issuer ? `${cred.schema} (${cred.issuer})` : cred.schema}
-                                    onDelete={() => removeChallengeCredential(i)}
-                                />
-                            ))}
-                        </Box>
-                    }
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={closeChallengeDialog}>Cancel</Button>
-                    <Button variant="contained" onClick={newChallenge}>
-                        Create
-                    </Button>
-                </DialogActions>
-            </Dialog>
+
+                    <Box className="flex-box mt-2">
+                        <TextField
+                            label="Response"
+                            variant="outlined"
+                            value={response}
+                            onChange={(e) => setResponse(e.target.value.trim())}
+                            size="small"
+                            className="text-field top"
+                        />
+                    </Box>
+
+                    <Box className="flex-box">
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={() => decryptResponse(response)}
+                            className="button large bottom"
+                            disabled={!response || response === authDID}
+                        >
+                            Decrypt
+                        </Button>
+
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={verifyResponse}
+                            className="button large bottom"
+                            disabled={!response}
+                        >
+                            Verify
+                        </Button>
+
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={sendResponse}
+                            className="button large bottom"
+                            disabled={disableSendResponse}
+                        >
+                            Send
+                        </Button>
+
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={clearResponse}
+                            className="button large bottom"
+                            disabled={!response}
+                        >
+                            Clear
+                        </Button>
+                    </Box>
+
+                    <Dialog open={showChallengeDialog} onClose={closeChallengeDialog}>
+                        <DialogTitle>New Challenge</DialogTitle>
+                        <DialogContent>
+                            <Typography variant="body2" sx={{ mb: 2 }}>
+                                Add credential requirements. Leave empty for an open challenge.
+                            </Typography>
+                            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', mb: 2 }}>
+                                <Select
+                                    value={challengeSchemaSelection}
+                                    onChange={(e) => setChallengeSchemaSelection(e.target.value)}
+                                    displayEmpty
+                                    size="small"
+                                    sx={{ minWidth: 180 }}
+                                >
+                                    <MenuItem value="" disabled>Schema</MenuItem>
+                                    {schemaList.map((s: string) => (
+                                        <MenuItem key={s} value={s}>{s}</MenuItem>
+                                    ))}
+                                </Select>
+                                <Select
+                                    value={challengeIssuerSelection}
+                                    onChange={(e) => setChallengeIssuerSelection(e.target.value)}
+                                    displayEmpty
+                                    size="small"
+                                    sx={{ minWidth: 180 }}
+                                >
+                                    <MenuItem value="">Any issuer</MenuItem>
+                                    {agentList.map((s: string) => (
+                                        <MenuItem key={s} value={s}>{s}</MenuItem>
+                                    ))}
+                                </Select>
+                                <Button variant="contained" size="small" onClick={addChallengeCredential} disabled={!challengeSchemaSelection}>
+                                    Add
+                                </Button>
+                            </Box>
+                            {challengeCredentials.length > 0 &&
+                                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                                    {challengeCredentials.map((cred, i) => (
+                                        <Chip
+                                            key={i}
+                                            label={cred.issuer ? `${cred.schema} (${cred.issuer})` : cred.schema}
+                                            onDelete={() => removeChallengeCredential(i)}
+                                        />
+                                    ))}
+                                </Box>
+                            }
+                        </DialogContent>
+                        <DialogActions>
+                            <Button onClick={closeChallengeDialog}>Cancel</Button>
+                            <Button variant="contained" onClick={newChallenge}>
+                                Create
+                            </Button>
+                        </DialogActions>
+                    </Dialog>
                 </>
             )}
         </Box>

--- a/apps/react-wallet/src/components/AuthTab.tsx
+++ b/apps/react-wallet/src/components/AuthTab.tsx
@@ -1,15 +1,24 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
-    Box, Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle,
-    MenuItem, Select, TextField, IconButton, InputAdornment, Tooltip, Typography
+    Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle,
+    Divider, MenuItem, Paper, Select, TextField, IconButton, InputAdornment, Tooltip, Typography
 } from "@mui/material";
-import { CameraAlt } from "@mui/icons-material";
+import { CameraAlt, CheckCircle, Login, Warning } from "@mui/icons-material";
 import axios from "axios";
 import { useWalletContext } from "../contexts/WalletProvider";
 import { useSnackbar } from "../contexts/SnackbarProvider";
 import { useUIContext } from "../contexts/UIContext";
 import { useVariablesContext } from "../contexts/VariablesProvider";
 import { scanQrCode } from "../utils/utils";
+
+interface AutoLoginState {
+    responseDID: string;
+    callbackUrl: string;
+    fulfilled: number;
+    requested: number;
+    match: boolean;
+    credentials: { vc: string; vp: string }[];
+}
 
 function AuthTab() {
     const [authDID, setAuthDID] = useState<string>("");
@@ -21,6 +30,10 @@ function AuthTab() {
     const [challengeCredentials, setChallengeCredentials] = useState<{ schema: string; issuer: string }[]>([]);
     const [challengeSchemaSelection, setChallengeSchemaSelection] = useState<string>("");
     const [challengeIssuerSelection, setChallengeIssuerSelection] = useState<string>("");
+    const [autoLogin, setAutoLogin] = useState<AutoLoginState | null>(null);
+    const [autoLoginLoading, setAutoLoginLoading] = useState(false);
+    const [autoLoginSent, setAutoLoginSent] = useState(false);
+    const pendingAutoRef = useRef<string | null>(null);
     const { keymaster } = useWalletContext();
     const {
         setOpenBrowser,
@@ -37,9 +50,83 @@ function AuthTab() {
         if (pendingChallenge && pendingChallenge !== challenge) {
             setChallenge(pendingChallenge);
             setPendingChallenge(null);
+            if (keymaster) {
+                handleAutoResponse(pendingChallenge);
+            } else {
+                pendingAutoRef.current = pendingChallenge;
+            }
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [pendingChallenge]);
+
+    useEffect(() => {
+        if (keymaster && pendingAutoRef.current) {
+            const did = pendingAutoRef.current;
+            pendingAutoRef.current = null;
+            handleAutoResponse(did);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [keymaster]);
+
+    async function handleAutoResponse(challengeDID: string) {
+        if (!keymaster) return;
+
+        setAutoLoginLoading(true);
+        setAutoLogin(null);
+        setAutoLoginSent(false);
+
+        try {
+            const asset = await keymaster.resolveAsset(challengeDID);
+            const challengeData = (asset as { challenge: { callback?: string; credentials?: { schema: string; issuers?: string[] }[] } }).challenge;
+            const callbackUrl = challengeData?.callback || "";
+
+            const responseDID = await keymaster.createResponse(challengeDID, { retries: 10 });
+            setResponse(responseDID);
+
+            const decrypted = await keymaster.decryptJSON(responseDID) as {
+                response: { challenge: string; credentials: { vc: string; vp: string }[]; requested: number; fulfilled: number; match: boolean }
+            };
+            const responseData = decrypted.response;
+
+            setAutoLogin({
+                responseDID,
+                callbackUrl,
+                fulfilled: responseData.fulfilled,
+                requested: responseData.requested,
+                match: responseData.match,
+                credentials: responseData.credentials,
+            });
+
+            setCallback(callbackUrl);
+            if (callbackUrl) {
+                setDisableSendResponse(false);
+            }
+        } catch (error: any) {
+            setError(error);
+        } finally {
+            setAutoLoginLoading(false);
+        }
+    }
+
+    async function autoLoginSend() {
+        if (!autoLogin?.callbackUrl) return;
+        try {
+            setDisableSendResponse(true);
+            await axios.post(autoLogin.callbackUrl, { response });
+            setAutoLoginSent(true);
+            setSuccess("Response sent successfully");
+            setCallback("");
+        } catch (error: any) {
+            setDisableSendResponse(false);
+            setError(error);
+        }
+    }
+
+    function dismissAutoLogin() {
+        setAutoLogin(null);
+        setAutoLoginLoading(false);
+        setAutoLoginSent(false);
+    }
 
     function openChallengeDialog() {
         setChallengeCredentials([]);
@@ -200,7 +287,112 @@ function AuthTab() {
 
     return (
         <Box>
-            <Box className="flex-box mt-2">
+            {autoLoginLoading && (
+                <Paper elevation={2} sx={{ p: 3, m: 2, textAlign: 'center' }}>
+                    <CircularProgress size={40} />
+                    <Typography sx={{ mt: 2 }}>Processing challenge...</Typography>
+                </Paper>
+            )}
+
+            {autoLogin && !autoLoginLoading && (
+                <Paper elevation={2} sx={{ p: 3, m: 2 }}>
+                    <Typography variant="h6" sx={{ mb: 2, display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Login /> Login Request
+                    </Typography>
+
+                    <Divider sx={{ mb: 2 }} />
+
+                    {autoLogin.callbackUrl && (
+                        <Box sx={{ mb: 2 }}>
+                            <Typography variant="body2" color="text.secondary">
+                                Destination
+                            </Typography>
+                            <Typography variant="body1" sx={{ wordBreak: 'break-all' }}>
+                                {autoLogin.callbackUrl}
+                            </Typography>
+                        </Box>
+                    )}
+
+                    <Box sx={{ mb: 2 }}>
+                        <Typography variant="body2" color="text.secondary">
+                            Credentials
+                        </Typography>
+                        {autoLogin.requested === 0 ? (
+                            <Typography variant="body1">
+                                Identity verification only (no credentials requested)
+                            </Typography>
+                        ) : (
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5 }}>
+                                {autoLogin.match ? (
+                                    <Chip
+                                        icon={<CheckCircle />}
+                                        label={`${autoLogin.fulfilled} of ${autoLogin.requested} credential(s) matched`}
+                                        color="success"
+                                        size="small"
+                                    />
+                                ) : (
+                                    <Chip
+                                        icon={<Warning />}
+                                        label={`${autoLogin.fulfilled} of ${autoLogin.requested} credential(s) matched`}
+                                        color="warning"
+                                        size="small"
+                                    />
+                                )}
+                            </Box>
+                        )}
+                    </Box>
+
+                    <Box sx={{ mb: 2 }}>
+                        <Typography variant="body2" color="text.secondary">
+                            Response
+                        </Typography>
+                        <Typography variant="body2" sx={{ wordBreak: 'break-all', fontFamily: 'monospace', fontSize: '0.75rem' }}>
+                            {autoLogin.responseDID}
+                        </Typography>
+                    </Box>
+
+                    <Divider sx={{ mb: 2 }} />
+
+                    {autoLoginSent ? (
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <CheckCircle color="success" />
+                            <Typography color="success.main">Response sent</Typography>
+                            <Button
+                                variant="outlined"
+                                onClick={dismissAutoLogin}
+                                sx={{ ml: 'auto' }}
+                            >
+                                Done
+                            </Button>
+                        </Box>
+                    ) : (
+                        <Box sx={{ display: 'flex', gap: 1 }}>
+                            {autoLogin.callbackUrl && (
+                                <Button
+                                    variant="contained"
+                                    color="primary"
+                                    onClick={autoLoginSend}
+                                    disabled={disableSendResponse}
+                                    startIcon={<Login />}
+                                    size="large"
+                                >
+                                    Login
+                                </Button>
+                            )}
+                            <Button
+                                variant="outlined"
+                                onClick={dismissAutoLogin}
+                            >
+                                Cancel
+                            </Button>
+                        </Box>
+                    )}
+                </Paper>
+            )}
+
+            {!autoLogin && !autoLoginLoading && (
+                <>
+                    <Box className="flex-box mt-2">
                 <TextField
                     label="Challenge"
                     variant="outlined"
@@ -380,6 +572,8 @@ function AuthTab() {
                     </Button>
                 </DialogActions>
             </Dialog>
+                </>
+            )}
         </Box>
     );
 }

--- a/apps/react-wallet/src/components/AuthTab.tsx
+++ b/apps/react-wallet/src/components/AuthTab.tsx
@@ -98,9 +98,7 @@ function AuthTab() {
             });
 
             setCallback(callbackUrl);
-            if (callbackUrl) {
-                setDisableSendResponse(false);
-            }
+            setDisableSendResponse(!callbackUrl);
         } catch (error: any) {
             setError(error);
         } finally {
@@ -109,10 +107,10 @@ function AuthTab() {
     }
 
     async function autoLoginSend() {
-        if (!autoLogin?.callbackUrl) return;
+        if (!autoLogin?.callbackUrl || !autoLogin.responseDID) return;
         try {
             setDisableSendResponse(true);
-            await axios.post(autoLogin.callbackUrl, { response });
+            await axios.post(autoLogin.callbackUrl, { response: autoLogin.responseDID });
             setAutoLoginSent(true);
             setSuccess("Response sent successfully");
             setCallback("");


### PR DESCRIPTION
## Summary

When a wallet receives a challenge via URL parameter (`?challenge=did:...`), it now automatically creates a response and displays a **Login Request** panel instead of requiring the user to manually click Resolve → Respond → Send.

## Login Request Panel

- **Destination** — callback URL where the response will be sent
- **Credentials** — shows match status (fulfilled vs requested) with success/warning indicators
- **Response** — the generated response DID
- **Login** button — single click to send the response
- **Cancel** — dismisses the panel and falls back to the existing manual auth UI

## Changes

- `apps/react-wallet/src/components/AuthTab.tsx` — auto-response logic triggered by `pendingChallenge`; Login Request panel UI
- `apps/browser-extension/src/components/AuthTab.tsx` — same auto-response and Login Request panel
- `apps/browser-extension/src/contexts/AuthContext.tsx` — added `pendingAutoResponse` flag
- `apps/browser-extension/src/contexts/UIContext.tsx` — sets `pendingAutoResponse` when processing a URL challenge

The existing manual auth flow (New/Resolve/Respond/Decrypt/Verify/Send/Clear) remains fully accessible.