### PR TITLE
fix(gatekeeper): preserve event-level registration for upperBound timestamps

### DIFF
--- a/rust/services/gatekeeper/src/api.rs
+++ b/rust/services/gatekeeper/src/api.rs
@@ -693,13 +693,18 @@ pub(crate) async fn import_batch_by_cids(
                 })
                 .unwrap_or_else(|| vec![index as u32]);
 
+            let mut reg = metadata.get("registration").cloned().unwrap_or(Value::Null);
+            if let Some(obj) = reg.as_object_mut() {
+                obj.insert("opidx".to_string(), Value::from(index));
+            }
+
             batch.push(json!({
                 "registry": metadata.get("registry").cloned().unwrap_or(Value::String("hyperswarm".to_string())),
                 "time": metadata.get("time").cloned().unwrap_or(Value::String(chrono_like_now())),
                 "ordinal": ordinal,
                 "operation": operation,
                 "opid": cid,
-                "registration": metadata.get("registration").cloned().unwrap_or(Value::Null)
+                "registration": reg
             }));
         }
     }

--- a/rust/services/gatekeeper/src/events.rs
+++ b/rust/services/gatekeeper/src/events.rs
@@ -217,6 +217,7 @@ pub(crate) async fn handle_did_operation(
         operation: payload.clone(),
         opid: Some(opid),
         did: Some(did.clone()),
+        registration: None,
     };
 
     let queue_registry = if op_type == "create" {

--- a/rust/services/gatekeeper/src/store.rs
+++ b/rust/services/gatekeeper/src/store.rs
@@ -1581,21 +1581,21 @@ impl JsonDb {
         let upper = registration.as_ref().and_then(|reg| {
             let height = reg.get("height").and_then(Value::as_u64)?;
             let block = self.get_block(registry, Some(BlockLookup::Height(height)))?;
-            Some(json!({
-                "time": block.get("time").cloned().unwrap_or(Value::Null),
-                "timeISO": block.get("time")
-                    .and_then(Value::as_u64)
-                    .and_then(|time| chrono::DateTime::<chrono::Utc>::from_timestamp(time as i64, 0))
-                    .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true))
-                    .map(Value::String)
-                    .unwrap_or(Value::Null),
-                "blockid": block.get("hash").cloned().unwrap_or(Value::Null),
-                "height": block.get("height").cloned().unwrap_or(Value::Null),
-                "txid": reg.get("txid").cloned().unwrap_or(Value::Null),
-                "txidx": reg.get("index").cloned().unwrap_or(Value::Null),
-                "batchid": reg.get("batch").cloned().unwrap_or(Value::Null),
-                "opidx": reg.get("opidx").cloned().unwrap_or(Value::Null)
-            }))
+            let mut obj = serde_json::Map::new();
+            obj.insert("time".to_string(), block.get("time").cloned().unwrap_or(Value::Null));
+            obj.insert("timeISO".to_string(), block.get("time")
+                .and_then(Value::as_u64)
+                .and_then(|time| chrono::DateTime::<chrono::Utc>::from_timestamp(time as i64, 0))
+                .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true))
+                .map(Value::String)
+                .unwrap_or(Value::Null));
+            obj.insert("blockid".to_string(), block.get("hash").cloned().unwrap_or(Value::Null));
+            obj.insert("height".to_string(), block.get("height").cloned().unwrap_or(Value::Null));
+            if let Some(v) = reg.get("txid") { obj.insert("txid".to_string(), v.clone()); }
+            if let Some(v) = reg.get("index") { obj.insert("txidx".to_string(), v.clone()); }
+            if let Some(v) = reg.get("batch") { obj.insert("batchid".to_string(), v.clone()); }
+            if let Some(v) = reg.get("opidx") { obj.insert("opidx".to_string(), v.clone()); }
+            Some(Value::Object(obj))
         });
 
         (lower, upper)

--- a/rust/services/gatekeeper/src/store.rs
+++ b/rust/services/gatekeeper/src/store.rs
@@ -26,6 +26,8 @@ pub(crate) struct EventRecord {
     pub(crate) opid: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) did: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) registration: Option<Value>,
 }
 
 #[derive(Default, Serialize, Deserialize)]
@@ -190,18 +192,23 @@ pub(crate) fn value_to_event_record(value: &Value) -> EventRecord {
             .get("did")
             .and_then(Value::as_str)
             .map(ToString::to_string),
+        registration: value.get("registration").cloned().filter(|v| !v.is_null()),
     }
 }
 
 pub(crate) fn event_record_to_value(event: &EventRecord) -> Value {
-    json!({
+    let mut val = json!({
         "registry": event.registry,
         "time": event.time,
         "ordinal": event.ordinal,
         "operation": event.operation,
         "opid": event.opid,
         "did": event.did
-    })
+    });
+    if let Some(reg) = &event.registration {
+        val["registration"] = reg.clone();
+    }
+    val
 }
 
 pub(crate) fn redis_event_to_stored_value(event: &EventRecord) -> Value {
@@ -1569,7 +1576,7 @@ impl JsonDb {
             .cloned()
             .or_else(|| {
                 // registration may be attached at the event level for batch-imported events
-                None
+                event.registration.clone()
             });
         let upper = registration.as_ref().and_then(|reg| {
             let height = reg.get("height").and_then(Value::as_u64)?;


### PR DESCRIPTION
## Problem

After the block store was repopulated (PR #426), `lowerBound` timestamps appear correctly but `upperBound` is always `null`.

## Root Cause

The Rust gatekeeper's `EventRecord` struct was missing the `registration` field. When the satoshi mediator batch-imports events, it attaches blockchain confirmation metadata (`height`, `txid`, `index`, `batch`) at the **event level** as `registration` — not inside `operation`.

`value_to_event_record()` silently dropped this field, and `block_timestamp_bounds()` had a TODO stub returning `None` instead of checking the event-level registration for the height needed to look up the upper-bound block.

## Fix

- Add `registration: Option<Value>` to `EventRecord`
- Extract `registration` in `value_to_event_record()`
- Include `registration` in `event_record_to_value()`
- In `block_timestamp_bounds()`, fall back to `event.registration` when `operation.registration` has no height