### PR TITLE
chore: update cln image

### DIFF
--- a/docker-compose.lightning.yml
+++ b/docker-compose.lightning.yml
@@ -1,6 +1,6 @@
 services:
   cln-mainnet-node:
-    image: ghcr.io/archetech/cl-hive-node:${ARCHON_CLN_VERSION:-3.1.0}
+    image: ghcr.io/lightning-goats/cl-hive-node:${ARCHON_CLN_VERSION:-3.4.0}
     environment:
       - NETWORK=bitcoin
       - ALIAS=${ARCHON_CLN_ALIAS:-archon}


### PR DESCRIPTION
## Summary
- switch the Lightning CLN node image to ghcr.io/lightning-goats/cl-hive-node
- update the default ARCHON_CLN_VERSION from 3.1.0 to 3.4.0

## Validation
- docker compose -f docker-compose.lightning.yml config