### PR TITLE
feat(react-wallet): route challenge QR scans through deep-link flow

### DIFF
--- a/apps/react-wallet/src/components/AuthTab.tsx
+++ b/apps/react-wallet/src/components/AuthTab.tsx
@@ -9,7 +9,8 @@ import { useWalletContext } from "../contexts/WalletProvider";
 import { useSnackbar } from "../contexts/SnackbarProvider";
 import { useUIContext } from "../contexts/UIContext";
 import { useVariablesContext } from "../contexts/VariablesProvider";
-import { scanQrCode } from "../utils/utils";
+import { scanQrCodeRaw } from "../utils/utils";
+import { dispatchDeepLink } from "../utils/deepLinkQueue";
 
 interface AutoLoginState {
     responseDID: string;
@@ -274,13 +275,13 @@ function AuthTab() {
     }
 
     async function scanChallengeQR() {
-        const qr = await scanQrCode();
+        const qr = await scanQrCodeRaw();
         if (!qr) {
             setError("Failed to scan QR code");
             return;
         }
 
-        setChallenge(qr);
+        dispatchDeepLink(qr);
     }
 
     return (

--- a/apps/react-wallet/src/main.tsx
+++ b/apps/react-wallet/src/main.tsx
@@ -5,7 +5,7 @@ import { ContextProviders } from "./contexts/ContextProviders";
 import "./extension.css";
 import "./utils/polyfills";
 import { App } from '@capacitor/app';
-import { queueDeepLink } from './utils/deepLinkQueue';
+import { dispatchDeepLink } from './utils/deepLinkQueue';
 import { BarcodeScanner } from '@capacitor-mlkit/barcode-scanning';
 import { Capacitor } from '@capacitor/core';
 
@@ -51,11 +51,6 @@ function getPendingWalletAction(): PendingWalletAction | null {
     }
 
     return null;
-}
-
-function queueAndDispatch(url: string) {
-    queueDeepLink(url);
-    window.dispatchEvent(new Event('archon:deepLinkQueued'));
 }
 
 function isMobileBrowser() {
@@ -155,7 +150,7 @@ async function handleWalletUrl(): Promise<WalletUrlResult> {
 
         fallbackTimer = window.setTimeout(() => {
             if (document.visibilityState === 'visible') {
-                queueAndDispatch(action.deepLinkUrl);
+                dispatchDeepLink(action.deepLinkUrl);
             }
             cleanup();
         }, 1200);
@@ -171,18 +166,18 @@ async function handleWalletUrl(): Promise<WalletUrlResult> {
         return { status: 'fallback', action };
     }
 
-    queueAndDispatch(action.deepLinkUrl);
+    dispatchDeepLink(action.deepLinkUrl);
     return { status: 'fallback', action };
 }
 
 App.addListener('appUrlOpen', ({ url }) => {
-    queueAndDispatch(url);
+    dispatchDeepLink(url);
 });
 
 (async () => {
     const launch = await App.getLaunchUrl();
     if (launch?.url) {
-        queueAndDispatch(launch.url);
+        dispatchDeepLink(launch.url);
     }
 })();
 
@@ -206,7 +201,7 @@ const BrowserUI = () => {
 
     if (handoffResult.status === 'extension-handoff') {
         const openWebWallet = () => {
-            queueAndDispatch(handoffResult.action.deepLinkUrl);
+            dispatchDeepLink(handoffResult.action.deepLinkUrl);
             setHandoffResult({ status: 'fallback', action: handoffResult.action });
         };
 

--- a/apps/react-wallet/src/utils/deepLinkQueue.ts
+++ b/apps/react-wallet/src/utils/deepLinkQueue.ts
@@ -9,3 +9,8 @@ export function takeDeepLink(): string | null {
     pendingUrl = null;
     return url;
 }
+
+export function dispatchDeepLink(url: string) {
+    queueDeepLink(url);
+    window.dispatchEvent(new Event('archon:deepLinkQueued'));
+}

--- a/apps/react-wallet/src/utils/utils.ts
+++ b/apps/react-wallet/src/utils/utils.ts
@@ -125,6 +125,29 @@ export async function scanQrCode() {
     return null;
 }
 
+export async function scanQrCodeRaw(): Promise<string | null> {
+    try {
+        const perm = await BarcodeScanner.requestPermissions();
+        if (perm.camera !== 'granted') {
+            return null;
+        }
+
+        const ready = await ensureGoogleModuleReady();
+        if (!ready) {
+            return null;
+        }
+
+        const { barcodes } = await BarcodeScanner.scan();
+
+        for (const b of barcodes) {
+            if (extractDid(b.rawValue)) {
+                return b.rawValue;
+            }
+        }
+    } catch {}
+    return null;
+}
+
 export async function scanAliasQrCode(): Promise<{ alias: string; did: string } | null> {
     try {
         const perm = await BarcodeScanner.requestPermissions();


### PR DESCRIPTION
## Summary
- Scanning an auth-challenge QR code now dispatches the raw value through the same deep-link handler used for `archon://` links, triggering the 1-click login workflow.
- Adds `dispatchDeepLink` helper (queue + dispatch) and a `scanQrCodeRaw` variant that returns the raw barcode value.
- `AuthTab.scanChallengeQR` no longer drops the DID into the form — it hands the raw scan to the deep-link pipeline so `archon://auth?challenge=...`, plain DIDs, and https challenge URLs all flow through one handler.

## Test plan
- [x] Scan an `archon://auth?challenge=did:...` QR in the Android app → auto-login panel appears
- [x] Scan a plain `did:...` QR → auto-login panel appears
- [ ] Scan an unrelated QR → "Failed to scan QR code" error
- [ ] Tapping an `archon://auth?challenge=...` link still triggers the same flow (regression check on `dispatchDeepLink` refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)