### PR TITLE
fix: copy Cargo.lock into Rust gatekeeper Docker build

### DIFF
--- a/Dockerfile.gatekeeper-rust
+++ b/Dockerfile.gatekeeper-rust
@@ -2,6 +2,7 @@ FROM rust:1.90-bullseye AS builder
 
 WORKDIR /build
 COPY rust/services/gatekeeper/Cargo.toml ./Cargo.toml
+COPY rust/services/gatekeeper/Cargo.lock ./Cargo.lock
 COPY rust/services/gatekeeper/src ./src
 RUN cargo build --release
 


### PR DESCRIPTION
The `cid` crate's transitive dependency `core2 v0.4.0` was yanked from crates.io. Cargo can still use yanked versions when they appear in a lockfile, but the Dockerfile only copied `Cargo.toml`, so every build resolved dependencies from scratch and hit the yank.

This copies `Cargo.lock` alongside `Cargo.toml` so the builder uses pinned, known-good versions.

Fixes the failing **Build & Test Docker images (rust gatekeeper)** CI check.