### PR TITLE
chore: Initialize v0.8

### DIFF
--- a/apps/browser-extension/package-lock.json
+++ b/apps/browser-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "archon-chrome-extension",
-  "version": "0.7.0",
+  "name": "archon-browser-extension",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "archon-chrome-extension",
-      "version": "0.7.0",
+      "name": "archon-browser-extension",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "qrcode.react": "^4.2.0"

--- a/apps/browser-extension/package.json
+++ b/apps/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archon-browser-extension",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Archon Browser Extension",
   "main": "index.js",
   "scripts": {

--- a/apps/gatekeeper-client/package-lock.json
+++ b/apps/gatekeeper-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatekeeper-client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatekeeper-client",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/apps/gatekeeper-client/package.json
+++ b/apps/gatekeeper-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatekeeper-client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/herald-client/package-lock.json
+++ b/apps/herald-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-client",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.14.1",

--- a/apps/herald-client/package.json
+++ b/apps/herald-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/keymaster-client/package-lock.json
+++ b/apps/keymaster-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "keymaster-client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "keymaster-client",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/apps/keymaster-client/package.json
+++ b/apps/keymaster-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymaster-client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/react-wallet/package-lock.json
+++ b/apps/react-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@didcid/react-wallet",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@didcid/react-wallet",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor-mlkit/barcode-scanning": "^7.3.0",

--- a/apps/react-wallet/package.json
+++ b/apps/react-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/react-wallet",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Archon Android Demo",
   "scripts": {
     "dev": "vite",

--- a/docs/gatekeeper-api.json
+++ b/docs/gatekeeper-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Gatekeeper API",
-    "version": "0.5.0",
+    "version": "0.8.0",
     "description": "Documentation for Keymaster API"
   },
   "paths": {

--- a/docs/keymaster-api.json
+++ b/docs/keymaster-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Keymaster API",
-    "version": "0.5.0",
+    "version": "0.8.0",
     "description": "Documentation for Keymaster API"
   },
   "paths": {
@@ -2330,6 +2330,69 @@
                   "properties": {
                     "ok": {
                       "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nostr/import": {
+      "post": {
+        "summary": "Import a Nostr private key (nsec) for the current identity.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "nsec": {
+                    "type": "string",
+                    "description": "Bech32-encoded Nostr private key."
+                  },
+                  "id": {
+                    "type": "string",
+                    "description": "Identity name (optional, defaults to current)."
+                  }
+                },
+                "required": [
+                  "nsec"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The imported Nostr public keys.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "npub": {
+                      "type": "string"
+                    },
+                    "pubkey": {
+                      "type": "string"
                     }
                   }
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "archon",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "archon",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "ISC",
       "workspaces": [
         "packages/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25342,7 +25342,7 @@
     },
     "packages/cipher": {
       "name": "@didcid/cipher",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "MIT",
       "dependencies": {
         "@didcid/browser-hdkey": "^0.1.11",
@@ -25395,7 +25395,7 @@
     },
     "packages/common": {
       "name": "@didcid/common",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.3",
@@ -25405,12 +25405,12 @@
     },
     "packages/gatekeeper": {
       "name": "@didcid/gatekeeper",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "MIT",
       "dependencies": {
-        "@didcid/cipher": "^0.2.7",
-        "@didcid/common": "^0.1.9",
-        "@didcid/ipfs": "^0.1.9",
+        "@didcid/cipher": "^0.2.8",
+        "@didcid/common": "^0.1.10",
+        "@didcid/ipfs": "^0.1.10",
         "axios": "^1.15.0",
         "canonicalize": "^2.0.0",
         "dotenv": "^16.4.5",
@@ -25425,10 +25425,10 @@
     },
     "packages/ipfs": {
       "name": "@didcid/ipfs",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
-        "@didcid/common": "^0.1.9",
+        "@didcid/common": "^0.1.10",
         "@helia/json": "^4.0.3",
         "@helia/unixfs": "^5.0.0",
         "axios": "^1.15.0",
@@ -25444,12 +25444,12 @@
     },
     "packages/keymaster": {
       "name": "@didcid/keymaster",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "MIT",
       "dependencies": {
-        "@didcid/cipher": "^0.2.7",
-        "@didcid/common": "^0.1.9",
-        "@didcid/gatekeeper": "^0.4.7",
+        "@didcid/cipher": "^0.2.8",
+        "@didcid/common": "^0.1.10",
+        "@didcid/gatekeeper": "^0.4.8",
         "axios": "^1.15.0",
         "commander": "^11.1.0",
         "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archon",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "Self-sovereign identity infrastructure for the decentralized web",
   "private": true,

--- a/packages/cipher/CHANGELOG.md
+++ b/packages/cipher/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.8](https://github.com/archetech/archon/compare/@didcid/cipher@0.1.3...@didcid/cipher@0.2.8) (2026-04-17)
+
+
+### Bug Fixes
+
+* Incorrect passphrase on react-wallet ([#97](https://github.com/archetech/archon/issues/97)) ([5ce0523](https://github.com/archetech/archon/commit/5ce05238ecb2dd6e5a4a647ab0429a9cf9bdb6a4))
+
+
+### Features
+
+* Add nostr support ([#133](https://github.com/archetech/archon/issues/133)) ([3591d62](https://github.com/archetech/archon/commit/3591d6281bf29c5e98e761e7ad56a7abf78a4106)), closes [#87](https://github.com/archetech/archon/issues/87)
+* Adopt W3C JWE standard for encryption ([#90](https://github.com/archetech/archon/issues/90)) ([2321ca7](https://github.com/archetech/archon/commit/2321ca7fd6e074bac1f4b8fa7c12e58d4b45b181))
+* Store imported nostr nsec in wallet ([#397](https://github.com/archetech/archon/issues/397)) ([7a0a919](https://github.com/archetech/archon/commit/7a0a919f34ba9161dce25eaa528dccf3443840a4))
+
+
+
+
+
 ## [0.2.7](https://github.com/archetech/archon/compare/@didcid/cipher@0.1.3...@didcid/cipher@0.2.7) (2026-04-06)
 
 

--- a/packages/cipher/package.json
+++ b/packages/cipher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/cipher",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Archon cipher lib",
   "type": "module",
   "main": "./dist/cjs/cipher-web.cjs",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.10](https://github.com/archetech/archon/compare/@didcid/common@0.1.3...@didcid/common@0.1.10) (2026-04-17)
+
+
+### Features
+
+* Add Lightning wallet support via LNbits integration ([#136](https://github.com/archetech/archon/issues/136)) ([#140](https://github.com/archetech/archon/issues/140)) ([4d99d5a](https://github.com/archetech/archon/commit/4d99d5ab8da20897e5aecf8557b271c3b1779d45))
+
+
+
+
+
 ## [0.1.9](https://github.com/archetech/archon/compare/@didcid/common@0.1.3...@didcid/common@0.1.9) (2026-04-06)
 
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/common",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Archon common utilities",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/gatekeeper/CHANGELOG.md
+++ b/packages/gatekeeper/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.8](https://github.com/archetech/archon/compare/@didcid/gatekeeper@0.2.0...@didcid/gatekeeper@0.4.8) (2026-04-17)
+
+
+### Bug Fixes
+
+* Better error message for missing wallet ([#53](https://github.com/archetech/archon/issues/53)) ([1a8dad0](https://github.com/archetech/archon/commit/1a8dad05a8a1eafb5d89e88224b913657d1f0530))
+* getVaultItem failed for small vault items ([#45](https://github.com/archetech/archon/issues/45)) ([a6fdd52](https://github.com/archetech/archon/commit/a6fdd5233ae2013879b28252d322e392211a59c2))
+* Show failed lightning payments ([#376](https://github.com/archetech/archon/issues/376)) ([7d3b24f](https://github.com/archetech/archon/commit/7d3b24faff2cf8a1800143079a3367f2cf1e873e))
+
+
+### Features
+
+* Add ARCHON_ADMIN_API_KEY support to CLI docker container ([#128](https://github.com/archetech/archon/issues/128)) ([#131](https://github.com/archetech/archon/issues/131)) ([8526717](https://github.com/archetech/archon/commit/8526717c50b6fb71b3812fe9cd7867051d134c53))
+* Add change-registry command to change a DID's registry ([#194](https://github.com/archetech/archon/issues/194)) ([0d258de](https://github.com/archetech/archon/commit/0d258def464394a9c49b6d07f7681c35cfda5721)), closes [#153](https://github.com/archetech/archon/issues/153)
+* Add decodeLightningInvoice to Keymaster ([#146](https://github.com/archetech/archon/issues/146)) ([2ed4139](https://github.com/archetech/archon/commit/2ed4139f3ae548b21ca509877f3b05d3ce68f1b6)), closes [#145](https://github.com/archetech/archon/issues/145)
+* Add getVersion() to KeymasterClient ([#219](https://github.com/archetech/archon/issues/219)) ([f06d89c](https://github.com/archetech/archon/commit/f06d89c8047d60c00611eef4b2a577b54ca6d6a6)), closes [#205](https://github.com/archetech/archon/issues/205)
+* Add Lightning tab to web clients ([#148](https://github.com/archetech/archon/issues/148)) ([73ed52e](https://github.com/archetech/archon/commit/73ed52ea0da92b391fa53a92ba2c671f91912bbd)), closes [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147)
+* Add Lightning wallet support via LNbits integration ([#136](https://github.com/archetech/archon/issues/136)) ([#140](https://github.com/archetech/archon/issues/140)) ([4d99d5a](https://github.com/archetech/archon/commit/4d99d5ab8da20897e5aecf8557b271c3b1779d45))
+* Add Lightning Zap tab and Publish toggle to web clients ([#161](https://github.com/archetech/archon/issues/161)) ([6357451](https://github.com/archetech/archon/commit/6357451083f464120b01348c889deb5c80bed05f)), closes [#159](https://github.com/archetech/archon/issues/159)
+* Added update-credential to agent CLI ([#66](https://github.com/archetech/archon/issues/66)) ([002fce1](https://github.com/archetech/archon/commit/002fce1dcf2edb8c621eb77501cdf0abeed90484))
+* Adds CLI to keymaster package ([#39](https://github.com/archetech/archon/issues/39)) ([894ce73](https://github.com/archetech/archon/commit/894ce732f5beaca37bb90ace6b760b8e80aba3e9))
+* Adds get-property command to CLI ([#73](https://github.com/archetech/archon/issues/73)) ([310d7fe](https://github.com/archetech/archon/commit/310d7fe5d95976b8ca37ec12b7d6dc16cc52f65a))
+* Display Lightning payment history ([#164](https://github.com/archetech/archon/issues/164)) ([#165](https://github.com/archetech/archon/issues/165)) ([c8ec283](https://github.com/archetech/archon/commit/c8ec2835b0cde542c71e02fdb7fc55c3d46a81d1))
+* Lightning zap — send sats to a DID ([#155](https://github.com/archetech/archon/issues/155)) ([39d7ee3](https://github.com/archetech/archon/commit/39d7ee3242973ace494e45f636ca12fe78d911ab)), closes [#154](https://github.com/archetech/archon/issues/154)
+* move lightning payment filtering to client with full state display ([#237](https://github.com/archetech/archon/issues/237)) ([0eee4c0](https://github.com/archetech/archon/commit/0eee4c0987513d689a2a4eec3b7b088556be53b2)), closes [#236](https://github.com/archetech/archon/issues/236)
+* stream large file uploads/downloads for multi-GB video support ([#238](https://github.com/archetech/archon/issues/238)) ([eca94a0](https://github.com/archetech/archon/commit/eca94a06c041849a181a5a072728b9fe0c22bfae)), closes [#208](https://github.com/archetech/archon/issues/208)
+* Support mainnet registries ([#34](https://github.com/archetech/archon/issues/34)) ([a206c9e](https://github.com/archetech/archon/commit/a206c9e24f29fabec45f3cb239b8ba88f0525e6d))
+
+
+
+
+
 ## [0.4.7](https://github.com/archetech/archon/compare/@didcid/gatekeeper@0.2.0...@didcid/gatekeeper@0.4.7) (2026-04-06)
 
 

--- a/packages/gatekeeper/package.json
+++ b/packages/gatekeeper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/gatekeeper",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Archon Gatekeeper",
   "type": "module",
   "module": "./dist/esm/index.js",
@@ -114,9 +114,9 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/cipher": "^0.2.7",
-    "@didcid/common": "^0.1.9",
-    "@didcid/ipfs": "^0.1.9",
+    "@didcid/cipher": "^0.2.8",
+    "@didcid/common": "^0.1.10",
+    "@didcid/ipfs": "^0.1.10",
     "axios": "^1.15.0",
     "canonicalize": "^2.0.0",
     "dotenv": "^16.4.5",

--- a/packages/ipfs/CHANGELOG.md
+++ b/packages/ipfs/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.10](https://github.com/archetech/archon/compare/@didcid/ipfs@0.1.3...@didcid/ipfs@0.1.10) (2026-04-17)
+
+
+### Features
+
+* stream large file uploads/downloads for multi-GB video support ([#238](https://github.com/archetech/archon/issues/238)) ([eca94a0](https://github.com/archetech/archon/commit/eca94a06c041849a181a5a072728b9fe0c22bfae)), closes [#208](https://github.com/archetech/archon/issues/208)
+
+
+
+
+
 ## [0.1.9](https://github.com/archetech/archon/compare/@didcid/ipfs@0.1.3...@didcid/ipfs@0.1.9) (2026-04-06)
 
 

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/ipfs",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Archon IPFS lib",
   "type": "module",
   "module": "./dist/esm/index.js",
@@ -74,7 +74,7 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/common": "^0.1.9",
+    "@didcid/common": "^0.1.10",
     "@helia/json": "^4.0.3",
     "@helia/unixfs": "^5.0.0",
     "axios": "^1.15.0",

--- a/packages/keymaster/CHANGELOG.md
+++ b/packages/keymaster/CHANGELOG.md
@@ -3,6 +3,69 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.8](https://github.com/archetech/archon/compare/@didcid/keymaster@0.2.0...@didcid/keymaster@0.4.8) (2026-04-17)
+
+
+### Bug Fixes
+
+* Allow create-id to auto-create wallet ([#102](https://github.com/archetech/archon/issues/102)) ([#103](https://github.com/archetech/archon/issues/103)) ([bb6bc7a](https://github.com/archetech/archon/commit/bb6bc7a57d6bcfed679812b8489ab43ab9f10731)), closes [#53](https://github.com/archetech/archon/issues/53)
+* Better error message for missing wallet ([#53](https://github.com/archetech/archon/issues/53)) ([1a8dad0](https://github.com/archetech/archon/commit/1a8dad05a8a1eafb5d89e88224b913657d1f0530))
+* Check zap status in CLI ([#255](https://github.com/archetech/archon/issues/255)) ([634196a](https://github.com/archetech/archon/commit/634196a8e6a627bcf49b11a568be8a363eb18bc2))
+* Incorrect passphrase on react-wallet ([#97](https://github.com/archetech/archon/issues/97)) ([5ce0523](https://github.com/archetech/archon/commit/5ce05238ecb2dd6e5a4a647ab0429a9cf9bdb6a4))
+* send binary responses for image/file API routes ([#444](https://github.com/archetech/archon/issues/444)) ([3317c72](https://github.com/archetech/archon/commit/3317c7210f041fa84097a1a9efac377cb1942b00))
+* Show failed lightning payments ([#376](https://github.com/archetech/archon/issues/376)) ([7d3b24f](https://github.com/archetech/archon/commit/7d3b24faff2cf8a1800143079a3367f2cf1e873e))
+
+
+### Features
+
+* Add ARCHON_ADMIN_API_KEY support to CLI docker container ([#128](https://github.com/archetech/archon/issues/128)) ([#131](https://github.com/archetech/archon/issues/131)) ([8526717](https://github.com/archetech/archon/commit/8526717c50b6fb71b3812fe9cd7867051d134c53))
+* Add change-passphrase command ([#111](https://github.com/archetech/archon/issues/111)) ([#112](https://github.com/archetech/archon/issues/112)) ([b6b24bb](https://github.com/archetech/archon/commit/b6b24bb6c32da91edebcf85e1212420975da70ed))
+* Add change-registry command to change a DID's registry ([#194](https://github.com/archetech/archon/issues/194)) ([0d258de](https://github.com/archetech/archon/commit/0d258def464394a9c49b6d07f7681c35cfda5721)), closes [#153](https://github.com/archetech/archon/issues/153)
+* Add decodeLightningInvoice to Keymaster ([#146](https://github.com/archetech/archon/issues/146)) ([2ed4139](https://github.com/archetech/archon/commit/2ed4139f3ae548b21ca509877f3b05d3ce68f1b6)), closes [#145](https://github.com/archetech/archon/issues/145)
+* Add getVersion() to KeymasterClient ([#219](https://github.com/archetech/archon/issues/219)) ([f06d89c](https://github.com/archetech/archon/commit/f06d89c8047d60c00611eef4b2a577b54ca6d6a6)), closes [#205](https://github.com/archetech/archon/issues/205)
+* Add guided Keymaster installer ([#259](https://github.com/archetech/archon/issues/259)) ([8f139d4](https://github.com/archetech/archon/commit/8f139d4280adbe6f9575ad56f516d9814f04aea0))
+* Add keymaster address CLI commands ([#378](https://github.com/archetech/archon/issues/378)) ([35dc407](https://github.com/archetech/archon/commit/35dc407f6d6c45fd0b9293f31218667d7d212f33))
+* Add Lightning tab to web clients ([#148](https://github.com/archetech/archon/issues/148)) ([73ed52e](https://github.com/archetech/archon/commit/73ed52ea0da92b391fa53a92ba2c671f91912bbd)), closes [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147)
+* Add Lightning wallet support via LNbits integration ([#136](https://github.com/archetech/archon/issues/136)) ([#140](https://github.com/archetech/archon/issues/140)) ([4d99d5a](https://github.com/archetech/archon/commit/4d99d5ab8da20897e5aecf8557b271c3b1779d45))
+* Add nostr support ([#133](https://github.com/archetech/archon/issues/133)) ([3591d62](https://github.com/archetech/archon/commit/3591d6281bf29c5e98e761e7ad56a7abf78a4106)), closes [#87](https://github.com/archetech/archon/issues/87)
+* Add remote dmail name resolution ([#251](https://github.com/archetech/archon/issues/251)) ([157b0b0](https://github.com/archetech/archon/commit/157b0b036cf933d4385fa13007967fcc9e170f78))
+* Added update-credential to agent CLI ([#66](https://github.com/archetech/archon/issues/66)) ([002fce1](https://github.com/archetech/archon/commit/002fce1dcf2edb8c621eb77501cdf0abeed90484))
+* Adds dmail commands to agent CLI ([#67](https://github.com/archetech/archon/issues/67)) ([c5648b3](https://github.com/archetech/archon/commit/c5648b32b9c468e7dd2ead8225cbfc8ba28f929b))
+* Adds get-property command to CLI ([#73](https://github.com/archetech/archon/issues/73)) ([310d7fe](https://github.com/archetech/archon/commit/310d7fe5d95976b8ca37ec12b7d6dc16cc52f65a))
+* Adds view-credential command ([#96](https://github.com/archetech/archon/issues/96)) ([560a472](https://github.com/archetech/archon/commit/560a4727679a2b0e7154e26aef6ff3370b616d6c))
+* Adopt W3C JWE standard for encryption ([#90](https://github.com/archetech/archon/issues/90)) ([2321ca7](https://github.com/archetech/archon/commit/2321ca7fd6e074bac1f4b8fa7c12e58d4b45b181))
+* Allow any URI as credentialSubject.id per W3C VC Data Model v2 ([#92](https://github.com/archetech/archon/issues/92)) ([80d9f29](https://github.com/archetech/archon/commit/80d9f29a9653a93c19356c499512682794d270ce))
+* Display Lightning payment history ([#164](https://github.com/archetech/archon/issues/164)) ([#165](https://github.com/archetech/archon/issues/165)) ([c8ec283](https://github.com/archetech/archon/commit/c8ec2835b0cde542c71e02fdb7fc55c3d46a81d1))
+* Lightning zap — send sats to a DID ([#155](https://github.com/archetech/archon/issues/155)) ([39d7ee3](https://github.com/archetech/archon/commit/39d7ee3242973ace494e45f636ca12fe78d911ab)), closes [#154](https://github.com/archetech/archon/issues/154)
+* Refactor polls to use vault-based architecture ([#88](https://github.com/archetech/archon/issues/88)) ([#100](https://github.com/archetech/archon/issues/100)) ([8fa9eef](https://github.com/archetech/archon/commit/8fa9eef5230daf853c6f29194b72bbbec5de041a)), closes [#1](https://github.com/archetech/archon/issues/1) [#7](https://github.com/archetech/archon/issues/7) [#8](https://github.com/archetech/archon/issues/8) [#6](https://github.com/archetech/archon/issues/6) [#5](https://github.com/archetech/archon/issues/5) [#9](https://github.com/archetech/archon/issues/9)
+* Rename user-facing URL labels to Node URL ([#260](https://github.com/archetech/archon/issues/260)) ([5b5082c](https://github.com/archetech/archon/commit/5b5082cf5360edf29973e80b9e37a6190cace57a))
+* Store imported nostr nsec in wallet ([#397](https://github.com/archetech/archon/issues/397)) ([7a0a919](https://github.com/archetech/archon/commit/7a0a919f34ba9161dce25eaa528dccf3443840a4))
+* stream large file uploads/downloads for multi-GB video support ([#238](https://github.com/archetech/archon/issues/238)) ([eca94a0](https://github.com/archetech/archon/commit/eca94a06c041849a181a5a072728b9fe0c22bfae)), closes [#208](https://github.com/archetech/archon/issues/208)
+* Support LUD-16 Lightning Addresses in zapLightning ([#168](https://github.com/archetech/archon/issues/168)) ([f81457e](https://github.com/archetech/archon/commit/f81457e058c1ed99b54dafa463c48353a95d99b0)), closes [#160](https://github.com/archetech/archon/issues/160) [#160](https://github.com/archetech/archon/issues/160)
+* Update identity views across client apps ([#379](https://github.com/archetech/archon/issues/379)) ([4944281](https://github.com/archetech/archon/commit/49442810dd08a0b6e36221fbc93ccb0d89ca9f13))
+* V2 groups — promote name, add version field ([#109](https://github.com/archetech/archon/issues/109)) ([#132](https://github.com/archetech/archon/issues/132)) ([f04855d](https://github.com/archetech/archon/commit/f04855dac48a9a040c10143305029fb2d9c4c9ee))
+
+
+
+# 0.2.0 (2026-02-04)
+
+
+### Bug Fixes
+
+* Fix for duplicate credential types ([#37](https://github.com/archetech/archon/issues/37)) ([9613c46](https://github.com/archetech/archon/commit/9613c469a69b8c610df12bd64bea264a7cb6f8a9))
+* getVaultItem failed for small vault items ([#45](https://github.com/archetech/archon/issues/45)) ([a6fdd52](https://github.com/archetech/archon/commit/a6fdd5233ae2013879b28252d322e392211a59c2))
+
+
+### Features
+
+* Added import schema pack ([#29](https://github.com/archetech/archon/issues/29)) ([4af8acf](https://github.com/archetech/archon/commit/4af8acf4e9c15b36319f65f6a5b59a0c2c4bf2df))
+* Adds CLI to keymaster package ([#39](https://github.com/archetech/archon/issues/39)) ([894ce73](https://github.com/archetech/archon/commit/894ce732f5beaca37bb90ace6b760b8e80aba3e9))
+* Improve DTG credential support ([#48](https://github.com/archetech/archon/issues/48)) ([fb7e245](https://github.com/archetech/archon/commit/fb7e24538d93f36a310a36040e1608052969aba6))
+
+
+
+
+
 ## [0.4.7](https://github.com/archetech/archon/compare/@didcid/keymaster@0.2.0...@didcid/keymaster@0.4.7) (2026-04-06)
 
 

--- a/packages/keymaster/package.json
+++ b/packages/keymaster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/keymaster",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Archon Keymaster",
   "type": "module",
   "module": "./dist/esm/index.js",
@@ -141,9 +141,9 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/cipher": "^0.2.7",
-    "@didcid/common": "^0.1.9",
-    "@didcid/gatekeeper": "^0.4.7",
+    "@didcid/cipher": "^0.2.8",
+    "@didcid/common": "^0.1.10",
+    "@didcid/gatekeeper": "^0.4.8",
     "axios": "^1.15.0",
     "commander": "^11.1.0",
     "dotenv": "^16.4.5",

--- a/services/drawbridge/server/package-lock.json
+++ b/services/drawbridge/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drawbridge-server",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drawbridge-server",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",

--- a/services/drawbridge/server/package.json
+++ b/services/drawbridge/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drawbridge-server",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "Archon Drawbridge L402 API Gateway",
   "main": "dist/drawbridge-api.js",

--- a/services/explorer/package-lock.json
+++ b/services/explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "archon-explorer",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "archon-explorer",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/services/explorer/package.json
+++ b/services/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archon-explorer",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "start": "npm run build && node server.js",

--- a/services/gatekeeper/server/package-lock.json
+++ b/services/gatekeeper/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatekeeper-server",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatekeeper-server",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.6",

--- a/services/gatekeeper/server/package.json
+++ b/services/gatekeeper/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatekeeper-server",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "Archon Gatekeeper REST API server",
   "main": "src/index.js",

--- a/services/herald/server/package-lock.json
+++ b/services/herald/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "herald-server",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "herald-server",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@sendgrid/mail": "^8.1.6",

--- a/services/herald/server/package.json
+++ b/services/herald/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herald-server",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "Archon naming service",
   "main": "dist/index.js",

--- a/services/keymaster/server/package-lock.json
+++ b/services/keymaster/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "keymaster-server",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "keymaster-server",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.6",

--- a/services/keymaster/server/package.json
+++ b/services/keymaster/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymaster-server",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "Archon Keymaster REST API server",
   "main": "src/index.js",

--- a/services/mediators/hyperswarm/package-lock.json
+++ b/services/mediators/hyperswarm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hyperswarm-mediator",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hyperswarm-mediator",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.3.3",

--- a/services/mediators/hyperswarm/package.json
+++ b/services/mediators/hyperswarm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswarm-mediator",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "Archon hyperswarm network mediator",
   "main": "src/index.js",

--- a/services/mediators/lightning/package-lock.json
+++ b/services/mediators/lightning/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-mediator",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-mediator",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",

--- a/services/mediators/lightning/package.json
+++ b/services/mediators/lightning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-mediator",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "Archon Lightning mediator",
   "main": "dist/lightning-mediator.js",

--- a/services/mediators/satoshi-wallet/package-lock.json
+++ b/services/mediators/satoshi-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "satoshi-wallet",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "satoshi-wallet",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/services/mediators/satoshi-wallet/package.json
+++ b/services/mediators/satoshi-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satoshi-wallet",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "Archon Satoshi Wallet Service",
   "main": "dist/wallet-api.js",

--- a/services/mediators/satoshi/package-lock.json
+++ b/services/mediators/satoshi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "satoshi-mediator",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "satoshi-mediator",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/services/mediators/satoshi/package.json
+++ b/services/mediators/satoshi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satoshi-mediator",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "Archon satoshi blockchain mediator",
   "main": "src/index.js",

--- a/swaggerConf.js
+++ b/swaggerConf.js
@@ -5,7 +5,7 @@ const baseDefinition = {
     openapi: '3.0.0',
     info: {
         title: 'Keymaster API',
-        version: '0.5.0',
+        version: '0.8.0',
         description: 'Documentation for Keymaster API'
     },
 };


### PR DESCRIPTION
## Summary
- bump the root, app, and service package versions to `0.8.0`
- update the Swagger metadata version to `0.8.0`

## Notes
- no tests were run because these are version metadata changes
