### PR TITLE
feat: add Archon MCP server

### DIFF
--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -321,7 +321,7 @@ keymaster remove-address myagent@${agentDomain}`}
                             The lower-level HTTP API is still available for direct integrations and debugging.
                         </Typography>
                         <Typography variant="body2" sx={{ color: '#888', mt: 2 }}>
-                            MCP Server: <a href="https://www.npmjs.com/package/@archon-protocol/mcp-server" target="_blank" rel="noopener noreferrer" style={{ color: '#00d4aa' }}>@archon-protocol/mcp-server</a>
+                            MCP Server: <a href="https://www.npmjs.com/package/@didcid/mcp-server" target="_blank" rel="noopener noreferrer" style={{ color: '#00d4aa' }}>@didcid/mcp-server</a>
                             {' • '}
                             Keymaster: <a href="https://www.npmjs.com/package/@didcid/keymaster" target="_blank" rel="noopener noreferrer" style={{ color: '#00d4aa' }}>@didcid/keymaster</a>
                         </Typography>

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,6 +28,7 @@ const config = {
         '^@didcid/keymaster$': '<rootDir>/packages/keymaster/src/keymaster.ts',
         '^@didcid/keymaster/client$': '<rootDir>/packages/keymaster/src/keymaster-client.ts',
         '^@didcid/keymaster/wallet/(.*)$': '<rootDir>/packages/keymaster/src/db/$1',
+        '^@didcid/mcp-server$': '<rootDir>/packages/mcp-server/src/index.ts',
         '^@didcid/cipher/passphrase': '<rootDir>/packages/cipher/src/passphrase.ts',
         '^\\.\\/typeGuards\\.js$': '<rootDir>/packages/keymaster/src/db/typeGuards.ts',
         '^\\.\\/db\\/typeGuards\\.js$': '<rootDir>/packages/keymaster/src/db/typeGuards.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2839,6 +2839,10 @@
       "resolved": "packages/keymaster",
       "link": true
     },
+    "node_modules/@didcid/mcp-server": {
+      "resolved": "packages/mcp-server",
+      "link": true
+    },
     "node_modules/@dnsquery/dns-packet": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
@@ -3202,6 +3206,18 @@
         "p-defer": "^4.0.1",
         "progress-events": "^1.0.1",
         "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -5291,6 +5307,46 @@
       "integrity": "sha512-lYtBcmvHustHQtg4X7TXUu1Xa/tbLC3p2wLvgQI+fWVySguVZJF60Snxijw5EiohumxZbR10kWYFFebh1zotiw==",
       "dev": true,
       "license": "LGPL-3.0"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
     },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.6",
@@ -8777,7 +8833,6 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -8791,7 +8846,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8801,7 +8855,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -8898,7 +8951,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -8909,6 +8961,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/anser": {
@@ -9999,6 +10068,42 @@
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -10163,6 +10268,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/cacache": {
@@ -10876,6 +10990,28 @@
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/conventional-changelog-angular": {
       "version": "8.3.1",
@@ -11725,6 +11861,24 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
@@ -11744,6 +11898,23 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
@@ -12181,7 +12352,6 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -12351,8 +12521,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -12712,8 +12881,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -13257,7 +13425,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -13284,6 +13451,27 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -13350,11 +13538,201 @@
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "license": "Apache-2.0"
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -13408,7 +13786,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13737,6 +14114,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/freeport-promise": {
@@ -14945,6 +15331,15 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
@@ -15011,7 +15406,6 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -15032,7 +15426,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -15088,7 +15481,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -15451,10 +15843,9 @@
       "license": "MIT"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "devOptional": true,
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -15470,6 +15861,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/ipfs-unixfs": {
@@ -16035,6 +16435,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-reference": {
       "version": "1.2.1",
@@ -17394,6 +17800,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -17460,8 +17875,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -18525,6 +18945,15 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -18543,6 +18972,18 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
       "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -20285,7 +20726,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -20295,7 +20735,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -21057,7 +21496,6 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -21123,6 +21561,16 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -21168,6 +21616,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -21492,6 +21949,19 @@
         "uint8arrays": "^5.0.1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -21553,6 +22023,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue": {
@@ -21676,9 +22161,23 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/rc": {
@@ -22384,7 +22883,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -22554,6 +23052,22 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.3",
         "@rollup/rollup-win32-x64-msvc": "4.60.3",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/run-async": {
@@ -22899,8 +23413,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/sha.js": {
       "version": "2.4.12",
@@ -23011,7 +23524,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -23031,7 +23543,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -23048,7 +23559,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -23067,7 +23577,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -24527,7 +25036,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -24837,6 +25345,62 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -25121,7 +25685,6 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -25271,6 +25834,15 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vlq": {
@@ -25772,6 +26344,24 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
     "packages/browser-hdkey": {
       "name": "@didcid/browser-hdkey",
       "version": "0.1.13",
@@ -25952,6 +26542,25 @@
       },
       "engines": {
         "node": ">=16.x"
+      }
+    },
+    "packages/mcp-server": {
+      "name": "@didcid/mcp-server",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@didcid/cipher": "^0.2.11",
+        "@didcid/gatekeeper": "^0.4.11",
+        "@didcid/keymaster": "^0.4.11",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "dotenv": "^16.4.5",
+        "zod": "^3.25.76"
+      },
+      "bin": {
+        "archon-mcp-server": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.18.11"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26557,7 +26557,7 @@
         "zod": "^3.25.76"
       },
       "bin": {
-        "archon-mcp-server": "dist/index.js"
+        "archon-mcp-server": "dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^22.18.11"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:cli": "node --experimental-vm-modules node_modules/.bin/jest --config jest.config.cli.js --runInBand --verbose",
     "generate-openapi": "node swaggerConf.js",
     "lint": "eslint .",
-    "build": "npm run build -w @didcid/browser-hdkey && npm run build -w @didcid/common && npm run build -w @didcid/ipfs && npm run build -w @didcid/cipher && npm run build -w @didcid/gatekeeper && npm run build -w @didcid/keymaster"
+    "build": "npm run build -w @didcid/browser-hdkey && npm run build -w @didcid/common && npm run build -w @didcid/ipfs && npm run build -w @didcid/cipher && npm run build -w @didcid/gatekeeper && npm run build -w @didcid/keymaster && npm run build -w @didcid/mcp-server"
   },
   "author": "",
   "license": "ISC",

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,6 +1,6 @@
 # Archon MCP Server
 
-`@didcid/mcp-server` lets MCP clients work with Archon identities, aliases, addresses, and JSON assets from a local wallet. It runs as a stdio server on the user's machine, so agents can use Archon without a separate Keymaster HTTP service.
+`@didcid/mcp-server` lets MCP clients work with Archon identities, aliases, addresses, and JSON assets from a local wallet. It runs as a stdio server on the user's machine, so agents can use Archon from local MCP-compatible tools.
 
 The server uses the same wallet files and passphrase flow as the Keymaster CLI, then connects to an Archon node through Gatekeeper/Drawbridge for registry reads and writes.
 
@@ -76,4 +76,4 @@ Set `ARCHON_MCP_READ_ONLY=true` to disable all mutating tools.
 
 ## Intentionally omitted from v1
 
-The v1 server does not expose wallet creation/recovery/mnemonic/passphrase tools, Keymaster service proxy mode, Gatekeeper admin tools, credentials, vaults, dmail, Nostr, Lightning, polls, groups, schemas, or binary file/image asset tools.
+The v1 server does not expose wallet creation/recovery/mnemonic/passphrase tools, Gatekeeper admin tools, credentials, vaults, dmail, Nostr, Lightning, polls, groups, schemas, or binary file/image asset tools.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -36,7 +36,7 @@ Example MCP client config:
 | `ARCHON_GATEKEEPER_URL` | unset | Legacy fallback when `ARCHON_NODE_URL` is unset |
 | `ARCHON_WALLET_TYPE` | `json` | Local wallet backend: `json` or `sqlite` |
 | `ARCHON_WALLET_PATH` | `./wallet.json` | Wallet file path |
-| `ARCHON_PASSPHRASE` | required | Passphrase for local wallet operations |
+| `ARCHON_PASSPHRASE` | unset | Required for wallet-backed tools; node health tools work without it |
 | `ARCHON_DEFAULT_REGISTRY` | Keymaster default | Default registry for new DIDs |
 | `ARCHON_MCP_READ_ONLY` | `false` | Set to `true` to block mutating tools |
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,0 +1,79 @@
+# Archon MCP Server
+
+`@didcid/mcp-server` exposes a local Archon wallet runtime to MCP clients over stdio.
+
+The server instantiates the Keymaster library directly, using the same local wallet model as the Keymaster CLI. It does not proxy to the Keymaster HTTP service and does not use `ARCHON_KEYMASTER_URL`.
+
+## Usage
+
+```bash
+npx @didcid/mcp-server
+```
+
+Example MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "archon": {
+      "command": "npx",
+      "args": ["-y", "@didcid/mcp-server"],
+      "env": {
+        "ARCHON_NODE_URL": "http://localhost:4224",
+        "ARCHON_WALLET_PATH": "./wallet.json",
+        "ARCHON_PASSPHRASE": "your-wallet-passphrase"
+      }
+    }
+  }
+}
+```
+
+## Environment
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `ARCHON_NODE_URL` | `http://localhost:4224` | Archon Gatekeeper/Drawbridge node URL |
+| `ARCHON_GATEKEEPER_URL` | unset | Legacy fallback when `ARCHON_NODE_URL` is unset |
+| `ARCHON_WALLET_TYPE` | `json` | Local wallet backend: `json` or `sqlite` |
+| `ARCHON_WALLET_PATH` | `./wallet.json` | Wallet file path |
+| `ARCHON_PASSPHRASE` | required | Passphrase for local wallet operations |
+| `ARCHON_DEFAULT_REGISTRY` | Keymaster default | Default registry for new DIDs |
+| `ARCHON_MCP_READ_ONLY` | `false` | Set to `true` to block mutating tools |
+
+## Tools
+
+Read tools:
+
+- `archon_get_version`
+- `archon_get_status`
+- `archon_list_registries`
+- `archon_list_ids`
+- `archon_get_current_id`
+- `archon_resolve_did`
+- `archon_resolve_id`
+- `archon_list_aliases`
+- `archon_get_alias`
+- `archon_list_addresses`
+- `archon_check_address`
+- `archon_list_assets`
+- `archon_get_asset`
+
+Mutating tools:
+
+- `archon_use_id`
+- `archon_create_id`
+- `archon_add_alias`
+- `archon_remove_alias`
+- `archon_add_address`
+- `archon_remove_address`
+- `archon_publish_address`
+- `archon_unpublish_address`
+- `archon_create_asset_json`
+- `archon_update_asset_json`
+- `archon_transfer_asset`
+
+Set `ARCHON_MCP_READ_ONLY=true` to disable all mutating tools.
+
+## Intentionally omitted from v1
+
+The v1 server does not expose wallet creation/recovery/mnemonic/passphrase tools, Keymaster service proxy mode, Gatekeeper admin tools, credentials, vaults, dmail, Nostr, Lightning, polls, groups, schemas, or binary file/image asset tools.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,8 +1,8 @@
 # Archon MCP Server
 
-`@didcid/mcp-server` exposes a local Archon wallet runtime to MCP clients over stdio.
+`@didcid/mcp-server` lets MCP clients work with Archon identities, aliases, addresses, and JSON assets from a local wallet. It runs as a stdio server on the user's machine, so agents can use Archon without a separate Keymaster HTTP service.
 
-The server instantiates the Keymaster library directly, using the same local wallet model as the Keymaster CLI.
+The server uses the same wallet files and passphrase flow as the Keymaster CLI, then connects to an Archon node through Gatekeeper/Drawbridge for registry reads and writes.
 
 ## Usage
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -72,7 +72,7 @@ Mutating tools:
 - `archon_update_asset_json`
 - `archon_transfer_asset`
 
-Set `ARCHON_MCP_READ_ONLY=true` to disable all mutating tools.
+Set `ARCHON_MCP_READ_ONLY=true` to omit mutating tools from the advertised MCP tool list.
 
 ## Intentionally omitted from v1
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 `@didcid/mcp-server` exposes a local Archon wallet runtime to MCP clients over stdio.
 
-The server instantiates the Keymaster library directly, using the same local wallet model as the Keymaster CLI. It does not proxy to the Keymaster HTTP service and does not use `ARCHON_KEYMASTER_URL`.
+The server instantiates the Keymaster library directly, using the same local wallet model as the Keymaster CLI.
 
 ## Usage
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -19,7 +19,7 @@ Example MCP client config:
       "command": "npx",
       "args": ["-y", "@didcid/mcp-server"],
       "env": {
-        "ARCHON_NODE_URL": "http://localhost:4224",
+        "ARCHON_NODE_URL": "https://archon.technology",
         "ARCHON_WALLET_PATH": "./wallet.json",
         "ARCHON_PASSPHRASE": "your-wallet-passphrase"
       }
@@ -32,7 +32,7 @@ Example MCP client config:
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `ARCHON_NODE_URL` | `http://localhost:4224` | Archon Gatekeeper/Drawbridge node URL |
+| `ARCHON_NODE_URL` | `https://archon.technology` | Archon Gatekeeper/Drawbridge node URL |
 | `ARCHON_GATEKEEPER_URL` | unset | Legacy fallback when `ARCHON_NODE_URL` is unset |
 | `ARCHON_WALLET_TYPE` | `json` | Local wallet backend: `json` or `sqlite` |
 | `ARCHON_WALLET_PATH` | `./wallet.json` | Wallet file path |

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@didcid/mcp-server",
+  "version": "0.1.0",
+  "description": "Archon MCP server",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "archon-mcp-server": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "npm run clean && tsc -p tsconfig.json && chmod +x dist/index.js"
+  },
+  "keywords": [
+    "archon",
+    "mcp",
+    "did",
+    "wallet"
+  ],
+  "author": "David McFadzean <davidmc@gmail.com>",
+  "license": "MIT",
+  "dependencies": {
+    "@didcid/cipher": "^0.2.11",
+    "@didcid/gatekeeper": "^0.4.11",
+    "@didcid/keymaster": "^0.4.11",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "dotenv": "^16.4.5",
+    "zod": "^3.25.76"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/archetech/archon.git"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.11"
+  }
+}

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "archon-mcp-server": "./dist/index.js"
+    "archon-mcp-server": "./dist/cli.js"
   },
   "files": [
     "dist",
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "npm run clean && tsc -p tsconfig.json && chmod +x dist/index.js"
+    "build": "npm run clean && tsc -p tsconfig.json && chmod +x dist/cli.js"
   },
   "keywords": [
     "archon",

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import dotenv from 'dotenv';
+import { main } from './index.js';
+import { redactSecretText } from './redact.js';
+
+dotenv.config();
+
+main().catch((error) => {
+    console.error(`Archon MCP server failed: ${redactSecretText(error)}`);
+    process.exit(1);
+});

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -1,0 +1,47 @@
+import path from 'path';
+
+export type WalletType = 'json' | 'sqlite';
+
+export interface McpServerConfig {
+    nodeUrl: string;
+    walletType: WalletType;
+    walletPath: string;
+    passphrase?: string;
+    defaultRegistry?: string;
+    readOnly: boolean;
+}
+
+function parseWalletType(value: string | undefined): WalletType {
+    switch (value) {
+    case undefined:
+    case '':
+    case 'json':
+        return 'json';
+    case 'sqlite':
+        return 'sqlite';
+    default:
+        throw new Error(`Unsupported ARCHON_WALLET_TYPE "${value}"`);
+    }
+}
+
+function parseBool(value: string | undefined): boolean {
+    return value === 'true' || value === '1' || value === 'yes';
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): McpServerConfig {
+    return {
+        nodeUrl: env.ARCHON_NODE_URL || env.ARCHON_GATEKEEPER_URL || 'http://localhost:4224',
+        walletType: parseWalletType(env.ARCHON_WALLET_TYPE),
+        walletPath: env.ARCHON_WALLET_PATH || './wallet.json',
+        passphrase: env.ARCHON_PASSPHRASE,
+        defaultRegistry: env.ARCHON_DEFAULT_REGISTRY,
+        readOnly: parseBool(env.ARCHON_MCP_READ_ONLY),
+    };
+}
+
+export function walletLocation(walletPath: string): { directory: string; file: string } {
+    return {
+        directory: path.dirname(walletPath),
+        file: path.basename(walletPath),
+    };
+}

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -30,7 +30,7 @@ function parseBool(value: string | undefined): boolean {
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): McpServerConfig {
     return {
-        nodeUrl: env.ARCHON_NODE_URL || env.ARCHON_GATEKEEPER_URL || 'http://localhost:4224',
+        nodeUrl: env.ARCHON_NODE_URL || env.ARCHON_GATEKEEPER_URL || 'https://archon.technology',
         walletType: parseWalletType(env.ARCHON_WALLET_TYPE),
         walletPath: env.ARCHON_WALLET_PATH || './wallet.json',
         passphrase: env.ARCHON_PASSPHRASE,

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,13 +1,8 @@
-#!/usr/bin/env node
-import dotenv from 'dotenv';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { loadConfig } from './config.js';
-import { redactSecretText } from './redact.js';
 import { createArchonRuntime } from './runtime.js';
 import { registerArchonTools } from './tools.js';
-
-dotenv.config();
 
 export async function main(): Promise<void> {
     const config = loadConfig();
@@ -22,8 +17,3 @@ export async function main(): Promise<void> {
     const transport = new StdioServerTransport();
     await server.connect(transport);
 }
-
-main().catch((error) => {
-    console.error(`Archon MCP server failed: ${redactSecretText(error)}`);
-    process.exit(1);
-});

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -4,6 +4,12 @@ import { loadConfig } from './config.js';
 import { createArchonRuntime } from './runtime.js';
 import { registerArchonTools } from './tools.js';
 
+export { loadConfig, walletLocation } from './config.js';
+export type { McpServerConfig, WalletType } from './config.js';
+export { createArchonRuntime, createWallet } from './runtime.js';
+export type { ArchonRuntime } from './runtime.js';
+export { registerArchonTools } from './tools.js';
+
 export async function main(): Promise<void> {
     const config = loadConfig();
     const runtime = await createArchonRuntime(config);

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import dotenv from 'dotenv';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { loadConfig } from './config.js';
+import { redactSecretText } from './redact.js';
+import { createArchonRuntime } from './runtime.js';
+import { registerArchonTools } from './tools.js';
+
+dotenv.config();
+
+export async function main(): Promise<void> {
+    const config = loadConfig();
+    const runtime = await createArchonRuntime(config);
+    const server = new McpServer({
+        name: '@didcid/mcp-server',
+        version: '0.1.0',
+    });
+
+    registerArchonTools(server as any, runtime, config);
+
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+}
+
+main().catch((error) => {
+    console.error(`Archon MCP server failed: ${redactSecretText(error)}`);
+    process.exit(1);
+});

--- a/packages/mcp-server/src/redact.ts
+++ b/packages/mcp-server/src/redact.ts
@@ -1,4 +1,41 @@
-const SECRET_ASSIGNMENT = /(ARCHON_(?:ADMIN_API_KEY|PASSPHRASE|ENCRYPTED_PASSPHRASE)|api[_-]?key|apikey|token|access_token|passphrase|password)=([^&\s]+)/gi;
+const QUOTED_SECRET_ASSIGNMENT = /\b(ARCHON_(?:ADMIN_API_KEY|PASSPHRASE|ENCRYPTED_PASSPHRASE)|api[_-]?key|apikey|token|access_token|passphrase|password)=("[^"]*"|'[^']*')/gi;
+const SPACED_SECRET_ASSIGNMENT = /\b(ARCHON_(?:PASSPHRASE|ENCRYPTED_PASSPHRASE)|passphrase|password)=([^&\r\n]*?)(?=\shttps?:\/\/|\s[A-Za-z_][A-Za-z0-9_-]*=|[&\r\n]|$)/gi;
+const SECRET_ASSIGNMENT = /\b(ARCHON_ADMIN_API_KEY|api[_-]?key|apikey|token|access_token)=([^&\s]+)/gi;
+const URL_TEXT = /https?:\/\/[^\s"'<>]+/gi;
+const URL_SECRET_PARAMS = new Set(['api_key', 'apikey', 'access_token', 'token', 'key', 'password', 'passphrase']);
+const TOKEN_PATH_HOSTS = [
+    /(^|\.)alchemy\.com$/i,
+    /(^|\.)infura\.io$/i,
+    /(^|\.)quicknode\.com$/i,
+];
+
+function redactUrl(rawUrl: string): string {
+    try {
+        const url = new URL(rawUrl);
+
+        if (url.username || url.password) {
+            url.username = '<redacted>';
+            url.password = '';
+        }
+
+        for (const param of [...url.searchParams.keys()]) {
+            if (URL_SECRET_PARAMS.has(param.toLowerCase())) {
+                url.searchParams.set(param, '<redacted>');
+            }
+        }
+
+        if (TOKEN_PATH_HOSTS.some(pattern => pattern.test(url.hostname))) {
+            url.pathname = url.pathname.replace(/\/v\d+\/[^/?#]+/gi, match => {
+                const [prefix] = match.match(/\/v\d+\//i) ?? ['/'];
+                return `${prefix}<redacted>`;
+            });
+        }
+
+        return url.toString().replace(/%3Credacted%3E/g, '<redacted>');
+    } catch {
+        return rawUrl;
+    }
+}
 
 export function redactSecretText(value: unknown): string {
     const text = typeof value === 'string'
@@ -8,8 +45,9 @@ export function redactSecretText(value: unknown): string {
             : JSON.stringify(value);
 
     return (text || String(value))
-        .replace(/\/\/([^:@/\s]+):([^@/\s]+)@/g, '//<redacted>@')
-        .replace(/\/v2\/[^/?#\s]+/g, '/v2/<redacted>')
+        .replace(URL_TEXT, redactUrl)
+        .replace(QUOTED_SECRET_ASSIGNMENT, '$1=<redacted>')
+        .replace(SPACED_SECRET_ASSIGNMENT, '$1=<redacted>')
         .replace(SECRET_ASSIGNMENT, '$1=<redacted>');
 }
 

--- a/packages/mcp-server/src/redact.ts
+++ b/packages/mcp-server/src/redact.ts
@@ -1,0 +1,26 @@
+const SECRET_ASSIGNMENT = /(ARCHON_(?:ADMIN_API_KEY|PASSPHRASE|ENCRYPTED_PASSPHRASE)|api[_-]?key|apikey|token|access_token|passphrase|password)=([^&\s]+)/gi;
+
+export function redactSecretText(value: unknown): string {
+    const text = typeof value === 'string'
+        ? value
+        : value instanceof Error
+            ? value.message
+            : JSON.stringify(value);
+
+    return (text || String(value))
+        .replace(/\/\/([^:@/\s]+):([^@/\s]+)@/g, '//<redacted>@')
+        .replace(/\/v2\/[^/?#\s]+/g, '/v2/<redacted>')
+        .replace(SECRET_ASSIGNMENT, '$1=<redacted>');
+}
+
+export function errorMessage(error: unknown): string {
+    if (typeof error === 'object' && error && 'error' in error && typeof error.error === 'string') {
+        return redactSecretText(error.error);
+    }
+
+    if (typeof error === 'object' && error && 'message' in error && typeof error.message === 'string') {
+        return redactSecretText(error.message);
+    }
+
+    return redactSecretText(error);
+}

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -12,11 +12,12 @@ export interface ArchonRuntime {
 }
 
 export async function createWallet(config: McpServerConfig) {
+    const { directory, file } = walletLocation(config.walletPath);
+
     if (config.walletType === 'sqlite') {
-        return WalletSQLite.create(config.walletPath);
+        return WalletSQLite.create(file, directory);
     }
 
-    const { directory, file } = walletLocation(config.walletPath);
     return new WalletJson(file, directory);
 }
 

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -1,0 +1,51 @@
+import path from 'path';
+import CipherNode from '@didcid/cipher/node';
+import DrawbridgeClient from '@didcid/gatekeeper/drawbridge';
+import Keymaster from '@didcid/keymaster';
+import WalletJson from '@didcid/keymaster/wallet/json';
+import WalletSQLite from '@didcid/keymaster/wallet/sqlite';
+import { McpServerConfig, walletLocation } from './config.js';
+
+export interface ArchonRuntime {
+    node: DrawbridgeClient;
+    keymaster?: Keymaster;
+}
+
+export async function createWallet(config: McpServerConfig) {
+    if (config.walletType === 'sqlite') {
+        return WalletSQLite.create(config.walletPath);
+    }
+
+    const { directory, file } = walletLocation(config.walletPath);
+    return new WalletJson(file, directory);
+}
+
+export async function createArchonRuntime(config: McpServerConfig): Promise<ArchonRuntime> {
+    const node = new DrawbridgeClient();
+    await node.connect({
+        url: config.nodeUrl,
+        waitUntilReady: true,
+        intervalSeconds: 3,
+        chatty: false,
+        becomeChattyAfter: 2,
+    });
+
+    if (!config.passphrase) {
+        return { node };
+    }
+
+    const wallet = await createWallet({
+        ...config,
+        walletPath: path.normalize(config.walletPath),
+    });
+    const cipher = new CipherNode();
+    const keymaster = new Keymaster({
+        gatekeeper: node,
+        wallet,
+        cipher,
+        defaultRegistry: config.defaultRegistry,
+        passphrase: config.passphrase,
+    });
+
+    return { node, keymaster };
+}

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -25,10 +25,6 @@ export async function createArchonRuntime(config: McpServerConfig): Promise<Arch
     const node = new DrawbridgeClient();
     await node.connect({
         url: config.nodeUrl,
-        waitUntilReady: true,
-        intervalSeconds: 3,
-        chatty: false,
-        becomeChattyAfter: 2,
     });
 
     if (!config.passphrase) {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -1,4 +1,4 @@
-import { z, ZodTypeAny } from 'zod';
+import { z } from 'zod';
 import { McpServerConfig } from './config.js';
 import { ArchonRuntime } from './runtime.js';
 import { errorMessage } from './redact.js';
@@ -61,12 +61,16 @@ function registerTool<T>(
     handler: ToolHandler<T>,
     options: { mutates?: boolean; readOnly?: boolean } = {}
 ) {
+    if (options.mutates && options.readOnly) {
+        return;
+    }
+
     const wrapped = async (rawArgs: unknown) => {
         try {
-            const args = schema.parse(rawArgs ?? {});
             if (options.mutates && options.readOnly) {
                 throw new Error('Tool disabled by ARCHON_MCP_READ_ONLY=true');
             }
+            const args = schema.parse(rawArgs ?? {});
             return ok(await handler(args));
         } catch (error) {
             return fail(error);
@@ -169,15 +173,3 @@ export function registerArchonTools(server: RegisterableServer, runtime: ArchonR
     );
     registerTool(server, 'archon_transfer_asset', 'Transfer an asset to a new controller DID.', z.object({ id: z.string(), controller: z.string() }), async ({ id, controller }) => requireKeymaster(runtime).transferAsset(id, controller), mutating);
 }
-
-export const testExports = {
-    fail,
-    ok,
-    requireKeymaster,
-    schemas: {
-        EmptySchema,
-        ResolveOptionsSchema: ResolveOptionsSchema as ZodTypeAny,
-        JsonObjectSchema: JsonObjectSchema as ZodTypeAny,
-        AssetOptionsSchema: AssetOptionsSchema as ZodTypeAny,
-    },
-};

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -1,0 +1,183 @@
+import { z, ZodTypeAny } from 'zod';
+import { McpServerConfig } from './config.js';
+import { ArchonRuntime } from './runtime.js';
+import { errorMessage } from './redact.js';
+
+type ToolHandler<T> = (args: T) => Promise<unknown>;
+
+type RegisterableServer = {
+    registerTool?: (name: string, config: any, handler: (args: unknown) => Promise<unknown>) => void;
+    tool?: (name: string, description: string, schema: unknown, handler: (args: unknown) => Promise<unknown>) => void;
+};
+
+const EmptySchema = z.object({});
+const ResolveOptionsSchema = z.object({
+    confirm: z.boolean().optional(),
+    verify: z.boolean().optional(),
+    versionTime: z.string().optional(),
+    versionSequence: z.number().int().optional(),
+});
+
+const JsonObjectSchema = z.record(z.unknown());
+const AssetOptionsSchema = z.object({
+    alias: z.string().optional(),
+    registry: z.string().optional(),
+    controller: z.string().optional(),
+    validUntil: z.string().optional(),
+});
+
+function jsonResult(result: unknown) {
+    return {
+        content: [
+            {
+                type: 'text',
+                text: JSON.stringify(result),
+            },
+        ],
+    };
+}
+
+function ok(result: unknown) {
+    return jsonResult({ ok: true, result });
+}
+
+function fail(error: unknown) {
+    return jsonResult({ ok: false, error: errorMessage(error) });
+}
+
+function requireKeymaster(runtime: ArchonRuntime) {
+    if (!runtime.keymaster) {
+        throw new Error('ARCHON_PASSPHRASE is required for wallet-backed MCP tools');
+    }
+
+    return runtime.keymaster;
+}
+
+function registerTool<T>(
+    server: RegisterableServer,
+    name: string,
+    description: string,
+    schema: z.ZodType<T>,
+    handler: ToolHandler<T>,
+    options: { mutates?: boolean; readOnly?: boolean } = {}
+) {
+    const wrapped = async (rawArgs: unknown) => {
+        try {
+            const args = schema.parse(rawArgs ?? {});
+            if (options.mutates && options.readOnly) {
+                throw new Error('Tool disabled by ARCHON_MCP_READ_ONLY=true');
+            }
+            return ok(await handler(args));
+        } catch (error) {
+            return fail(error);
+        }
+    };
+
+    if (server.registerTool) {
+        server.registerTool(name, { description, inputSchema: schema }, wrapped);
+        return;
+    }
+
+    if (server.tool && schema instanceof z.ZodObject) {
+        server.tool(name, description, schema.shape, wrapped);
+        return;
+    }
+
+    throw new Error('MCP server does not support tool registration');
+}
+
+function compactOptions<T extends Record<string, unknown>>(options: T): Partial<T> | undefined {
+    const entries = Object.entries(options).filter(([, value]) => value !== undefined);
+    return entries.length > 0 ? Object.fromEntries(entries) as Partial<T> : undefined;
+}
+
+export function registerArchonTools(server: RegisterableServer, runtime: ArchonRuntime, config: McpServerConfig): void {
+    const mutating = { mutates: true, readOnly: config.readOnly };
+
+    registerTool(server, 'archon_get_version', 'Get Archon node version information.', EmptySchema, async () => runtime.node.getVersion());
+    registerTool(server, 'archon_get_status', 'Get Archon node status.', EmptySchema, async () => runtime.node.getStatus());
+    registerTool(server, 'archon_list_registries', 'List registries supported by the connected Archon node.', EmptySchema, async () => runtime.node.listRegistries());
+
+    registerTool(server, 'archon_list_ids', 'List IDs in the local Keymaster wallet.', EmptySchema, async () => requireKeymaster(runtime).listIds());
+    registerTool(server, 'archon_get_current_id', 'Get the current local Keymaster wallet ID name.', EmptySchema, async () => requireKeymaster(runtime).getCurrentId());
+    registerTool(server, 'archon_use_id', 'Set the current local Keymaster wallet ID name.', z.object({ name: z.string() }), async ({ name }) => requireKeymaster(runtime).setCurrentId(name), mutating);
+    registerTool(
+        server,
+        'archon_create_id',
+        'Create a new local Keymaster wallet ID.',
+        z.object({ name: z.string(), registry: z.string().optional() }),
+        async ({ name, registry }) => requireKeymaster(runtime).createId(name, compactOptions({ registry })),
+        mutating
+    );
+    registerTool(
+        server,
+        'archon_resolve_did',
+        'Resolve a DID or DID-like Archon identifier.',
+        z.object({ did: z.string() }).merge(ResolveOptionsSchema),
+        async ({ did, ...options }) => requireKeymaster(runtime).resolveDID(did, compactOptions(options))
+    );
+    registerTool(
+        server,
+        'archon_resolve_id',
+        'Resolve a local ID name, alias, DID, or the current ID when id is omitted.',
+        z.object({ id: z.string().optional() }).merge(ResolveOptionsSchema),
+        async ({ id, ...options }) => {
+            const keymaster = requireKeymaster(runtime);
+            const resolvedId = id ?? await keymaster.getCurrentId();
+            if (!resolvedId) {
+                throw new Error('No current ID');
+            }
+            return keymaster.resolveDID(resolvedId, compactOptions(options));
+        }
+    );
+
+    registerTool(server, 'archon_list_aliases', 'List DID aliases in the local Keymaster wallet.', EmptySchema, async () => requireKeymaster(runtime).listAliases());
+    registerTool(server, 'archon_add_alias', 'Add a DID alias to the local Keymaster wallet.', z.object({ alias: z.string(), did: z.string() }), async ({ alias, did }) => requireKeymaster(runtime).addAlias(alias, did), mutating);
+    registerTool(server, 'archon_get_alias', 'Get the DID assigned to a local alias.', z.object({ alias: z.string() }), async ({ alias }) => requireKeymaster(runtime).getAlias(alias));
+    registerTool(server, 'archon_remove_alias', 'Remove a DID alias from the local Keymaster wallet.', z.object({ alias: z.string() }), async ({ alias }) => requireKeymaster(runtime).removeAlias(alias), mutating);
+
+    registerTool(server, 'archon_list_addresses', 'List wallet addresses claimed through Herald domains.', EmptySchema, async () => requireKeymaster(runtime).listAddresses());
+    registerTool(server, 'archon_check_address', 'Check whether a Herald address is available.', z.object({ address: z.string() }), async ({ address }) => requireKeymaster(runtime).checkAddress(address));
+    registerTool(server, 'archon_add_address', 'Claim a Herald address for the current ID.', z.object({ address: z.string() }), async ({ address }) => requireKeymaster(runtime).addAddress(address), mutating);
+    registerTool(server, 'archon_remove_address', 'Remove a Herald address from the current ID.', z.object({ address: z.string() }), async ({ address }) => requireKeymaster(runtime).removeAddress(address), mutating);
+    registerTool(server, 'archon_publish_address', 'Publish a stored Herald address on a DID document.', z.object({ address: z.string().optional(), id: z.string().optional() }), async ({ address, id }) => requireKeymaster(runtime).publishAddress(address, id), mutating);
+    registerTool(server, 'archon_unpublish_address', 'Remove a published Herald address from a DID document.', z.object({ id: z.string().optional() }), async ({ id }) => requireKeymaster(runtime).unpublishAddress(id), mutating);
+
+    registerTool(server, 'archon_list_assets', 'List assets owned by the current local ID.', EmptySchema, async () => requireKeymaster(runtime).listAssets());
+    registerTool(
+        server,
+        'archon_create_asset_json',
+        'Create a JSON asset DID from inline JSON data.',
+        z.object({ data: JsonObjectSchema }).merge(AssetOptionsSchema),
+        async ({ data, ...options }) => requireKeymaster(runtime).createAsset(data, compactOptions(options)),
+        mutating
+    );
+    registerTool(
+        server,
+        'archon_get_asset',
+        'Resolve an asset by local name, alias, or DID.',
+        z.object({ id: z.string() }).merge(ResolveOptionsSchema),
+        async ({ id, ...options }) => requireKeymaster(runtime).resolveAsset(id, compactOptions(options))
+    );
+    registerTool(
+        server,
+        'archon_update_asset_json',
+        'Merge JSON object data into an existing asset.',
+        z.object({ id: z.string(), data: JsonObjectSchema }),
+        async ({ id, data }) => requireKeymaster(runtime).mergeData(id, data),
+        mutating
+    );
+    registerTool(server, 'archon_transfer_asset', 'Transfer an asset to a new controller DID.', z.object({ id: z.string(), controller: z.string() }), async ({ id, controller }) => requireKeymaster(runtime).transferAsset(id, controller), mutating);
+}
+
+export const testExports = {
+    fail,
+    ok,
+    requireKeymaster,
+    schemas: {
+        EmptySchema,
+        ResolveOptionsSchema: ResolveOptionsSchema as ZodTypeAny,
+        JsonObjectSchema: JsonObjectSchema as ZodTypeAny,
+        AssetOptionsSchema: AssetOptionsSchema as ZodTypeAny,
+    },
+};

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "isolatedModules": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tests/mcp-server/config.test.ts
+++ b/tests/mcp-server/config.test.ts
@@ -9,7 +9,7 @@ describe('mcp server config', () => {
         const config = loadConfig({});
 
         expect(config).toStrictEqual({
-            nodeUrl: 'http://localhost:4224',
+            nodeUrl: 'https://archon.technology',
             walletType: 'json',
             walletPath: './wallet.json',
             passphrase: undefined,
@@ -40,7 +40,7 @@ describe('mcp server config', () => {
             ARCHON_KEYMASTER_URL: 'http://keymaster.example',
         });
 
-        expect(config.nodeUrl).toBe('http://localhost:4224');
+        expect(config.nodeUrl).toBe('https://archon.technology');
         expect(config).not.toHaveProperty('keymasterUrl');
     });
 

--- a/tests/mcp-server/config.test.ts
+++ b/tests/mcp-server/config.test.ts
@@ -1,4 +1,5 @@
-import { createWallet, loadConfig, walletLocation } from '@didcid/mcp-server';
+import { createArchonRuntime, createWallet, loadConfig, walletLocation } from '@didcid/mcp-server';
+import { jest } from '@jest/globals';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -84,5 +85,23 @@ describe('mcp server config', () => {
         expect(fs.existsSync(walletPath)).toBe(true);
         expect(fs.existsSync(path.join('data', walletPath))).toBe(false);
         fs.rmSync(directory, { recursive: true, force: true });
+    });
+
+    it('creates runtime without blocking startup or writing to stdout', async () => {
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        const runtime = await createArchonRuntime({
+            nodeUrl: 'http://127.0.0.1:1',
+            walletType: 'json',
+            walletPath: './wallet.json',
+            passphrase: undefined,
+            defaultRegistry: undefined,
+            readOnly: false,
+        });
+
+        expect(runtime.node.url).toBe('http://127.0.0.1:1');
+        expect(runtime.keymaster).toBeUndefined();
+        expect(logSpy).not.toHaveBeenCalled();
+
+        logSpy.mockRestore();
     });
 });

--- a/tests/mcp-server/config.test.ts
+++ b/tests/mcp-server/config.test.ts
@@ -1,0 +1,66 @@
+import { loadConfig, walletLocation } from '../../packages/mcp-server/src/config';
+
+describe('mcp server config', () => {
+    it('uses Keymaster CLI compatible defaults', () => {
+        const config = loadConfig({});
+
+        expect(config).toStrictEqual({
+            nodeUrl: 'http://localhost:4224',
+            walletType: 'json',
+            walletPath: './wallet.json',
+            passphrase: undefined,
+            defaultRegistry: undefined,
+            readOnly: false,
+        });
+    });
+
+    it('uses ARCHON_NODE_URL before legacy ARCHON_GATEKEEPER_URL', () => {
+        const config = loadConfig({
+            ARCHON_NODE_URL: 'http://node.example',
+            ARCHON_GATEKEEPER_URL: 'http://gatekeeper.example',
+        });
+
+        expect(config.nodeUrl).toBe('http://node.example');
+    });
+
+    it('falls back to ARCHON_GATEKEEPER_URL when ARCHON_NODE_URL is unset', () => {
+        const config = loadConfig({
+            ARCHON_GATEKEEPER_URL: 'http://gatekeeper.example',
+        });
+
+        expect(config.nodeUrl).toBe('http://gatekeeper.example');
+    });
+
+    it('does not use ARCHON_KEYMASTER_URL', () => {
+        const config = loadConfig({
+            ARCHON_KEYMASTER_URL: 'http://keymaster.example',
+        });
+
+        expect(config.nodeUrl).toBe('http://localhost:4224');
+        expect(config).not.toHaveProperty('keymasterUrl');
+    });
+
+    it('parses wallet and read-only settings', () => {
+        const config = loadConfig({
+            ARCHON_WALLET_TYPE: 'sqlite',
+            ARCHON_WALLET_PATH: '/tmp/archon/wallet.db',
+            ARCHON_PASSPHRASE: 'secret',
+            ARCHON_DEFAULT_REGISTRY: 'BTC:mainnet',
+            ARCHON_MCP_READ_ONLY: 'true',
+        });
+
+        expect(config.walletType).toBe('sqlite');
+        expect(config.walletPath).toBe('/tmp/archon/wallet.db');
+        expect(config.passphrase).toBe('secret');
+        expect(config.defaultRegistry).toBe('BTC:mainnet');
+        expect(config.readOnly).toBe(true);
+        expect(walletLocation(config.walletPath)).toStrictEqual({
+            directory: '/tmp/archon',
+            file: 'wallet.db',
+        });
+    });
+
+    it('rejects unsupported wallet types', () => {
+        expect(() => loadConfig({ ARCHON_WALLET_TYPE: 'mongo' })).toThrow('Unsupported ARCHON_WALLET_TYPE');
+    });
+});

--- a/tests/mcp-server/config.test.ts
+++ b/tests/mcp-server/config.test.ts
@@ -1,4 +1,8 @@
 import { loadConfig, walletLocation } from '../../packages/mcp-server/src/config';
+import { createWallet } from '../../packages/mcp-server/src/runtime';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 describe('mcp server config', () => {
     it('uses Keymaster CLI compatible defaults', () => {
@@ -62,5 +66,24 @@ describe('mcp server config', () => {
 
     it('rejects unsupported wallet types', () => {
         expect(() => loadConfig({ ARCHON_WALLET_TYPE: 'mongo' })).toThrow('Unsupported ARCHON_WALLET_TYPE');
+    });
+
+    it('creates sqlite wallets at ARCHON_WALLET_PATH instead of under default data folder', async () => {
+        const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'archon-mcp-wallet-'));
+        const walletPath = path.join(directory, 'wallet.db');
+        const wallet = await createWallet({
+            nodeUrl: 'http://localhost:4224',
+            walletType: 'sqlite',
+            walletPath,
+            passphrase: 'secret',
+            defaultRegistry: undefined,
+            readOnly: false,
+        }) as { disconnect?: () => Promise<void> };
+
+        await wallet.disconnect?.();
+
+        expect(fs.existsSync(walletPath)).toBe(true);
+        expect(fs.existsSync(path.join('data', walletPath))).toBe(false);
+        fs.rmSync(directory, { recursive: true, force: true });
     });
 });

--- a/tests/mcp-server/config.test.ts
+++ b/tests/mcp-server/config.test.ts
@@ -1,5 +1,4 @@
-import { loadConfig, walletLocation } from '../../packages/mcp-server/src/config';
-import { createWallet } from '../../packages/mcp-server/src/runtime';
+import { createWallet, loadConfig, walletLocation } from '@didcid/mcp-server';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';

--- a/tests/mcp-server/import.test.ts
+++ b/tests/mcp-server/import.test.ts
@@ -7,7 +7,7 @@ describe('mcp server package import', () => {
         }) as never);
         const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-        const module = await import('../../packages/mcp-server/src/index');
+        const module = await import('@didcid/mcp-server');
 
         expect(module.main).toBeInstanceOf(Function);
         expect(exitSpy).not.toHaveBeenCalled();

--- a/tests/mcp-server/import.test.ts
+++ b/tests/mcp-server/import.test.ts
@@ -1,0 +1,19 @@
+import { jest } from '@jest/globals';
+
+describe('mcp server package import', () => {
+    it('does not start stdio or exit when importing the library entrypoint', async () => {
+        const exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {
+            throw new Error('process.exit should not be called');
+        }) as never);
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const module = await import('../../packages/mcp-server/src/index');
+
+        expect(module.main).toBeInstanceOf(Function);
+        expect(exitSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+
+        exitSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+});

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -1,0 +1,182 @@
+import { jest } from '@jest/globals';
+import { registerArchonTools } from '../../packages/mcp-server/src/tools';
+import { McpServerConfig } from '../../packages/mcp-server/src/config';
+
+type ToolHandler = (args?: unknown) => Promise<any>;
+
+class FakeServer {
+    tools = new Map<string, { config: any; handler: ToolHandler }>();
+
+    registerTool(name: string, config: any, handler: ToolHandler) {
+        this.tools.set(name, { config, handler });
+    }
+}
+
+const baseConfig: McpServerConfig = {
+    nodeUrl: 'http://localhost:4224',
+    walletType: 'json',
+    walletPath: './wallet.json',
+    passphrase: 'secret',
+    defaultRegistry: undefined,
+    readOnly: false,
+};
+
+function parseToolResult(response: any) {
+    return JSON.parse(response.content[0].text);
+}
+
+function mockRuntime(overrides: Record<string, unknown> = {}) {
+    const keymaster = {
+        listIds: jest.fn().mockResolvedValue(['alice']),
+        getCurrentId: jest.fn().mockResolvedValue('alice'),
+        setCurrentId: jest.fn().mockResolvedValue(true),
+        createId: jest.fn().mockResolvedValue('did:cid:new'),
+        resolveDID: jest.fn().mockResolvedValue({ didDocument: { id: 'did:cid:alice' } }),
+        listAliases: jest.fn().mockResolvedValue({ me: 'did:cid:alice' }),
+        addAlias: jest.fn().mockResolvedValue(true),
+        getAlias: jest.fn().mockResolvedValue('did:cid:alice'),
+        removeAlias: jest.fn().mockResolvedValue(true),
+        listAddresses: jest.fn().mockResolvedValue({}),
+        checkAddress: jest.fn().mockResolvedValue({ available: true }),
+        addAddress: jest.fn().mockResolvedValue(true),
+        removeAddress: jest.fn().mockResolvedValue(true),
+        publishAddress: jest.fn().mockResolvedValue(true),
+        unpublishAddress: jest.fn().mockResolvedValue(true),
+        listAssets: jest.fn().mockResolvedValue(['asset']),
+        createAsset: jest.fn().mockResolvedValue('did:cid:asset'),
+        resolveAsset: jest.fn().mockResolvedValue({ hello: 'world' }),
+        mergeData: jest.fn().mockResolvedValue(true),
+        transferAsset: jest.fn().mockResolvedValue(true),
+        ...overrides,
+    };
+
+    return {
+        node: {
+            getVersion: jest.fn().mockResolvedValue({ version: '0.10.0', commit: 'abc123' }),
+            getStatus: jest.fn().mockResolvedValue({ ready: true }),
+            listRegistries: jest.fn().mockResolvedValue(['hyperswarm']),
+        },
+        keymaster,
+    };
+}
+
+describe('mcp server tools', () => {
+    it('registers the v1 tool surface', () => {
+        const server = new FakeServer();
+        registerArchonTools(server, mockRuntime() as any, baseConfig);
+
+        expect([...server.tools.keys()].sort()).toStrictEqual([
+            'archon_add_address',
+            'archon_add_alias',
+            'archon_check_address',
+            'archon_create_asset_json',
+            'archon_create_id',
+            'archon_get_alias',
+            'archon_get_asset',
+            'archon_get_current_id',
+            'archon_get_status',
+            'archon_get_version',
+            'archon_list_addresses',
+            'archon_list_aliases',
+            'archon_list_assets',
+            'archon_list_ids',
+            'archon_list_registries',
+            'archon_publish_address',
+            'archon_remove_address',
+            'archon_remove_alias',
+            'archon_resolve_did',
+            'archon_resolve_id',
+            'archon_transfer_asset',
+            'archon_unpublish_address',
+            'archon_update_asset_json',
+            'archon_use_id',
+        ]);
+    });
+
+    it('calls read tools and returns compact JSON payloads', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const response = await server.tools.get('archon_list_registries')!.handler({});
+
+        expect(parseToolResult(response)).toStrictEqual({ ok: true, result: ['hyperswarm'] });
+        expect(runtime.node.listRegistries).toHaveBeenCalledTimes(1);
+    });
+
+    it('blocks mutating tools in read-only mode', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, { ...baseConfig, readOnly: true });
+
+        const response = await server.tools.get('archon_create_id')!.handler({ name: 'alice' });
+
+        expect(parseToolResult(response)).toStrictEqual({
+            ok: false,
+            error: 'Tool disabled by ARCHON_MCP_READ_ONLY=true',
+        });
+        expect(runtime.keymaster.createId).not.toHaveBeenCalled();
+    });
+
+    it('returns a clear passphrase error for wallet-backed tools without keymaster runtime', async () => {
+        const server = new FakeServer();
+        registerArchonTools(server, { node: mockRuntime().node } as any, { ...baseConfig, passphrase: undefined });
+
+        const response = await server.tools.get('archon_list_ids')!.handler({});
+
+        expect(parseToolResult(response)).toStrictEqual({
+            ok: false,
+            error: 'ARCHON_PASSPHRASE is required for wallet-backed MCP tools',
+        });
+    });
+
+    it('validates required inputs', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const response = await server.tools.get('archon_create_id')!.handler({});
+        const result = parseToolResult(response);
+
+        expect(result.ok).toBe(false);
+        expect(result.error).toContain('Required');
+        expect(runtime.keymaster.createId).not.toHaveBeenCalled();
+    });
+
+    it('passes optional inputs to keymaster calls', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const response = await server.tools.get('archon_create_asset_json')!.handler({
+            data: { hello: 'world' },
+            alias: 'hello',
+            registry: 'hyperswarm',
+        });
+
+        expect(parseToolResult(response)).toStrictEqual({ ok: true, result: 'did:cid:asset' });
+        expect(runtime.keymaster.createAsset).toHaveBeenCalledWith(
+            { hello: 'world' },
+            { alias: 'hello', registry: 'hyperswarm' }
+        );
+    });
+
+    it('redacts secrets from tool errors', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime({
+            listIds: jest.fn().mockRejectedValue(
+                new Error('failed ARCHON_PASSPHRASE=secret https://user:pass@example.com/v2/api-token?api_key=123')
+            ),
+        });
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const response = await server.tools.get('archon_list_ids')!.handler({});
+        const result = parseToolResult(response);
+
+        expect(result.ok).toBe(false);
+        expect(result.error).toContain('ARCHON_PASSPHRASE=<redacted>');
+        expect(result.error).toContain('https://<redacted>@example.com/v2/<redacted>?api_key=<redacted>');
+        expect(result.error).not.toContain('secret');
+        expect(result.error).not.toContain('api-token');
+    });
+});

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -20,6 +20,36 @@ const baseConfig: McpServerConfig = {
     readOnly: false,
 };
 
+const mutatingTools = [
+    'archon_add_address',
+    'archon_add_alias',
+    'archon_create_asset_json',
+    'archon_create_id',
+    'archon_publish_address',
+    'archon_remove_address',
+    'archon_remove_alias',
+    'archon_transfer_asset',
+    'archon_unpublish_address',
+    'archon_update_asset_json',
+    'archon_use_id',
+];
+
+const readTools = [
+    'archon_check_address',
+    'archon_get_alias',
+    'archon_get_asset',
+    'archon_get_current_id',
+    'archon_get_status',
+    'archon_get_version',
+    'archon_list_addresses',
+    'archon_list_aliases',
+    'archon_list_assets',
+    'archon_list_ids',
+    'archon_list_registries',
+    'archon_resolve_did',
+    'archon_resolve_id',
+];
+
 function parseToolResult(response: any) {
     return JSON.parse(response.content[0].text);
 }
@@ -64,32 +94,7 @@ describe('mcp server tools', () => {
         const server = new FakeServer();
         registerArchonTools(server, mockRuntime() as any, baseConfig);
 
-        expect([...server.tools.keys()].sort()).toStrictEqual([
-            'archon_add_address',
-            'archon_add_alias',
-            'archon_check_address',
-            'archon_create_asset_json',
-            'archon_create_id',
-            'archon_get_alias',
-            'archon_get_asset',
-            'archon_get_current_id',
-            'archon_get_status',
-            'archon_get_version',
-            'archon_list_addresses',
-            'archon_list_aliases',
-            'archon_list_assets',
-            'archon_list_ids',
-            'archon_list_registries',
-            'archon_publish_address',
-            'archon_remove_address',
-            'archon_remove_alias',
-            'archon_resolve_did',
-            'archon_resolve_id',
-            'archon_transfer_asset',
-            'archon_unpublish_address',
-            'archon_update_asset_json',
-            'archon_use_id',
-        ]);
+        expect([...server.tools.keys()].sort()).toStrictEqual([...mutatingTools, ...readTools].sort());
     });
 
     it('calls read tools and returns compact JSON payloads', async () => {
@@ -103,17 +108,15 @@ describe('mcp server tools', () => {
         expect(runtime.node.listRegistries).toHaveBeenCalledTimes(1);
     });
 
-    it('blocks mutating tools in read-only mode', async () => {
+    it('does not advertise mutating tools in read-only mode', () => {
         const server = new FakeServer();
         const runtime = mockRuntime();
         registerArchonTools(server, runtime as any, { ...baseConfig, readOnly: true });
 
-        const response = await server.tools.get('archon_create_id')!.handler({ name: 'alice' });
-
-        expect(parseToolResult(response)).toStrictEqual({
-            ok: false,
-            error: 'Tool disabled by ARCHON_MCP_READ_ONLY=true',
-        });
+        expect([...server.tools.keys()].sort()).toStrictEqual(readTools.sort());
+        for (const tool of mutatingTools) {
+            expect(server.tools.has(tool)).toBe(false);
+        }
         expect(runtime.keymaster.createId).not.toHaveBeenCalled();
     });
 
@@ -164,7 +167,7 @@ describe('mcp server tools', () => {
         const server = new FakeServer();
         const runtime = mockRuntime({
             listIds: jest.fn().mockRejectedValue(
-                new Error('failed ARCHON_PASSPHRASE=secret https://user:pass@example.com/v2/api-token?api_key=123')
+                new Error('failed ARCHON_PASSPHRASE="my secret phrase" https://user:pass@bitcoin-mainnet.g.alchemy.com/v3/api-token?api_key=123')
             ),
         });
         registerArchonTools(server, runtime as any, baseConfig);
@@ -174,8 +177,9 @@ describe('mcp server tools', () => {
 
         expect(result.ok).toBe(false);
         expect(result.error).toContain('ARCHON_PASSPHRASE=<redacted>');
-        expect(result.error).toContain('https://<redacted>@example.com/v2/<redacted>?api_key=<redacted>');
+        expect(result.error).toContain('https://<redacted>@bitcoin-mainnet.g.alchemy.com/v3/<redacted>?api_key=<redacted>');
         expect(result.error).not.toContain('secret');
+        expect(result.error).not.toContain('phrase');
         expect(result.error).not.toContain('api-token');
     });
 });

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -1,6 +1,5 @@
 import { jest } from '@jest/globals';
-import { registerArchonTools } from '../../packages/mcp-server/src/tools';
-import { McpServerConfig } from '../../packages/mcp-server/src/config';
+import { registerArchonTools, McpServerConfig } from '@didcid/mcp-server';
 
 type ToolHandler = (args?: unknown) => Promise<any>;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -69,6 +69,9 @@
       ],
       "@didcid/keymaster/wallet/*": [
         "packages/keymaster/src/db/*"
+      ],
+      "@didcid/mcp-server": [
+        "packages/mcp-server/src/index.ts"
       ]
     }
   },


### PR DESCRIPTION
## Summary

Adds `@didcid/mcp-server`, a local stdio MCP server for Archon wallet-agent workflows.

The server instantiates the Keymaster library directly with the same local wallet model as the Keymaster CLI, and connects to the Archon node through Gatekeeper/Drawbridge. It intentionally does not use `ARCHON_KEYMASTER_URL` in v1.

## Changes

- Add publishable workspace package `packages/mcp-server` with bin `archon-mcp-server`.
- Use stable `@modelcontextprotocol/sdk` v1 package.
- Add local runtime config:
  - `ARCHON_NODE_URL` / `ARCHON_GATEKEEPER_URL`
  - `ARCHON_WALLET_TYPE=json|sqlite`
  - `ARCHON_WALLET_PATH`
  - `ARCHON_PASSPHRASE`
  - `ARCHON_DEFAULT_REGISTRY`
  - `ARCHON_MCP_READ_ONLY=true`
- Register 24 stdio MCP tools for health, identities, aliases, Herald addresses, and JSON assets.
- Block mutating tools in read-only mode.
- Redact passphrases, API keys, tokens, and credentialed URLs from tool errors.
- Add README usage and MCP client config examples.
- Update Herald client package link to `@didcid/mcp-server`.

## Validation

- `npm run build -w @didcid/mcp-server`
- `node --experimental-vm-modules node_modules/.bin/jest tests/mcp-server --runInBand --verbose`
- `npx eslint packages/mcp-server/src tests/mcp-server apps/herald-client/src/App.tsx`
- `npm run build`
- `npm pack --dry-run -w @didcid/mcp-server`
- Stdio MCP smoke:
  - started `packages/mcp-server/dist/index.js`
  - `tools/list` returned 24 tools
  - `archon_list_ids` returned the expected missing-passphrase error when no `ARCHON_PASSPHRASE` was set
