### PR TITLE
chore: Add npm supply-chain protections (min release age, dep-review)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,10 +39,12 @@ updates:
       - "/services/mediators/satoshi"
       - "/services/satoshi-wallet/server"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
       day: "monday"
       time: "05:00"
       timezone: "America/Toronto"
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 1
     labels:
       - "dependencies"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Review dependency changes
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
         with:
-          fail-on-severity: high
+          fail-on-severity: moderate

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ dids.db-journal
 
 
 **/.npmrc
+!/.npmrc
 rust/services/gatekeeper/target/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=4320


### PR DESCRIPTION
## Summary

Defense against Shai-Hulud-class worm attacks. The recent Mini Shai-Hulud waves (TanStack, @uipath, @mistralai, @cap-js, etc.) were all caught and unpublished within hours of going live — so the most effective single mitigation is to refuse package versions younger than a few days.

- **`.npmrc`** — adds `minimum-release-age=4320` (72 hours). npm 11.5.1+ refuses to install any version published in the last 3 days.
- **`.gitignore`** — adds `!/.npmrc` exception so the root policy file is tracked, while still ignoring child `.npmrc` files in subdirs that may contain auth tokens.
- **`dependabot.yml`** — npm interval `monthly` → `weekly`, plus `cooldown.default-days: 3` so Dependabot itself won't open PRs for versions younger than 3 days.
- **`dependency-review.yml`** — `fail-on-severity: high` → `moderate`.

**Not included:** `ignore-scripts=true`. Several workspaces have native modules, so flipping this globally would break installs. Worth revisiting later as a per-package allowlist.

## Heads up

`minimum-release-age` requires npm 11.5.1+. Confirm CI runners and local devs are on at least that version, otherwise the setting is silently ignored (`npm --version`).

## Test plan

- [ ] Confirm CI runners are on npm ≥ 11.5.1 (otherwise the .npmrc setting is silently no-op)
- [ ] Run `npm install` locally on a clean checkout and confirm it succeeds
- [ ] Verify `dependency-review` workflow still runs green on this PR
- [ ] Wait one Dependabot cycle and confirm grouped PRs respect the 3-day cooldown

🤖 Generated with [Claude Code](https://claude.com/claude-code)