### PR TITLE
fix: stop Satoshi historical scan log OOM

### DIFF
--- a/services/mediators/satoshi/src/satoshi-mediator.ts
+++ b/services/mediators/satoshi/src/satoshi-mediator.ts
@@ -132,7 +132,7 @@ async function getChainBlockHex(hash: string, height?: number): Promise<string> 
         try {
             return await fallbackBtcClient.getBlock(hash, BlockVerbosity.HEX) as string;
         } catch (error) {
-            throw new HistoricalBlockDataUnavailableError(`block ${hash}`, `primary RPC is pruned through height ${primaryPruneHeight}`, error);
+            throw new HistoricalBlockDataUnavailableError(`block ${hash}`, `primary RPC skipped because it is pruned through height ${primaryPruneHeight}`, error);
         }
     }
 
@@ -1135,7 +1135,7 @@ async function waitForChain() {
             console.log("Blockchain Info:", JSON.stringify(blockchainInfo, null, 4));
             const info = blockchainInfo as BlockchainInfo;
             primaryPruneHeight = info.pruned && typeof info.pruneheight === 'number' ? info.pruneheight : undefined;
-            if (primaryPruneHeight !== undefined && config.startBlock < primaryPruneHeight && !fallbackBtcClient) {
+            if (primaryPruneHeight !== undefined && config.startBlock <= primaryPruneHeight && !fallbackBtcClient) {
                 console.warn(`${config.chain} primary RPC is pruned at height ${primaryPruneHeight}, but start block is ${config.startBlock} and ARCHON_SAT_FALLBACK_RPC_URL is unset. Missing historical blocks will not be recoverable from this node.`);
             }
             isReady = true;

--- a/services/mediators/satoshi/src/satoshi-mediator.ts
+++ b/services/mediators/satoshi/src/satoshi-mediator.ts
@@ -54,6 +54,7 @@ const btcClient = new BtcClient({
 const fallbackBtcClient = config.fallbackRpcUrl
     ? new BtcClient({ host: config.fallbackRpcUrl })
     : undefined;
+let primaryPruneHeight: number | undefined;
 
 type ChainReadClient = Pick<BtcClient, 'getBlockHash' | 'getBlock' | 'getBlockHeader' | 'getBlockCount'>;
 
@@ -126,7 +127,15 @@ async function getChainBlockTxids(hash: string): Promise<Block> {
     return withFallback(`block ${hash}`, async (client) => await client.getBlock(hash, BlockVerbosity.JSON) as Block);
 }
 
-async function getChainBlockHex(hash: string): Promise<string> {
+async function getChainBlockHex(hash: string, height?: number): Promise<string> {
+    if (fallbackBtcClient && primaryPruneHeight !== undefined && height !== undefined && height <= primaryPruneHeight) {
+        try {
+            return await fallbackBtcClient.getBlock(hash, BlockVerbosity.HEX) as string;
+        } catch (error) {
+            throw new HistoricalBlockDataUnavailableError(`block ${hash}`, `primary RPC is pruned through height ${primaryPruneHeight}`, error);
+        }
+    }
+
     return withFallback(`block ${hash}`, async (client) => await client.getBlock(hash, BlockVerbosity.HEX) as string);
 }
 
@@ -664,15 +673,13 @@ async function fetchBlock(height: number, blockCount: number): Promise<void> {
     try {
         const blockHash = await getChainBlockHash(height);
         const header = await getChainBlockHeader(blockHash);
-        const blockHex = await getChainBlockHex(blockHash);
+        const blockHex = await getChainBlockHex(blockHash, height);
         const transactions = parseRawBlockTransactions(blockHex);
         const blockTime = header.time ?? 0;
         const timestamp = new Date(blockTime * 1000).toISOString();
 
         for (let index = 0; index < transactions.length; index++) {
             const tx = transactions[index];
-
-            console.log(height, String(index).padStart(4), tx.txid);
 
             for (const opReturn of tx.opReturns) {
                 try {
@@ -1127,8 +1134,9 @@ async function waitForChain() {
             const blockchainInfo = await btcClient.getBlockchainInfo();
             console.log("Blockchain Info:", JSON.stringify(blockchainInfo, null, 4));
             const info = blockchainInfo as BlockchainInfo;
-            if (info.pruned && typeof info.pruneheight === 'number' && config.startBlock < info.pruneheight && !fallbackBtcClient) {
-                console.warn(`${config.chain} primary RPC is pruned at height ${info.pruneheight}, but start block is ${config.startBlock} and ARCHON_SAT_FALLBACK_RPC_URL is unset. Missing historical blocks will not be recoverable from this node.`);
+            primaryPruneHeight = info.pruned && typeof info.pruneheight === 'number' ? info.pruneheight : undefined;
+            if (primaryPruneHeight !== undefined && config.startBlock < primaryPruneHeight && !fallbackBtcClient) {
+                console.warn(`${config.chain} primary RPC is pruned at height ${primaryPruneHeight}, but start block is ${config.startBlock} and ARCHON_SAT_FALLBACK_RPC_URL is unset. Missing historical blocks will not be recoverable from this node.`);
             }
             isReady = true;
         } catch (error) {


### PR DESCRIPTION
## Summary

Fixes the remaining BTC mainnet historical catch-up OOM after PR #595 by removing per-transaction stdout logging from the scan hot path and avoiding repeated primary RPC failures for blocks known to be below the primary node's prune height.

## Root Cause

The raw-block parser itself stays small, but the mediator still logged every transaction while scanning historical blocks. During catch-up, stdout could not flush Docker log lines as quickly as the mediator produced them, so V8 retained a huge backlog of log strings until the process hit the heap limit and exited with code 139.

The JSON DB showed the scan had advanced beyond the last flushed tx log line, confirming the process was still scanning while stdout buffering lagged behind.

## Changes

- Remove per-transaction `console.log(height, index, txid)` from `fetchBlock()`.
- Keep block-level progress logs.
- Record the primary node prune height learned at startup.
- When a fallback RPC is configured and the requested raw block is at or below the primary prune height, fetch raw block hex directly from fallback instead of failing primary first.

## Validation

- `npm run build` in `services/mediators/satoshi`
- `npx eslint services/mediators/satoshi/src/satoshi-mediator.ts services/mediators/satoshi/src/config.ts`
- `git diff --check`
- Rebuilt and restarted `btc-mainnet-mediator` locally.
- Live catch-up continued past the previous crash area:
  - DB height advanced from `940211` to `941163+`
  - container remained running with `OOMKilled=false`
  - memory stayed in the normal hundreds of MiB instead of climbing toward the ~2 GB V8 heap limit
  - logs are now block-level progress only, without per-tx spam
