### PR TITLE
chore: init v0.9.0

### DIFF
--- a/apps/browser-extension/package-lock.json
+++ b/apps/browser-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "archon-browser-extension",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "archon-browser-extension",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "qrcode.react": "^4.2.0"

--- a/apps/browser-extension/package.json
+++ b/apps/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archon-browser-extension",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Archon Browser Extension",
   "main": "index.js",
   "scripts": {

--- a/apps/browser-extension/src/static/manifest.firefox.json
+++ b/apps/browser-extension/src/static/manifest.firefox.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Archon Wallet",
     "description": "Archon Wallet",
-    "version": "0.5.0",
+    "version": "0.9.0",
     "icons": {
         "16": "icon.png",
         "48": "icon.png",

--- a/apps/browser-extension/src/static/manifest.json
+++ b/apps/browser-extension/src/static/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Archon Wallet",
     "description": "Archon Wallet",
-    "version": "0.6.0",
+    "version": "0.9.0",
     "icons": {
         "16": "icon.png",
         "48": "icon.png",

--- a/apps/gatekeeper-client/package-lock.json
+++ b/apps/gatekeeper-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatekeeper-client",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatekeeper-client",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/apps/gatekeeper-client/package.json
+++ b/apps/gatekeeper-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatekeeper-client",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/herald-client/package-lock.json
+++ b/apps/herald-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-client",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-client",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.14.1",

--- a/apps/herald-client/package.json
+++ b/apps/herald-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-client",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/keymaster-client/package-lock.json
+++ b/apps/keymaster-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "keymaster-client",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "keymaster-client",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/apps/keymaster-client/package.json
+++ b/apps/keymaster-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymaster-client",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/react-wallet/package-lock.json
+++ b/apps/react-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@didcid/react-wallet",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@didcid/react-wallet",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor-mlkit/barcode-scanning": "^7.3.0",

--- a/apps/react-wallet/package.json
+++ b/apps/react-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/react-wallet",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Archon Android Demo",
   "scripts": {
     "dev": "vite",

--- a/docs/gatekeeper-api.json
+++ b/docs/gatekeeper-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Gatekeeper API",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "description": "Documentation for Keymaster API"
   },
   "paths": {

--- a/docs/keymaster-api.json
+++ b/docs/keymaster-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Keymaster API",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "description": "Documentation for Keymaster API"
   },
   "paths": {

--- a/services/drawbridge/server/package-lock.json
+++ b/services/drawbridge/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drawbridge-server",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drawbridge-server",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",

--- a/services/drawbridge/server/package.json
+++ b/services/drawbridge/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drawbridge-server",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "description": "Archon Drawbridge L402 API Gateway",
   "main": "dist/drawbridge-api.js",

--- a/services/explorer/package-lock.json
+++ b/services/explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "archon-explorer",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "archon-explorer",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/services/explorer/package.json
+++ b/services/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archon-explorer",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "start": "npm run build && node server.js",

--- a/services/gatekeeper/server/package-lock.json
+++ b/services/gatekeeper/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatekeeper-server",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatekeeper-server",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.6",

--- a/services/gatekeeper/server/package.json
+++ b/services/gatekeeper/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatekeeper-server",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "description": "Archon Gatekeeper REST API server",
   "main": "src/index.js",

--- a/services/herald/package-lock.json
+++ b/services/herald/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "herald",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "herald",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "dependencies": {
         "jose": "^6.2.1"

--- a/services/herald/package.json
+++ b/services/herald/package.json
@@ -1,5 +1,6 @@
 {
   "name": "herald",
+  "version": "0.9.0",
   "private": true,
   "scripts": {
     "install": "npm install --prefix server",

--- a/services/herald/server/package-lock.json
+++ b/services/herald/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "herald-server",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "herald-server",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@sendgrid/mail": "^8.1.6",

--- a/services/herald/server/package.json
+++ b/services/herald/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herald-server",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "description": "Archon naming service",
   "main": "dist/index.js",

--- a/services/keymaster/server/package-lock.json
+++ b/services/keymaster/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "keymaster-server",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "keymaster-server",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.6",

--- a/services/keymaster/server/package.json
+++ b/services/keymaster/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymaster-server",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "description": "Archon Keymaster REST API server",
   "main": "src/index.js",

--- a/services/mediators/hyperswarm/package-lock.json
+++ b/services/mediators/hyperswarm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hyperswarm-mediator",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hyperswarm-mediator",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.3.3",

--- a/services/mediators/hyperswarm/package.json
+++ b/services/mediators/hyperswarm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswarm-mediator",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "description": "Archon hyperswarm network mediator",
   "main": "src/index.js",

--- a/services/mediators/lightning/package-lock.json
+++ b/services/mediators/lightning/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-mediator",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-mediator",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.2",

--- a/services/mediators/lightning/package.json
+++ b/services/mediators/lightning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-mediator",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "description": "Archon Lightning mediator",
   "main": "dist/lightning-mediator.js",

--- a/services/mediators/satoshi-wallet/package-lock.json
+++ b/services/mediators/satoshi-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "satoshi-wallet",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "satoshi-wallet",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/services/mediators/satoshi-wallet/package.json
+++ b/services/mediators/satoshi-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satoshi-wallet",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "description": "Archon Satoshi Wallet Service",
   "main": "dist/wallet-api.js",

--- a/services/mediators/satoshi/package-lock.json
+++ b/services/mediators/satoshi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "satoshi-mediator",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "satoshi-mediator",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/services/mediators/satoshi/package.json
+++ b/services/mediators/satoshi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satoshi-mediator",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "description": "Archon satoshi blockchain mediator",
   "main": "src/index.js",

--- a/services/mediators/zcash-wallet/package-lock.json
+++ b/services/mediators/zcash-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zcash-wallet",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zcash-wallet",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@bitgo/utxo-lib": "^11.22.1",

--- a/services/mediators/zcash-wallet/package.json
+++ b/services/mediators/zcash-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcash-wallet",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "description": "Archon Zcash Transparent Wallet Service",
   "main": "dist/wallet-api.js",

--- a/services/mediators/zcash/package-lock.json
+++ b/services/mediators/zcash/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zcash-mediator",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zcash-mediator",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/services/mediators/zcash/package.json
+++ b/services/mediators/zcash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcash-mediator",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "description": "Archon Zcash blockchain mediator",
   "main": "dist/zcash-mediator.js",

--- a/swaggerConf.js
+++ b/swaggerConf.js
@@ -5,7 +5,7 @@ const baseDefinition = {
     openapi: '3.0.0',
     info: {
         title: 'Keymaster API',
-        version: '0.8.0',
+        version: '0.9.0',
         description: 'Documentation for Keymaster API'
     },
 };
@@ -38,4 +38,3 @@ const gatekeeperSpec = swaggerJsdoc(gatekeeperOptions);
 const keymasterSpec = swaggerJsdoc(keymasterOptions);
 fs.writeFileSync('docs/gatekeeper-api.json', JSON.stringify(gatekeeperSpec, null, 2));
 fs.writeFileSync('docs/keymaster-api.json', JSON.stringify(keymasterSpec, null, 2));
-


### PR DESCRIPTION
## Summary

- Bump app and service package versions to 0.9.0.
- Update matching app/service package-lock root versions.
- Align browser extension Chrome and Firefox source manifest versions with 0.9.0.

## Validation

- Verified 34 app/service package and lock files plus 2 extension manifests report 0.9.0.
- Ran git diff --check.
