### PR TITLE
fix: Bind bundled Tor SOCKS port to localhost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ These rules apply to coding agents working in this repository.
 - For GitHub operations in this repo, use `gh` by default, especially for write actions and PR creation. Do not try the GitHub app first and then fall back to `gh` unless the user explicitly asks for the app or `gh` cannot perform the operation.
 - When generating or updating npm lockfiles, use the repo-pinned npm version from the root `package.json` so lockfiles stay compatible with CI.
 - Internal service-to-service admin auth should use `X-Archon-Admin-Key` consistently. Reserve `Authorization` for user/session/OAuth-style flows unless a file explicitly documents a different scheme.
+- Drawbridge's bundled Tor SOCKS host port should default to `127.0.0.1:9050`; internal services should keep using the Docker network address `tor:9050`.
 - For Herald agent guidance, prefer Keymaster address commands (`check-address`, `add-address`, `remove-address`, etc.) in quick starts while keeping direct API endpoint documentation available for lower-level integrations.
 - Keymaster address metadata should stay in parity across TypeScript and Python implementations; when Herald exposes a domain relay agent, store it with the address as `relay` and surface it through list/get address APIs.
 - Keymaster CLI command additions should keep `scripts/archon-cli.js`, `packages/keymaster/src/cli.ts`, and `python/keymaster/src/keymaster/cli.py` in parity; commands that only query Gatekeeper, such as registry listing, should not require an existing local wallet.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ These rules apply to coding agents working in this repository.
 - When generating or updating npm lockfiles, use the repo-pinned npm version from the root `package.json` so lockfiles stay compatible with CI.
 - Internal service-to-service admin auth should use `X-Archon-Admin-Key` consistently. Reserve `Authorization` for user/session/OAuth-style flows unless a file explicitly documents a different scheme.
 - Drawbridge's bundled Tor SOCKS host port should default to `127.0.0.1:9050`; internal services should keep using the Docker network address `tor:9050`.
+- Keymaster's Docker host port should default to localhost via `ARCHON_KEYMASTER_HOST_BIND=127.0.0.1`; internal services should keep using `keymaster:4226`.
 - For Herald agent guidance, prefer Keymaster address commands (`check-address`, `add-address`, `remove-address`, etc.) in quick starts while keeping direct API endpoint documentation available for lower-level integrations.
 - Keymaster address metadata should stay in parity across TypeScript and Python implementations; when Herald exposes a domain relay agent, store it with the address as `relay` and surface it through list/get address APIs.
 - Keymaster CLI command additions should keep `scripts/archon-cli.js`, `packages/keymaster/src/cli.ts`, and `python/keymaster/src/keymaster/cli.py` in parity; commands that only query Gatekeeper, such as registry listing, should not require an existing local wallet.

--- a/docker/compose/drawbridge.yml
+++ b/docker/compose/drawbridge.yml
@@ -189,7 +189,7 @@ services:
     profiles: ["drawbridge"]
     image: goldy/tor-hidden-service:latest
     ports:
-      - "${ARCHON_TOR_SOCKS_PORT:-9050}:9050"
+      - "${ARCHON_TOR_SOCKS_PORT:-127.0.0.1:9050}:9050"
     environment:
       DRAWBRIDGE_TOR_SERVICE_HOSTS: '4222:drawbridge:4222'
       DRAWBRIDGE_TOR_SERVICE_VERSION: '3'

--- a/docker/compose/keymaster-py.yml
+++ b/docker/compose/keymaster-py.yml
@@ -28,7 +28,7 @@ services:
       - ../../data:/app/keymaster/data
     user: "${ARCHON_UID}:${ARCHON_GID}"
     ports:
-      - ${ARCHON_KEYMASTER_PORT}:4226
+      - "${ARCHON_KEYMASTER_HOST_BIND:-127.0.0.1}:${ARCHON_KEYMASTER_PORT:-4226}:4226"
     healthcheck:
       test:
         [

--- a/docker/compose/keymaster-ts.yml
+++ b/docker/compose/keymaster-ts.yml
@@ -27,7 +27,7 @@ services:
       - ../../data:/app/keymaster/data
     user: "${ARCHON_UID}:${ARCHON_GID}"
     ports:
-      - ${ARCHON_KEYMASTER_PORT}:4226
+      - "${ARCHON_KEYMASTER_HOST_BIND:-127.0.0.1}:${ARCHON_KEYMASTER_PORT:-4226}:4226"
     healthcheck:
       test:
         [

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -521,6 +521,7 @@ Enable the `lightning` profile, or enable `drawbridge`, which also starts the bu
 | `ARCHON_LIGHTNING_MEDIATOR_CLN_RUNE` | empty | CLN rune used by the mediator; auto-loaded from `./data/cln-mainnet/drawbridge/rune.txt` in the bundled stack |
 | `ARCHON_LIGHTNING_MEDIATOR_LNBITS_URL` | `http://lnbits:5000` | LNbits base URL used by the mediator |
 | `ARCHON_DRAWBRIDGE_PUBLIC_HOST` | *(auto)* | Public Drawbridge URL used for published invoice endpoints |
+| `ARCHON_TOR_SOCKS_PORT` | `127.0.0.1:9050` | Optional host-side Tor SOCKS bind; use `HOST_IP:HOST_PORT` such as `127.0.0.1:9051` when overriding |
 | `ARCHON_DRAWBRIDGE_RATE_LIMIT_MAX` | `100` | Max requests per window |
 | `ARCHON_DRAWBRIDGE_RATE_LIMIT_WINDOW` | `60` | Rate limit window in seconds |
 | `ARCHON_DRAWBRIDGE_MACAROON_SECRET` | *(auto)* | L402 macaroon signing secret (auto-generated) |
@@ -693,7 +694,7 @@ GRAFANA_ADMIN_PASSWORD=your-secure-password
 | 3001 | CLN REST | 3001 | -- | localhost |
 | 3002 | RTL | 3002 | `ARCHON_RTL_PORT` | localhost |
 | 5000 | LNbits | 5000 | `ARCHON_LNBITS_PORT` | localhost |
-| 9050 | Tor SOCKS | 127.0.0.1:9050 | `ARCHON_TOR_SOCKS_PORT` | localhost |
+| 9050 | Tor SOCKS | 127.0.0.1:9050 | `ARCHON_TOR_SOCKS_PORT` | localhost; overrides should use `HOST_IP:HOST_PORT` |
 | 38332 | BTC Signet Node RPC | 38332 | -- | localhost |
 | 4232 | Hyperswarm Metrics | 4232 | -- | localhost |
 | 4234 | BTC Mainnet Mediator Metrics | 4234 | -- | localhost |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -89,6 +89,7 @@ Available profiles: `hyperswarm`, `cli`, `explorer`, `gatekeeper-client`, `keyma
 | `COMPOSE_PROFILES` | sample default | Optional Docker Compose service profiles |
 | `ARCHON_GATEKEEPER_PORT` | `4224` | Gatekeeper API port |
 | `ARCHON_KEYMASTER_PORT` | `4226` | Keymaster API port |
+| `ARCHON_KEYMASTER_HOST_BIND` | `127.0.0.1` | Keymaster host bind address |
 | `ARCHON_GATEKEEPER_CLIENT_PORT` | `4225` | Gatekeeper client UI port |
 | `ARCHON_REACT_WALLET_PORT` | `4228` | React wallet UI port |
 | `ARCHON_GATEKEEPER_DB` | `redis` | Storage backend (`redis` or `json`) |
@@ -679,7 +680,7 @@ GRAFANA_ADMIN_PASSWORD=your-secure-password
 |------|---------|---------|---------|---------|
 | 4224 | Gatekeeper | 4224 | `ARCHON_GATEKEEPER_PORT` | configurable |
 | 4225 | Gatekeeper Client | 4225 | `ARCHON_GATEKEEPER_CLIENT_PORT` | configurable |
-| 4226 | Keymaster | 4226 | `ARCHON_KEYMASTER_PORT` | configurable |
+| 4226 | Keymaster | 127.0.0.1:4226 | `ARCHON_KEYMASTER_HOST_BIND` / `ARCHON_KEYMASTER_PORT` | localhost |
 | 4227 | Keymaster Client | 4227 | `ARCHON_KEYMASTER_CLIENT_PORT` | configurable |
 | 4223 | Drawbridge Client | 4223 | `ARCHON_DRAWBRIDGE_CLIENT_PORT` | configurable |
 | 4228 | React Wallet | 4228 | `ARCHON_REACT_WALLET_PORT` | configurable |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -692,7 +692,7 @@ GRAFANA_ADMIN_PASSWORD=your-secure-password
 | 3001 | CLN REST | 3001 | -- | localhost |
 | 3002 | RTL | 3002 | `ARCHON_RTL_PORT` | localhost |
 | 5000 | LNbits | 5000 | `ARCHON_LNBITS_PORT` | localhost |
-| 9050 | Tor SOCKS | 9050 | `ARCHON_TOR_SOCKS_PORT` | configurable |
+| 9050 | Tor SOCKS | 127.0.0.1:9050 | `ARCHON_TOR_SOCKS_PORT` | localhost |
 | 38332 | BTC Signet Node RPC | 38332 | -- | localhost |
 | 4232 | Hyperswarm Metrics | 4232 | -- | localhost |
 | 4234 | BTC Mainnet Mediator Metrics | 4234 | -- | localhost |

--- a/sample.env
+++ b/sample.env
@@ -41,6 +41,9 @@ ARCHON_GATEKEEPER_CONFIRM_FALLBACK_URL=
 # Implementation flavor: `ts` (default) or `py`. Selects which
 # docker/compose/keymaster-*.yml is pulled in by docker-compose.yml.
 ARCHON_KEYMASTER_FLAVOR=ts
+# Keep Keymaster off public interfaces by default; use a private/VPN address
+# here only when remote admin access is intentional.
+ARCHON_KEYMASTER_HOST_BIND=127.0.0.1
 ARCHON_KEYMASTER_PORT=4226
 ARCHON_KEYMASTER_DB=json
 ARCHON_ENCRYPTED_PASSPHRASE=


### PR DESCRIPTION
## Summary
- bind the Drawbridge bundled Tor SOCKS host port to 127.0.0.1 by default
- bind the Keymaster host port to 127.0.0.1 by default across both TS and Python flavors
- keep explicit host-bind override knobs for operators who intentionally bind to a private/VPN interface
- document the localhost-only defaults and record durable repo guidance for future Drawbridge/Tor/Keymaster changes

Closes #589

## Validation
- COMPOSE_PROFILES=drawbridge docker compose config --format json | jq '.services.tor.ports'\n- ARCHON_KEYMASTER_FLAVOR=ts docker compose config --format json | jq '.services.keymaster.ports'\n- ARCHON_KEYMASTER_FLAVOR=py docker compose config --format json | jq '.services.keymaster.ports'\n- ARCHON_KEYMASTER_FLAVOR=ts ARCHON_KEYMASTER_HOST_BIND=0.0.0.0 docker compose config --format json | jq '.services.keymaster.ports'\n- COMPOSE_PROFILES=observability,lightning docker compose config --format json | jq -r '.services | to_entries[] | select(.key=="grafana" or .key=="rtl") | [.key, ((.value.ports // [])[0].host_ip // "0.0.0.0"), ((.value.ports // [])[0].published|tostring), ((.value.ports // [])[0].target|tostring)] | @tsv'