### PR TITLE
fix: normalize JSON-serialized Buffer in getImage/getFile

### DIFF
--- a/packages/keymaster/src/keymaster-client.ts
+++ b/packages/keymaster/src/keymaster-client.ts
@@ -1351,11 +1351,29 @@ export default class KeymasterClient implements KeymasterInterface {
 
     async getImage(id: string): Promise<ImageFileAsset | null> {
         try {
-            const response = await this.axios.get(`${this.API}/images/${id}`);
-            return response.data;
+            const response = await this.axios.get(`${this.API}/images/${id}`, {
+                responseType: 'arraybuffer',
+                headers: { 'Accept': 'application/octet-stream' }
+            });
+            const metadata = JSON.parse(response.headers['x-metadata']);
+            return {
+                file: {
+                    ...metadata.file,
+                    data: Buffer.from(response.data),
+                },
+                image: metadata.image,
+            };
         }
         catch (error) {
-            throwError(error);
+            const axiosError = error as AxiosError;
+            if (axiosError.response?.status === 404) {
+                return null;
+            }
+            if (axiosError.response?.data instanceof Uint8Array) {
+                const textDecoder = new TextDecoder();
+                axiosError.response.data = JSON.parse(textDecoder.decode(axiosError.response.data));
+            }
+            throwError(axiosError);
         }
     }
 
@@ -1449,11 +1467,26 @@ export default class KeymasterClient implements KeymasterInterface {
 
     async getFile(id: string): Promise<FileAsset | null> {
         try {
-            const response = await this.axios.get(`${this.API}/files/${id}`);
-            return response.data.file;
+            const response = await this.axios.get(`${this.API}/files/${id}`, {
+                responseType: 'arraybuffer',
+                headers: { 'Accept': 'application/octet-stream' }
+            });
+            const metadata = JSON.parse(response.headers['x-metadata']);
+            return {
+                ...metadata,
+                data: Buffer.from(response.data),
+            };
         }
         catch (error) {
-            throwError(error);
+            const axiosError = error as AxiosError;
+            if (axiosError.response?.status === 404) {
+                return null;
+            }
+            if (axiosError.response?.data instanceof Uint8Array) {
+                const textDecoder = new TextDecoder();
+                axiosError.response.data = JSON.parse(textDecoder.decode(axiosError.response.data));
+            }
+            throwError(axiosError);
         }
     }
 

--- a/services/herald/server/src/index.ts
+++ b/services/herald/server/src/index.ts
@@ -297,14 +297,9 @@ async function resolveAvatarImage(name: string): Promise<{
     if (!avatarDid) return null;
 
     const image = await keymaster.getImage(avatarDid);
-    const rawData = image?.file?.data;
-    const data = Buffer.isBuffer(rawData)
-        ? rawData
-        : rawData && typeof rawData === 'object' && (rawData as any).type === 'Buffer' && Array.isArray((rawData as any).data)
-            ? Buffer.from((rawData as any).data)
-            : null;
+    const data = image?.file?.data ?? null;
 
-    if (!data || !image?.file?.type || !image.image) {
+    if (!data || !Buffer.isBuffer(data) || !image?.file?.type || !image.image) {
         return null;
     }
 

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -5984,7 +5984,19 @@ v1router.put('/images/:id', express.raw({ type: 'application/octet-stream', limi
 v1router.get('/images/:id', async (req, res) => {
     try {
         const imageAsset = await keymaster.getImage(req.params.id);
-        res.json(imageAsset);
+
+        if (req.get('Accept') === 'application/octet-stream') {
+            if (!imageAsset?.file?.data) {
+                res.status(404).send({ error: 'Image not found' });
+                return;
+            }
+            const { data, ...fileMeta } = imageAsset.file;
+            res.set('Content-Type', 'application/octet-stream');
+            res.set('X-Metadata', JSON.stringify({ file: fileMeta, image: imageAsset.image }));
+            res.send(data);
+        } else {
+            res.json(imageAsset);
+        }
     } catch (error: any) {
         res.status(404).send({ error: error.toString() });
     }
@@ -6214,7 +6226,19 @@ v1router.put('/files/:id', async (req, res) => {
 v1router.get('/files/:id', async (req, res) => {
     try {
         const file = await keymaster.getFile(req.params.id);
-        res.json({ file });
+
+        if (req.get('Accept') === 'application/octet-stream') {
+            if (!file?.data) {
+                res.status(404).send({ error: 'File not found' });
+                return;
+            }
+            const { data, ...fileMeta } = file;
+            res.set('Content-Type', 'application/octet-stream');
+            res.set('X-Metadata', JSON.stringify(fileMeta));
+            res.send(data);
+        } else {
+            res.json({ file });
+        }
     } catch (error: any) {
         res.status(404).send({ error: error.toString() });
     }

--- a/tests/keymaster/client.test.ts
+++ b/tests/keymaster/client.test.ts
@@ -3274,26 +3274,36 @@ describe('updateImage', () => {
 
 describe('getImage', () => {
     const mockImageId = 'image1';
-    const mockImageAsset = {
-        file: { cid: 'mockCID', filename: 'image', type: 'image/png', bytes: 392 },
+    const mockImageData = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const mockMetadata = {
+        file: { cid: 'mockCID', filename: 'image', type: 'image/png', bytes: 4 },
         image: { width: 100, height: 100 },
     };
 
     it('should get image', async () => {
         nock(KeymasterURL)
             .get(`${Endpoints.images}/${mockImageId}`)
-            .reply(200, mockImageAsset);
+            .reply(200, mockImageData, {
+                'Content-Type': 'application/octet-stream',
+                'X-Metadata': JSON.stringify(mockMetadata),
+            });
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
         const result = await keymaster.getImage(mockImageId);
 
-        expect(result).toStrictEqual(mockImageAsset);
+        expect(result).toEqual({
+            file: {
+                ...mockMetadata.file,
+                data: mockImageData,
+            },
+            image: mockMetadata.image,
+        });
     });
 
     it('should throw exception on getImage server error', async () => {
         nock(KeymasterURL)
             .get(`${Endpoints.images}/${mockImageId}`)
-            .reply(500, ServerError);
+            .reply(500, JSON.stringify(ServerError));
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
 
@@ -3464,23 +3474,30 @@ describe('updateFileStream', () => {
 
 describe('getFile', () => {
     const mockFileId = 'file1';
-    const mockFile = { cid: 'mockCID', bytes: 12345, type: 'pdf' };
+    const mockFileData = Buffer.from('hello world');
+    const mockFileMeta = { cid: 'mockCID', bytes: 11, type: 'text/plain', filename: 'test.txt' };
 
     it('should get file', async () => {
         nock(KeymasterURL)
             .get(`${Endpoints.files}/${mockFileId}`)
-            .reply(200, { file: mockFile });
+            .reply(200, mockFileData, {
+                'Content-Type': 'application/octet-stream',
+                'X-Metadata': JSON.stringify(mockFileMeta),
+            });
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
         const result = await keymaster.getFile(mockFileId);
 
-        expect(result).toStrictEqual(mockFile);
+        expect(result).toEqual({
+            ...mockFileMeta,
+            data: mockFileData,
+        });
     });
 
     it('should throw exception on getFile server error', async () => {
         nock(KeymasterURL)
             .get(`${Endpoints.files}/${mockFileId}`)
-            .reply(500, ServerError);
+            .reply(500, JSON.stringify(ServerError));
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
 


### PR DESCRIPTION
**Problem:** `KeymasterClient.getImage()` and `getFile()` return file data as a plain object `{ type: "Buffer", data: [137, 80, ...] }` instead of a real `Buffer`. This happens because the keymaster server sends the response via `res.json()`, and Node's `Buffer.toJSON()` serializes to that format. The client never reconstitutes it.

This causes the CLI's `get-asset-image` and `get-asset-file` commands to crash with `ERR_INVALID_ARG_TYPE` when calling `fs.writeFileSync()`.

**Fix:** Add a `normalizeBufferData()` helper that detects the JSON-serialized Buffer pattern and converts it back to a real `Buffer`. Applied in both `getImage()` and `getFile()`.

Other binary methods (`getVaultItem`, `getDmailAttachment`) are not affected — they already use `responseType: 'arraybuffer'` with `Buffer.from()`.