### PR TITLE
fix: Clarify Solana slot metrics

### DIFF
--- a/docs/services/mediators/solana/README.md
+++ b/docs/services/mediators/solana/README.md
@@ -11,6 +11,12 @@ The memo payload intentionally does not validate Archon DID semantics. Gatekeepe
 
 Each import cycle also syncs finalized Solana block checkpoints into Gatekeeper for every produced block whose block height is at least `ARCHON_SOL_START_BLOCK` and divisible by 100. The mediator uses Solana slots as an internal scan cursor, but Gatekeeper block records and DID registration metadata use produced block heights so independent nodes can derive the same lower-bound timestamps.
 
+Mediator metrics distinguish slot scan state from produced block heights:
+
+- `solana_slot_cursor`, `solana_current_slot`, `solana_slot_lag`, and `solana_slots_scanned` describe slot-based import scanning.
+- `solana_checkpoint_block_height` and `solana_current_block_height` describe produced block heights.
+- The older `solana_block_height`, `solana_block_count`, `solana_blocks_pending`, and `solana_blocks_scanned` names remain as compatibility aliases for the slot metrics.
+
 ## Canonical memo format
 
 The Solana registries use the Solana Memo program with an Archon-specific payload prefix:

--- a/observability/grafana/provisioning/dashboards/solana-mediator-devnet.json
+++ b/observability/grafana/provisioning/dashboards/solana-mediator-devnet.json
@@ -191,7 +191,7 @@
       "pluginVersion": "10.0.0",
       "targets": [
         {
-          "expr": "solana_block_height{job=\"sol-devnet-mediator\"}",
+          "expr": "solana_slot_cursor{job=\"sol-devnet-mediator\"}",
           "legendFormat": "Slot Cursor",
           "refId": "A"
         }
@@ -207,23 +207,16 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "fixed",
+            "fixedColor": "blue"
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "blue",
                 "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 100
-              },
-              {
-                "color": "red",
-                "value": 1000
               }
             ]
           },
@@ -256,12 +249,12 @@
       "pluginVersion": "10.0.0",
       "targets": [
         {
-          "expr": "solana_blocks_pending{job=\"sol-devnet-mediator\"}",
-          "legendFormat": "Slot Lag",
+          "expr": "solana_slot_lag{job=\"sol-devnet-mediator\"}",
+          "legendFormat": "Current Slot - Cursor",
           "refId": "A"
         }
       ],
-      "title": "Slot Lag",
+      "title": "Slot Gap",
       "type": "stat"
     },
     {
@@ -340,7 +333,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 4
       },
@@ -362,17 +355,112 @@
       "pluginVersion": "10.0.0",
       "targets": [
         {
-          "expr": "solana_block_height{job=\"sol-devnet-mediator\"}",
+          "expr": "solana_slot_cursor{job=\"sol-devnet-mediator\"}",
           "legendFormat": "Slot Cursor",
           "refId": "A"
         },
         {
-          "expr": "solana_block_count{job=\"sol-devnet-mediator\"}",
+          "expr": "solana_current_slot{job=\"sol-devnet-mediator\"}",
           "legendFormat": "Current Slot",
           "refId": "B"
         }
       ],
       "title": "Slot Scan Progress",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 4
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "solana_checkpoint_block_height{job=\"sol-devnet-mediator\"}",
+          "legendFormat": "Checkpoint Block Height",
+          "refId": "A"
+        },
+        {
+          "expr": "solana_current_block_height{job=\"sol-devnet-mediator\"}",
+          "legendFormat": "Current Block Height",
+          "refId": "B"
+        }
+      ],
+      "title": "Produced Block Heights",
       "type": "timeseries"
     },
     {
@@ -434,8 +522,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 16,
         "y": 4
       },
       "id": 6,

--- a/observability/grafana/provisioning/dashboards/solana-mediator-mainnet.json
+++ b/observability/grafana/provisioning/dashboards/solana-mediator-mainnet.json
@@ -191,7 +191,7 @@
       "pluginVersion": "10.0.0",
       "targets": [
         {
-          "expr": "solana_block_height{job=\"sol-mainnet-mediator\"}",
+          "expr": "solana_slot_cursor{job=\"sol-mainnet-mediator\"}",
           "legendFormat": "Slot Cursor",
           "refId": "A"
         }
@@ -207,23 +207,16 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "fixed",
+            "fixedColor": "blue"
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "blue",
                 "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 100
-              },
-              {
-                "color": "red",
-                "value": 1000
               }
             ]
           },
@@ -256,12 +249,12 @@
       "pluginVersion": "10.0.0",
       "targets": [
         {
-          "expr": "solana_blocks_pending{job=\"sol-mainnet-mediator\"}",
-          "legendFormat": "Slot Lag",
+          "expr": "solana_slot_lag{job=\"sol-mainnet-mediator\"}",
+          "legendFormat": "Current Slot - Cursor",
           "refId": "A"
         }
       ],
-      "title": "Slot Lag",
+      "title": "Slot Gap",
       "type": "stat"
     },
     {
@@ -340,7 +333,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 4
       },
@@ -362,17 +355,112 @@
       "pluginVersion": "10.0.0",
       "targets": [
         {
-          "expr": "solana_block_height{job=\"sol-mainnet-mediator\"}",
+          "expr": "solana_slot_cursor{job=\"sol-mainnet-mediator\"}",
           "legendFormat": "Slot Cursor",
           "refId": "A"
         },
         {
-          "expr": "solana_block_count{job=\"sol-mainnet-mediator\"}",
+          "expr": "solana_current_slot{job=\"sol-mainnet-mediator\"}",
           "legendFormat": "Current Slot",
           "refId": "B"
         }
       ],
       "title": "Slot Scan Progress",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 4
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "solana_checkpoint_block_height{job=\"sol-mainnet-mediator\"}",
+          "legendFormat": "Checkpoint Block Height",
+          "refId": "A"
+        },
+        {
+          "expr": "solana_current_block_height{job=\"sol-mainnet-mediator\"}",
+          "legendFormat": "Current Block Height",
+          "refId": "B"
+        }
+      ],
+      "title": "Produced Block Heights",
       "type": "timeseries"
     },
     {
@@ -434,8 +522,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 16,
         "y": 4
       },
       "id": 6,

--- a/services/mediators/solana/README.md
+++ b/services/mediators/solana/README.md
@@ -11,6 +11,12 @@ The memo payload intentionally does not validate Archon DID semantics. Gatekeepe
 
 Each import cycle also syncs finalized Solana block checkpoints into Gatekeeper for every produced block whose block height is divisible by 100. The mediator uses Solana slots as an internal scan cursor, but Gatekeeper block records and DID registration metadata use produced block heights so independent nodes can derive the same lower-bound timestamps.
 
+Mediator metrics distinguish slot scan state from produced block heights:
+
+- `solana_slot_cursor`, `solana_current_slot`, `solana_slot_lag`, and `solana_slots_scanned` describe slot-based import scanning.
+- `solana_checkpoint_block_height` and `solana_current_block_height` describe produced block heights.
+- The older `solana_block_height`, `solana_block_count`, `solana_blocks_pending`, and `solana_blocks_scanned` names remain as compatibility aliases for the slot metrics.
+
 ## Canonical memo format
 
 The Solana registries use the Solana Memo program with an Archon-specific payload prefix:

--- a/services/mediators/solana/src/solana-mediator.ts
+++ b/services/mediators/solana/src/solana-mediator.ts
@@ -555,9 +555,12 @@ async function syncBlockCheckpoints(): Promise<void> {
             }
         }
 
+        const checkpointSlot = processedThroughSlot;
+        const checkpointHeight = maxCheckpointHeight;
+
         await jsonPersister.updateDb((db) => {
-            db.checkpointSlot = processedThroughSlot;
-            db.checkpointHeight = Math.max(db.checkpointHeight ?? 0, maxCheckpointHeight);
+            db.checkpointSlot = checkpointSlot;
+            db.checkpointHeight = Math.max(db.checkpointHeight ?? 0, checkpointHeight);
             db.currentBlockHeight = currentBlockHeight;
         });
 

--- a/services/mediators/solana/src/solana-mediator.ts
+++ b/services/mediators/solana/src/solana-mediator.ts
@@ -120,22 +120,52 @@ promClient.collectDefaultMetrics({ register });
 
 const solanaBlockHeight = new promClient.Gauge({
     name: 'solana_block_height',
-    help: 'Current scanned slot height',
+    help: 'Deprecated alias for solana_slot_cursor; current scanned Solana slot',
 });
 
 const solanaBlockCount = new promClient.Gauge({
     name: 'solana_block_count',
-    help: 'Total Solana slot height',
+    help: 'Deprecated alias for solana_current_slot; current Solana slot',
 });
 
 const solanaBlocksPending = new promClient.Gauge({
     name: 'solana_blocks_pending',
-    help: 'Remaining slots to scan',
+    help: 'Deprecated alias for solana_slot_lag; current slot minus scanned Solana slot cursor',
 });
 
 const solanaBlocksScanned = new promClient.Gauge({
     name: 'solana_blocks_scanned',
-    help: 'Total slots scanned',
+    help: 'Deprecated alias for solana_slots_scanned; total Solana slots covered by the scan cursor',
+});
+
+const solanaSlotCursor = new promClient.Gauge({
+    name: 'solana_slot_cursor',
+    help: 'Current scanned Solana slot cursor',
+});
+
+const solanaCurrentSlot = new promClient.Gauge({
+    name: 'solana_current_slot',
+    help: 'Current Solana slot reported by the configured RPC commitment',
+});
+
+const solanaSlotLag = new promClient.Gauge({
+    name: 'solana_slot_lag',
+    help: 'Current Solana slot minus scanned slot cursor; can grow between registry memo anchors',
+});
+
+const solanaSlotsScanned = new promClient.Gauge({
+    name: 'solana_slots_scanned',
+    help: 'Total Solana slots covered by the scan cursor',
+});
+
+const solanaCheckpointBlockHeight = new promClient.Gauge({
+    name: 'solana_checkpoint_block_height',
+    help: 'Latest produced Solana block height checkpoint synced to Gatekeeper',
+});
+
+const solanaCurrentBlockHeight = new promClient.Gauge({
+    name: 'solana_current_block_height',
+    help: 'Current produced Solana block height reported by the configured RPC commitment',
 });
 
 const solanaTxnsScanned = new promClient.Gauge({
@@ -213,6 +243,12 @@ async function updateGauges(): Promise<void> {
     solanaBlockCount.set(db.blockCount);
     solanaBlocksPending.set(db.blocksPending);
     solanaBlocksScanned.set(db.blocksScanned);
+    solanaSlotCursor.set(db.height);
+    solanaCurrentSlot.set(db.blockCount);
+    solanaSlotLag.set(db.blocksPending);
+    solanaSlotsScanned.set(db.blocksScanned);
+    solanaCheckpointBlockHeight.set(db.checkpointHeight ?? 0);
+    solanaCurrentBlockHeight.set(db.currentBlockHeight ?? 0);
     solanaTxnsScanned.set(db.txnsScanned);
     solanaDidsDiscovered.set(db.discovered.length);
     solanaDidsRegistered.set(db.registered.length);
@@ -522,6 +558,7 @@ async function syncBlockCheckpoints(): Promise<void> {
         await jsonPersister.updateDb((db) => {
             db.checkpointSlot = processedThroughSlot;
             db.checkpointHeight = Math.max(db.checkpointHeight ?? 0, maxCheckpointHeight);
+            db.currentBlockHeight = currentBlockHeight;
         });
 
         startSlot = processedThroughSlot + 1;
@@ -584,6 +621,11 @@ async function scanSignatures(): Promise<void> {
     console.log(`current slot height: ${currentSlot}, current block height: ${currentBlockHeight}, scan floor: ${scanFloor}, start block: ${config.startBlock}`);
 
     if (config.startBlock > currentBlockHeight) {
+        await jsonPersister.updateDb((db) => {
+            db.blockCount = currentSlot;
+            db.blocksPending = Math.max(0, currentSlot - db.height);
+            db.currentBlockHeight = currentBlockHeight;
+        });
         console.log(`Skipping ${REGISTRY} scan because start block ${config.startBlock} is ahead of current block height ${currentBlockHeight}`);
         return;
     }
@@ -695,6 +737,7 @@ async function scanSignatures(): Promise<void> {
         db.txnsScanned += scanned;
         db.blockCount = currentSlot;
         db.blocksPending = Math.max(0, currentSlot - db.height);
+        db.currentBlockHeight = currentBlockHeight;
     });
 
     if (maxSlot > 0) {

--- a/services/mediators/solana/src/types.ts
+++ b/services/mediators/solana/src/types.ts
@@ -30,6 +30,7 @@ export interface MediatorDb {
     blocksScanned: number;
     blocksPending: number;
     txnsScanned: number;
+    currentBlockHeight?: number;
     checkpointSlot?: number;
     checkpointHeight?: number;
     registered: RegisteredItem[];


### PR DESCRIPTION
## Summary

- add explicit Solana slot metrics (`solana_slot_cursor`, `solana_current_slot`, `solana_slot_lag`, `solana_slots_scanned`) while keeping the old block-named metrics as compatibility aliases
- add produced block-height metrics for current RPC block height and Gatekeeper checkpoint height
- update Solana mainnet/devnet Grafana dashboards and mediator docs so slot panels no longer look like block backlogs

## Root Cause

Solana scan state is slot-based, but the mediator exposed and graphed it with block-oriented metric names. That made `solana_blocks_pending` look like a normal block catch-up backlog even though it is really current slot minus the latest scanned registry memo slot, which can grow between anchors.

## Validation

- `npm --prefix services/mediators/solana run build`
- parsed Solana Grafana dashboards and confirmed no old block-oriented query names remain
- `docker compose --profile observability config --quiet`
- `git diff --check`

Fixes #572
