### PR TITLE
fix(satoshi): use getBlockHeader in syncBlocks for pruned node compat

### DIFF
--- a/services/mediators/satoshi/src/satoshi-mediator.ts
+++ b/services/mediators/satoshi/src/satoshi-mediator.ts
@@ -854,9 +854,9 @@ async function syncBlocks(): Promise<void> {
 
         for (let height = currentMax; height <= blockCount; height++) {
             const blockHash = await btcClient.getBlockHash(height);
-            const block = await btcClient.getBlock(blockHash) as Block;
+            const header = await btcClient.getBlockHeader(blockHash) as BlockHeader;
             console.log(`${height}/${blockCount} blocks (${(100 * height / blockCount).toFixed(2)}%)`);
-            await addBlock(height, blockHash, block.time);
+            await addBlock(height, blockHash, header.time!);
         }
     } catch (error) {
         console.error(`Error syncing blocks:`, error);


### PR DESCRIPTION
## Problem

`syncBlocks()` calls `getBlock()` which requires full block data. On pruned nodes, blocks below the prune height are unavailable, causing `Block not available (pruned data)` errors and preventing block metadata from being synced to the gatekeeper.

Without block metadata in the gatekeeper, resolved DIDs are missing their `timestamp` field in `didDocumentMetadata`.

## Fix

Replace `getBlock()` with `getBlockHeader()` in `syncBlocks()`. Headers are always retained on pruned nodes, and `syncBlocks` only needs `hash`, `height`, and `time` — all present on `BlockHeader`.

`scanBlocks`/`fetchBlock` still uses `getBlock` since it needs full transaction data for OP_RETURN scanning.