### PR TITLE
chore: Remove LNbits restart policy

### DIFF
--- a/docker-compose.lightning.yml
+++ b/docker-compose.lightning.yml
@@ -219,4 +219,3 @@ services:
         condition: service_completed_successfully
       cln-mainnet-node:
         condition: service_started
-    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Remove the explicit `restart: unless-stopped` policy from the `lnbits` service in the Lightning compose stack.
- Keep LNbits startup behavior consistent with the other long-running Lightning services, while preserving `restart: "no"` on one-shot init jobs.

## Validation
- `docker compose -f docker-compose.lightning.yml config`
