### PR TITLE
fix: address tests leaking relay discovery to network

### DIFF
--- a/tests/keymaster/address.test.ts
+++ b/tests/keymaster/address.test.ts
@@ -232,7 +232,9 @@ describe('addAddress', () => {
         jest.spyOn(keymaster, 'createResponse').mockResolvedValue('did:cid:response');
         jest.spyOn(globalThis, 'fetch')
             .mockResolvedValueOnce(mockFetchResponse(true, { challenge: 'did:cid:challenge' }))
-            .mockResolvedValueOnce(mockFetchResponse(true, { ok: true, name: 'alice' }));
+            .mockResolvedValueOnce(mockFetchResponse(true, { ok: true, name: 'alice' }))
+            .mockResolvedValueOnce(mockFetchResponse(false, { error: 'not found' }, 404))
+            .mockResolvedValueOnce(mockFetchResponse(false, { error: 'not found' }, 404));
 
         const ok = await keymaster.addAddress('alice@archon.social');
         const addresses = await keymaster.listAddresses();
@@ -307,7 +309,8 @@ describe('addAddress', () => {
         jest.spyOn(globalThis, 'fetch')
             .mockResolvedValueOnce(mockFetchResponse(true, { challenge: 'did:cid:challenge' }))
             .mockResolvedValueOnce(mockFetchResponse(true, { ok: true, name: 'alice' }))
-            .mockResolvedValueOnce(mockFetchResponse(true, { serviceDID }));
+            .mockResolvedValueOnce(mockFetchResponse(true, { serviceDID }))
+            .mockResolvedValueOnce(mockFetchResponse(false, { error: 'not found' }, 404));
 
         const ok = await keymaster.addAddress('alice@archon.social');
         const addresses = await keymaster.listAddresses();
@@ -334,7 +337,9 @@ describe('addAddress', () => {
             .mockResolvedValueOnce(mockFetchResponse(false, { error: 'not found' }, 404))
             .mockResolvedValueOnce(mockFetchResponse(true, { challenge: 'did:cid:challenge' }))
             .mockResolvedValueOnce(mockFetchResponse(false, { error: 'not found' }, 404))
-            .mockResolvedValueOnce(mockFetchResponse(true, { ok: true, name: 'alice' }));
+            .mockResolvedValueOnce(mockFetchResponse(true, { ok: true, name: 'alice' }))
+            .mockResolvedValueOnce(mockFetchResponse(false, { error: 'not found' }, 404))
+            .mockResolvedValueOnce(mockFetchResponse(false, { error: 'not found' }, 404));
 
         const ok = await keymaster.addAddress('alice@archon.social');
         const addresses = await keymaster.listAddresses();
@@ -369,7 +374,9 @@ describe('addAddress', () => {
             .mockResolvedValueOnce(mockFetchResponse(true, '<html>Name Service</html>', 200, 'text/html; charset=utf-8'))
             .mockResolvedValueOnce(mockFetchResponse(true, { challenge: 'did:cid:challenge' }))
             .mockResolvedValueOnce(mockFetchResponse(false, { error: 'not found' }, 404))
-            .mockResolvedValueOnce(mockFetchResponse(true, { ok: true, name: 'alice' }));
+            .mockResolvedValueOnce(mockFetchResponse(true, { ok: true, name: 'alice' }))
+            .mockResolvedValueOnce(mockFetchResponse(false, { error: 'not found' }, 404))
+            .mockResolvedValueOnce(mockFetchResponse(false, { error: 'not found' }, 404));
 
         const ok = await keymaster.addAddress('alice@archon.social');
         const addresses = await keymaster.listAddresses();


### PR DESCRIPTION
## Summary
- mock optional Herald relay discovery /config lookups in addAddress tests that expect no relay
- keep address tests independent from the current live response at archon.social

## Why main broke
The merged code matched the PR head, but these tests had finite fetch mocks. After the expected challenge/name calls were consumed, Keymaster's relay-discovery lookup fell through to real fetch. The live archon.social /api/config endpoint now advertises a relay agent, so tests that expected addresses without relay metadata started failing on main.

## Validation
- node --experimental-vm-modules node_modules/.bin/jest tests/keymaster/address.test.ts --runInBand --verbose