### PR TITLE
feat: expand MCP server toward Keymaster CLI parity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26364,7 +26364,7 @@
     },
     "packages/browser-hdkey": {
       "name": "@didcid/browser-hdkey",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.3.3",
@@ -26411,10 +26411,10 @@
     },
     "packages/cipher": {
       "name": "@didcid/cipher",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "license": "MIT",
       "dependencies": {
-        "@didcid/browser-hdkey": "^0.1.13",
+        "@didcid/browser-hdkey": "^0.1.14",
         "@noble/ciphers": "^0.4.1",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^1.3.3",
@@ -26464,7 +26464,7 @@
     },
     "packages/common": {
       "name": "@didcid/common",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.3",
@@ -26474,12 +26474,12 @@
     },
     "packages/gatekeeper": {
       "name": "@didcid/gatekeeper",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "license": "MIT",
       "dependencies": {
-        "@didcid/cipher": "^0.2.11",
-        "@didcid/common": "^0.1.13",
-        "@didcid/ipfs": "^0.1.13",
+        "@didcid/cipher": "^0.2.12",
+        "@didcid/common": "^0.1.14",
+        "@didcid/ipfs": "^0.1.14",
         "axios": "^1.17.0",
         "canonicalize": "^2.0.0",
         "dotenv": "^16.4.5",
@@ -26494,10 +26494,10 @@
     },
     "packages/ipfs": {
       "name": "@didcid/ipfs",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MIT",
       "dependencies": {
-        "@didcid/common": "^0.1.13",
+        "@didcid/common": "^0.1.14",
         "@helia/json": "^4.0.3",
         "@helia/unixfs": "^5.0.0",
         "axios": "^1.17.0",
@@ -26513,12 +26513,12 @@
     },
     "packages/keymaster": {
       "name": "@didcid/keymaster",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "license": "MIT",
       "dependencies": {
-        "@didcid/cipher": "^0.2.11",
-        "@didcid/common": "^0.1.13",
-        "@didcid/gatekeeper": "^0.4.11",
+        "@didcid/cipher": "^0.2.12",
+        "@didcid/common": "^0.1.14",
+        "@didcid/gatekeeper": "^0.4.12",
         "axios": "^1.17.0",
         "commander": "^11.1.0",
         "dotenv": "^16.4.5",
@@ -26546,12 +26546,12 @@
     },
     "packages/mcp-server": {
       "name": "@didcid/mcp-server",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "@didcid/cipher": "^0.2.11",
-        "@didcid/gatekeeper": "^0.4.11",
-        "@didcid/keymaster": "^0.4.11",
+        "@didcid/cipher": "^0.2.12",
+        "@didcid/gatekeeper": "^0.4.12",
+        "@didcid/keymaster": "^0.4.12",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^16.4.5",
         "zod": "^3.25.76"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26364,7 +26364,7 @@
     },
     "packages/browser-hdkey": {
       "name": "@didcid/browser-hdkey",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.3.3",
@@ -26411,10 +26411,10 @@
     },
     "packages/cipher": {
       "name": "@didcid/cipher",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "license": "MIT",
       "dependencies": {
-        "@didcid/browser-hdkey": "^0.1.14",
+        "@didcid/browser-hdkey": "^0.1.15",
         "@noble/ciphers": "^0.4.1",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^1.3.3",
@@ -26464,7 +26464,7 @@
     },
     "packages/common": {
       "name": "@didcid/common",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.3",
@@ -26474,12 +26474,12 @@
     },
     "packages/gatekeeper": {
       "name": "@didcid/gatekeeper",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "license": "MIT",
       "dependencies": {
-        "@didcid/cipher": "^0.2.12",
-        "@didcid/common": "^0.1.14",
-        "@didcid/ipfs": "^0.1.14",
+        "@didcid/cipher": "^0.2.13",
+        "@didcid/common": "^0.1.15",
+        "@didcid/ipfs": "^0.1.15",
         "axios": "^1.17.0",
         "canonicalize": "^2.0.0",
         "dotenv": "^16.4.5",
@@ -26494,10 +26494,10 @@
     },
     "packages/ipfs": {
       "name": "@didcid/ipfs",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "MIT",
       "dependencies": {
-        "@didcid/common": "^0.1.14",
+        "@didcid/common": "^0.1.15",
         "@helia/json": "^4.0.3",
         "@helia/unixfs": "^5.0.0",
         "axios": "^1.17.0",
@@ -26513,12 +26513,12 @@
     },
     "packages/keymaster": {
       "name": "@didcid/keymaster",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "license": "MIT",
       "dependencies": {
-        "@didcid/cipher": "^0.2.12",
-        "@didcid/common": "^0.1.14",
-        "@didcid/gatekeeper": "^0.4.12",
+        "@didcid/cipher": "^0.2.13",
+        "@didcid/common": "^0.1.15",
+        "@didcid/gatekeeper": "^0.4.13",
         "axios": "^1.17.0",
         "commander": "^11.1.0",
         "dotenv": "^16.4.5",
@@ -26546,12 +26546,12 @@
     },
     "packages/mcp-server": {
       "name": "@didcid/mcp-server",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@didcid/cipher": "^0.2.12",
-        "@didcid/gatekeeper": "^0.4.12",
-        "@didcid/keymaster": "^0.4.12",
+        "@didcid/cipher": "^0.2.13",
+        "@didcid/gatekeeper": "^0.4.13",
+        "@didcid/keymaster": "^0.4.13",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^16.4.5",
         "zod": "^3.25.76"

--- a/packages/browser-hdkey/CHANGELOG.md
+++ b/packages/browser-hdkey/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.14](https://github.com/archetech/archon/compare/@didcid/browser-hdkey@0.1.11...@didcid/browser-hdkey@0.1.14) (2026-06-06)
+
+**Note:** Version bump only for package @didcid/browser-hdkey
+
+
+
+
+
 ## [0.1.13](https://github.com/archetech/archon/compare/@didcid/browser-hdkey@0.1.12...@didcid/browser-hdkey@0.1.13) (2026-05-29)
 
 **Note:** Version bump only for package @didcid/browser-hdkey

--- a/packages/browser-hdkey/CHANGELOG.md
+++ b/packages/browser-hdkey/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.15](https://github.com/archetech/archon/compare/@didcid/browser-hdkey@0.1.14...@didcid/browser-hdkey@0.1.15) (2026-06-06)
+
+**Note:** Version bump only for package @didcid/browser-hdkey
+
+
+
+
+
 ## [0.1.14](https://github.com/archetech/archon/compare/@didcid/browser-hdkey@0.1.11...@didcid/browser-hdkey@0.1.14) (2026-06-06)
 
 **Note:** Version bump only for package @didcid/browser-hdkey

--- a/packages/browser-hdkey/package.json
+++ b/packages/browser-hdkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/browser-hdkey",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Bitcoin BIP32 hierarchical deterministic keys",
   "main": "lib/hdkey.js",
   "types": "lib/hdkey.d.ts",

--- a/packages/browser-hdkey/package.json
+++ b/packages/browser-hdkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/browser-hdkey",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Bitcoin BIP32 hierarchical deterministic keys",
   "main": "lib/hdkey.js",
   "types": "lib/hdkey.d.ts",

--- a/packages/cipher/CHANGELOG.md
+++ b/packages/cipher/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.12](https://github.com/archetech/archon/compare/@didcid/cipher@0.1.3...@didcid/cipher@0.2.12) (2026-06-06)
+
+
+### Bug Fixes
+
+* Incorrect passphrase on react-wallet ([#97](https://github.com/archetech/archon/issues/97)) ([5ce0523](https://github.com/archetech/archon/commit/5ce05238ecb2dd6e5a4a647ab0429a9cf9bdb6a4))
+
+
+### Features
+
+* Add nostr support ([#133](https://github.com/archetech/archon/issues/133)) ([3591d62](https://github.com/archetech/archon/commit/3591d6281bf29c5e98e761e7ad56a7abf78a4106)), closes [#87](https://github.com/archetech/archon/issues/87)
+* Adopt W3C JWE standard for encryption ([#90](https://github.com/archetech/archon/issues/90)) ([2321ca7](https://github.com/archetech/archon/commit/2321ca7fd6e074bac1f4b8fa7c12e58d4b45b181))
+* Store imported nostr nsec in wallet ([#397](https://github.com/archetech/archon/issues/397)) ([7a0a919](https://github.com/archetech/archon/commit/7a0a919f34ba9161dce25eaa528dccf3443840a4))
+
+
+
+
+
 ## [0.2.11](https://github.com/archetech/archon/compare/@didcid/cipher@0.2.10...@didcid/cipher@0.2.11) (2026-05-29)
 
 **Note:** Version bump only for package @didcid/cipher

--- a/packages/cipher/CHANGELOG.md
+++ b/packages/cipher/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.13](https://github.com/archetech/archon/compare/@didcid/cipher@0.2.12...@didcid/cipher@0.2.13) (2026-06-06)
+
+**Note:** Version bump only for package @didcid/cipher
+
+
+
+
+
 ## [0.2.12](https://github.com/archetech/archon/compare/@didcid/cipher@0.1.3...@didcid/cipher@0.2.12) (2026-06-06)
 
 

--- a/packages/cipher/package.json
+++ b/packages/cipher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/cipher",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Archon cipher lib",
   "type": "module",
   "main": "./dist/cjs/cipher-web.cjs",
@@ -75,7 +75,7 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/browser-hdkey": "^0.1.14",
+    "@didcid/browser-hdkey": "^0.1.15",
     "@noble/ciphers": "^0.4.1",
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^1.3.3",

--- a/packages/cipher/package.json
+++ b/packages/cipher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/cipher",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Archon cipher lib",
   "type": "module",
   "main": "./dist/cjs/cipher-web.cjs",
@@ -75,7 +75,7 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/browser-hdkey": "^0.1.13",
+    "@didcid/browser-hdkey": "^0.1.14",
     "@noble/ciphers": "^0.4.1",
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^1.3.3",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.15](https://github.com/archetech/archon/compare/@didcid/common@0.1.14...@didcid/common@0.1.15) (2026-06-06)
+
+**Note:** Version bump only for package @didcid/common
+
+
+
+
+
 ## [0.1.14](https://github.com/archetech/archon/compare/@didcid/common@0.1.3...@didcid/common@0.1.14) (2026-06-06)
 
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.14](https://github.com/archetech/archon/compare/@didcid/common@0.1.3...@didcid/common@0.1.14) (2026-06-06)
+
+
+### Features
+
+* Add Lightning wallet support via LNbits integration ([#136](https://github.com/archetech/archon/issues/136)) ([#140](https://github.com/archetech/archon/issues/140)) ([4d99d5a](https://github.com/archetech/archon/commit/4d99d5ab8da20897e5aecf8557b271c3b1779d45))
+
+
+
+
+
 ## [0.1.13](https://github.com/archetech/archon/compare/@didcid/common@0.1.12...@didcid/common@0.1.13) (2026-05-29)
 
 **Note:** Version bump only for package @didcid/common

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/common",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Archon common utilities",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/common",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Archon common utilities",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/gatekeeper/CHANGELOG.md
+++ b/packages/gatekeeper/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.13](https://github.com/archetech/archon/compare/@didcid/gatekeeper@0.4.12...@didcid/gatekeeper@0.4.13) (2026-06-06)
+
+**Note:** Version bump only for package @didcid/gatekeeper
+
+
+
+
+
 ## [0.4.12](https://github.com/archetech/archon/compare/@didcid/gatekeeper@0.2.0...@didcid/gatekeeper@0.4.12) (2026-06-06)
 
 

--- a/packages/gatekeeper/CHANGELOG.md
+++ b/packages/gatekeeper/CHANGELOG.md
@@ -3,6 +3,49 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.12](https://github.com/archetech/archon/compare/@didcid/gatekeeper@0.2.0...@didcid/gatekeeper@0.4.12) (2026-06-06)
+
+
+### Features
+
+* add Filecoin storage mediator ([#555](https://github.com/archetech/archon/issues/555)) ([50e1265](https://github.com/archetech/archon/commit/50e1265f939de089f22a4d0bea9b7745ef3eb8e1))
+* Allow pin as a DID registry ([#561](https://github.com/archetech/archon/issues/561)) ([fb90d66](https://github.com/archetech/archon/commit/fb90d6664ec9cf8a56f2a207a6652c6753b23fe8))
+
+
+
+# 0.8.0 (2026-05-15)
+
+
+### Bug Fixes
+
+* Better error message for missing wallet ([#53](https://github.com/archetech/archon/issues/53)) ([1a8dad0](https://github.com/archetech/archon/commit/1a8dad05a8a1eafb5d89e88224b913657d1f0530))
+* getVaultItem failed for small vault items ([#45](https://github.com/archetech/archon/issues/45)) ([a6fdd52](https://github.com/archetech/archon/commit/a6fdd5233ae2013879b28252d322e392211a59c2))
+* Show failed lightning payments ([#376](https://github.com/archetech/archon/issues/376)) ([7d3b24f](https://github.com/archetech/archon/commit/7d3b24faff2cf8a1800143079a3367f2cf1e873e))
+
+
+### Features
+
+* Add ARCHON_ADMIN_API_KEY support to CLI docker container ([#128](https://github.com/archetech/archon/issues/128)) ([#131](https://github.com/archetech/archon/issues/131)) ([8526717](https://github.com/archetech/archon/commit/8526717c50b6fb71b3812fe9cd7867051d134c53))
+* Add change-registry command to change a DID's registry ([#194](https://github.com/archetech/archon/issues/194)) ([0d258de](https://github.com/archetech/archon/commit/0d258def464394a9c49b6d07f7681c35cfda5721)), closes [#153](https://github.com/archetech/archon/issues/153)
+* Add decodeLightningInvoice to Keymaster ([#146](https://github.com/archetech/archon/issues/146)) ([2ed4139](https://github.com/archetech/archon/commit/2ed4139f3ae548b21ca509877f3b05d3ce68f1b6)), closes [#145](https://github.com/archetech/archon/issues/145)
+* Add getVersion() to KeymasterClient ([#219](https://github.com/archetech/archon/issues/219)) ([f06d89c](https://github.com/archetech/archon/commit/f06d89c8047d60c00611eef4b2a577b54ca6d6a6)), closes [#205](https://github.com/archetech/archon/issues/205)
+* Add Lightning tab to web clients ([#148](https://github.com/archetech/archon/issues/148)) ([73ed52e](https://github.com/archetech/archon/commit/73ed52ea0da92b391fa53a92ba2c671f91912bbd)), closes [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147)
+* Add Lightning wallet support via LNbits integration ([#136](https://github.com/archetech/archon/issues/136)) ([#140](https://github.com/archetech/archon/issues/140)) ([4d99d5a](https://github.com/archetech/archon/commit/4d99d5ab8da20897e5aecf8557b271c3b1779d45))
+* Add Lightning Zap tab and Publish toggle to web clients ([#161](https://github.com/archetech/archon/issues/161)) ([6357451](https://github.com/archetech/archon/commit/6357451083f464120b01348c889deb5c80bed05f)), closes [#159](https://github.com/archetech/archon/issues/159)
+* add zcash wallet and mediator services ([#517](https://github.com/archetech/archon/issues/517)) ([d898fab](https://github.com/archetech/archon/commit/d898fab47f71cdc4c718d977b007b51410da8b19))
+* Added update-credential to agent CLI ([#66](https://github.com/archetech/archon/issues/66)) ([002fce1](https://github.com/archetech/archon/commit/002fce1dcf2edb8c621eb77501cdf0abeed90484))
+* Adds CLI to keymaster package ([#39](https://github.com/archetech/archon/issues/39)) ([894ce73](https://github.com/archetech/archon/commit/894ce732f5beaca37bb90ace6b760b8e80aba3e9))
+* Adds get-property command to CLI ([#73](https://github.com/archetech/archon/issues/73)) ([310d7fe](https://github.com/archetech/archon/commit/310d7fe5d95976b8ca37ec12b7d6dc16cc52f65a))
+* Display Lightning payment history ([#164](https://github.com/archetech/archon/issues/164)) ([#165](https://github.com/archetech/archon/issues/165)) ([c8ec283](https://github.com/archetech/archon/commit/c8ec2835b0cde542c71e02fdb7fc55c3d46a81d1))
+* Lightning zap — send sats to a DID ([#155](https://github.com/archetech/archon/issues/155)) ([39d7ee3](https://github.com/archetech/archon/commit/39d7ee3242973ace494e45f636ca12fe78d911ab)), closes [#154](https://github.com/archetech/archon/issues/154)
+* move lightning payment filtering to client with full state display ([#237](https://github.com/archetech/archon/issues/237)) ([0eee4c0](https://github.com/archetech/archon/commit/0eee4c0987513d689a2a4eec3b7b088556be53b2)), closes [#236](https://github.com/archetech/archon/issues/236)
+* stream large file uploads/downloads for multi-GB video support ([#238](https://github.com/archetech/archon/issues/238)) ([eca94a0](https://github.com/archetech/archon/commit/eca94a06c041849a181a5a072728b9fe0c22bfae)), closes [#208](https://github.com/archetech/archon/issues/208)
+* Support mainnet registries ([#34](https://github.com/archetech/archon/issues/34)) ([a206c9e](https://github.com/archetech/archon/commit/a206c9e24f29fabec45f3cb239b8ba88f0525e6d))
+
+
+
+
+
 ## [0.4.11](https://github.com/archetech/archon/compare/@didcid/gatekeeper@0.4.10...@didcid/gatekeeper@0.4.11) (2026-05-29)
 
 **Note:** Version bump only for package @didcid/gatekeeper

--- a/packages/gatekeeper/package.json
+++ b/packages/gatekeeper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/gatekeeper",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Archon Gatekeeper",
   "type": "module",
   "module": "./dist/esm/index.js",
@@ -114,9 +114,9 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/cipher": "^0.2.11",
-    "@didcid/common": "^0.1.13",
-    "@didcid/ipfs": "^0.1.13",
+    "@didcid/cipher": "^0.2.12",
+    "@didcid/common": "^0.1.14",
+    "@didcid/ipfs": "^0.1.14",
     "axios": "^1.17.0",
     "canonicalize": "^2.0.0",
     "dotenv": "^16.4.5",

--- a/packages/gatekeeper/package.json
+++ b/packages/gatekeeper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/gatekeeper",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Archon Gatekeeper",
   "type": "module",
   "module": "./dist/esm/index.js",
@@ -114,9 +114,9 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/cipher": "^0.2.12",
-    "@didcid/common": "^0.1.14",
-    "@didcid/ipfs": "^0.1.14",
+    "@didcid/cipher": "^0.2.13",
+    "@didcid/common": "^0.1.15",
+    "@didcid/ipfs": "^0.1.15",
     "axios": "^1.17.0",
     "canonicalize": "^2.0.0",
     "dotenv": "^16.4.5",

--- a/packages/ipfs/CHANGELOG.md
+++ b/packages/ipfs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.15](https://github.com/archetech/archon/compare/@didcid/ipfs@0.1.14...@didcid/ipfs@0.1.15) (2026-06-06)
+
+**Note:** Version bump only for package @didcid/ipfs
+
+
+
+
+
 ## [0.1.14](https://github.com/archetech/archon/compare/@didcid/ipfs@0.1.3...@didcid/ipfs@0.1.14) (2026-06-06)
 
 

--- a/packages/ipfs/CHANGELOG.md
+++ b/packages/ipfs/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.14](https://github.com/archetech/archon/compare/@didcid/ipfs@0.1.3...@didcid/ipfs@0.1.14) (2026-06-06)
+
+
+### Features
+
+* stream large file uploads/downloads for multi-GB video support ([#238](https://github.com/archetech/archon/issues/238)) ([eca94a0](https://github.com/archetech/archon/commit/eca94a06c041849a181a5a072728b9fe0c22bfae)), closes [#208](https://github.com/archetech/archon/issues/208)
+
+
+
+
+
 ## [0.1.13](https://github.com/archetech/archon/compare/@didcid/ipfs@0.1.12...@didcid/ipfs@0.1.13) (2026-05-29)
 
 **Note:** Version bump only for package @didcid/ipfs

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/ipfs",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Archon IPFS lib",
   "type": "module",
   "module": "./dist/esm/index.js",
@@ -74,7 +74,7 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/common": "^0.1.13",
+    "@didcid/common": "^0.1.14",
     "@helia/json": "^4.0.3",
     "@helia/unixfs": "^5.0.0",
     "axios": "^1.17.0",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/ipfs",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Archon IPFS lib",
   "type": "module",
   "module": "./dist/esm/index.js",
@@ -74,7 +74,7 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/common": "^0.1.14",
+    "@didcid/common": "^0.1.15",
     "@helia/json": "^4.0.3",
     "@helia/unixfs": "^5.0.0",
     "axios": "^1.17.0",

--- a/packages/keymaster/CHANGELOG.md
+++ b/packages/keymaster/CHANGELOG.md
@@ -3,6 +3,71 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.12](https://github.com/archetech/archon/compare/@didcid/keymaster@0.2.0...@didcid/keymaster@0.4.12) (2026-06-06)
+
+
+### Bug Fixes
+
+* Allow create-id to auto-create wallet ([#102](https://github.com/archetech/archon/issues/102)) ([#103](https://github.com/archetech/archon/issues/103)) ([bb6bc7a](https://github.com/archetech/archon/commit/bb6bc7a57d6bcfed679812b8489ab43ab9f10731)), closes [#53](https://github.com/archetech/archon/issues/53)
+* Better error message for missing wallet ([#53](https://github.com/archetech/archon/issues/53)) ([1a8dad0](https://github.com/archetech/archon/commit/1a8dad05a8a1eafb5d89e88224b913657d1f0530))
+* Check zap status in CLI ([#255](https://github.com/archetech/archon/issues/255)) ([634196a](https://github.com/archetech/archon/commit/634196a8e6a627bcf49b11a568be8a363eb18bc2))
+* Incorrect passphrase on react-wallet ([#97](https://github.com/archetech/archon/issues/97)) ([5ce0523](https://github.com/archetech/archon/commit/5ce05238ecb2dd6e5a4a647ab0429a9cf9bdb6a4))
+* send binary responses for image/file API routes ([#444](https://github.com/archetech/archon/issues/444)) ([3317c72](https://github.com/archetech/archon/commit/3317c7210f041fa84097a1a9efac377cb1942b00))
+* Show failed lightning payments ([#376](https://github.com/archetech/archon/issues/376)) ([7d3b24f](https://github.com/archetech/archon/commit/7d3b24faff2cf8a1800143079a3367f2cf1e873e))
+
+
+### Features
+
+* Add ARCHON_ADMIN_API_KEY support to CLI docker container ([#128](https://github.com/archetech/archon/issues/128)) ([#131](https://github.com/archetech/archon/issues/131)) ([8526717](https://github.com/archetech/archon/commit/8526717c50b6fb71b3812fe9cd7867051d134c53))
+* Add change-passphrase command ([#111](https://github.com/archetech/archon/issues/111)) ([#112](https://github.com/archetech/archon/issues/112)) ([b6b24bb](https://github.com/archetech/archon/commit/b6b24bb6c32da91edebcf85e1212420975da70ed))
+* Add change-registry command to change a DID's registry ([#194](https://github.com/archetech/archon/issues/194)) ([0d258de](https://github.com/archetech/archon/commit/0d258def464394a9c49b6d07f7681c35cfda5721)), closes [#153](https://github.com/archetech/archon/issues/153)
+* Add CLI command to list supported registries ([#576](https://github.com/archetech/archon/issues/576)) ([e3debcf](https://github.com/archetech/archon/commit/e3debcf9b24396f9edc498e4fa9765692e001fa6))
+* Add decodeLightningInvoice to Keymaster ([#146](https://github.com/archetech/archon/issues/146)) ([2ed4139](https://github.com/archetech/archon/commit/2ed4139f3ae548b21ca509877f3b05d3ce68f1b6)), closes [#145](https://github.com/archetech/archon/issues/145)
+* Add getVersion() to KeymasterClient ([#219](https://github.com/archetech/archon/issues/219)) ([f06d89c](https://github.com/archetech/archon/commit/f06d89c8047d60c00611eef4b2a577b54ca6d6a6)), closes [#205](https://github.com/archetech/archon/issues/205)
+* Add guided Keymaster installer ([#259](https://github.com/archetech/archon/issues/259)) ([8f139d4](https://github.com/archetech/archon/commit/8f139d4280adbe6f9575ad56f516d9814f04aea0))
+* Add keymaster address CLI commands ([#378](https://github.com/archetech/archon/issues/378)) ([35dc407](https://github.com/archetech/archon/commit/35dc407f6d6c45fd0b9293f31218667d7d212f33))
+* Add Lightning tab to web clients ([#148](https://github.com/archetech/archon/issues/148)) ([73ed52e](https://github.com/archetech/archon/commit/73ed52ea0da92b391fa53a92ba2c671f91912bbd)), closes [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147)
+* Add Lightning wallet support via LNbits integration ([#136](https://github.com/archetech/archon/issues/136)) ([#140](https://github.com/archetech/archon/issues/140)) ([4d99d5a](https://github.com/archetech/archon/commit/4d99d5ab8da20897e5aecf8557b271c3b1779d45))
+* Add nostr support ([#133](https://github.com/archetech/archon/issues/133)) ([3591d62](https://github.com/archetech/archon/commit/3591d6281bf29c5e98e761e7ad56a7abf78a4106)), closes [#87](https://github.com/archetech/archon/issues/87)
+* Add remote dmail name resolution ([#251](https://github.com/archetech/archon/issues/251)) ([157b0b0](https://github.com/archetech/archon/commit/157b0b036cf933d4385fa13007967fcc9e170f78))
+* Added update-credential to agent CLI ([#66](https://github.com/archetech/archon/issues/66)) ([002fce1](https://github.com/archetech/archon/commit/002fce1dcf2edb8c621eb77501cdf0abeed90484))
+* Adds dmail commands to agent CLI ([#67](https://github.com/archetech/archon/issues/67)) ([c5648b3](https://github.com/archetech/archon/commit/c5648b32b9c468e7dd2ead8225cbfc8ba28f929b))
+* Adds get-property command to CLI ([#73](https://github.com/archetech/archon/issues/73)) ([310d7fe](https://github.com/archetech/archon/commit/310d7fe5d95976b8ca37ec12b7d6dc16cc52f65a))
+* Adds view-credential command ([#96](https://github.com/archetech/archon/issues/96)) ([560a472](https://github.com/archetech/archon/commit/560a4727679a2b0e7154e26aef6ff3370b616d6c))
+* Adopt W3C JWE standard for encryption ([#90](https://github.com/archetech/archon/issues/90)) ([2321ca7](https://github.com/archetech/archon/commit/2321ca7fd6e074bac1f4b8fa7c12e58d4b45b181))
+* Allow any URI as credentialSubject.id per W3C VC Data Model v2 ([#92](https://github.com/archetech/archon/issues/92)) ([80d9f29](https://github.com/archetech/archon/commit/80d9f29a9653a93c19356c499512682794d270ce))
+* Display Lightning payment history ([#164](https://github.com/archetech/archon/issues/164)) ([#165](https://github.com/archetech/archon/issues/165)) ([c8ec283](https://github.com/archetech/archon/commit/c8ec2835b0cde542c71e02fdb7fc55c3d46a81d1))
+* Lightning zap — send sats to a DID ([#155](https://github.com/archetech/archon/issues/155)) ([39d7ee3](https://github.com/archetech/archon/commit/39d7ee3242973ace494e45f636ca12fe78d911ab)), closes [#154](https://github.com/archetech/archon/issues/154)
+* Publish addresses with optional Herald email service ([#491](https://github.com/archetech/archon/issues/491)) ([11938bd](https://github.com/archetech/archon/commit/11938bdfc12f3edad201f21b5fb16c26328de02d))
+* Refactor polls to use vault-based architecture ([#88](https://github.com/archetech/archon/issues/88)) ([#100](https://github.com/archetech/archon/issues/100)) ([8fa9eef](https://github.com/archetech/archon/commit/8fa9eef5230daf853c6f29194b72bbbec5de041a)), closes [#1](https://github.com/archetech/archon/issues/1) [#7](https://github.com/archetech/archon/issues/7) [#8](https://github.com/archetech/archon/issues/8) [#6](https://github.com/archetech/archon/issues/6) [#5](https://github.com/archetech/archon/issues/5) [#9](https://github.com/archetech/archon/issues/9)
+* Rename user-facing URL labels to Node URL ([#260](https://github.com/archetech/archon/issues/260)) ([5b5082c](https://github.com/archetech/archon/commit/5b5082cf5360edf29973e80b9e37a6190cace57a))
+* Store imported nostr nsec in wallet ([#397](https://github.com/archetech/archon/issues/397)) ([7a0a919](https://github.com/archetech/archon/commit/7a0a919f34ba9161dce25eaa528dccf3443840a4))
+* stream large file uploads/downloads for multi-GB video support ([#238](https://github.com/archetech/archon/issues/238)) ([eca94a0](https://github.com/archetech/archon/commit/eca94a06c041849a181a5a072728b9fe0c22bfae)), closes [#208](https://github.com/archetech/archon/issues/208)
+* Support LUD-16 Lightning Addresses in zapLightning ([#168](https://github.com/archetech/archon/issues/168)) ([f81457e](https://github.com/archetech/archon/commit/f81457e058c1ed99b54dafa463c48353a95d99b0)), closes [#160](https://github.com/archetech/archon/issues/160) [#160](https://github.com/archetech/archon/issues/160)
+* Update identity views across client apps ([#379](https://github.com/archetech/archon/issues/379)) ([4944281](https://github.com/archetech/archon/commit/49442810dd08a0b6e36221fbc93ccb0d89ca9f13))
+* V2 groups — promote name, add version field ([#109](https://github.com/archetech/archon/issues/109)) ([#132](https://github.com/archetech/archon/issues/132)) ([f04855d](https://github.com/archetech/archon/commit/f04855dac48a9a040c10143305029fb2d9c4c9ee))
+
+
+
+# 0.2.0 (2026-02-04)
+
+
+### Bug Fixes
+
+* Fix for duplicate credential types ([#37](https://github.com/archetech/archon/issues/37)) ([9613c46](https://github.com/archetech/archon/commit/9613c469a69b8c610df12bd64bea264a7cb6f8a9))
+* getVaultItem failed for small vault items ([#45](https://github.com/archetech/archon/issues/45)) ([a6fdd52](https://github.com/archetech/archon/commit/a6fdd5233ae2013879b28252d322e392211a59c2))
+
+
+### Features
+
+* Added import schema pack ([#29](https://github.com/archetech/archon/issues/29)) ([4af8acf](https://github.com/archetech/archon/commit/4af8acf4e9c15b36319f65f6a5b59a0c2c4bf2df))
+* Adds CLI to keymaster package ([#39](https://github.com/archetech/archon/issues/39)) ([894ce73](https://github.com/archetech/archon/commit/894ce732f5beaca37bb90ace6b760b8e80aba3e9))
+* Improve DTG credential support ([#48](https://github.com/archetech/archon/issues/48)) ([fb7e245](https://github.com/archetech/archon/commit/fb7e24538d93f36a310a36040e1608052969aba6))
+
+
+
+
+
 ## [0.4.11](https://github.com/archetech/archon/compare/@didcid/keymaster@0.4.10...@didcid/keymaster@0.4.11) (2026-05-29)
 
 **Note:** Version bump only for package @didcid/keymaster

--- a/packages/keymaster/CHANGELOG.md
+++ b/packages/keymaster/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.13](https://github.com/archetech/archon/compare/@didcid/keymaster@0.4.12...@didcid/keymaster@0.4.13) (2026-06-06)
+
+**Note:** Version bump only for package @didcid/keymaster
+
+
+
+
+
 ## [0.4.12](https://github.com/archetech/archon/compare/@didcid/keymaster@0.2.0...@didcid/keymaster@0.4.12) (2026-06-06)
 
 

--- a/packages/keymaster/package.json
+++ b/packages/keymaster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/keymaster",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Archon Keymaster",
   "type": "module",
   "module": "./dist/esm/index.js",
@@ -141,9 +141,9 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/cipher": "^0.2.11",
-    "@didcid/common": "^0.1.13",
-    "@didcid/gatekeeper": "^0.4.11",
+    "@didcid/cipher": "^0.2.12",
+    "@didcid/common": "^0.1.14",
+    "@didcid/gatekeeper": "^0.4.12",
     "axios": "^1.17.0",
     "commander": "^11.1.0",
     "dotenv": "^16.4.5",

--- a/packages/keymaster/package.json
+++ b/packages/keymaster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/keymaster",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Archon Keymaster",
   "type": "module",
   "module": "./dist/esm/index.js",
@@ -141,9 +141,9 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/cipher": "^0.2.12",
-    "@didcid/common": "^0.1.14",
-    "@didcid/gatekeeper": "^0.4.12",
+    "@didcid/cipher": "^0.2.13",
+    "@didcid/common": "^0.1.15",
+    "@didcid/gatekeeper": "^0.4.13",
     "axios": "^1.17.0",
     "commander": "^11.1.0",
     "dotenv": "^16.4.5",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.1.1 (2026-06-06)
+
+
+### Features
+
+* add Archon MCP server ([#605](https://github.com/archetech/archon/issues/605)) ([7cb9b34](https://github.com/archetech/archon/commit/7cb9b340c4ea5fa9bc353f680f06ef05a38c49d5))

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.2](https://github.com/archetech/archon/compare/@didcid/mcp-server@0.1.1...@didcid/mcp-server@0.1.2) (2026-06-06)
+
+
+### Bug Fixes
+
+* normalize mcp inline payload results ([69bc73f](https://github.com/archetech/archon/commit/69bc73fd28d154c833538b9b48ebf53399d75580))
+
+
+### Features
+
+* expand mcp server cli parity ([85e7150](https://github.com/archetech/archon/commit/85e7150cdd64fb5e30f8f5f9c9e7072c2d6b51b9))
+
+
+
+
+
 ## 0.1.1 (2026-06-06)
 
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -38,42 +38,171 @@ Example MCP client config:
 | `ARCHON_WALLET_PATH` | `./wallet.json` | Wallet file path |
 | `ARCHON_PASSPHRASE` | unset | Required for wallet-backed tools; node health tools work without it |
 | `ARCHON_DEFAULT_REGISTRY` | Keymaster default | Default registry for new DIDs |
-| `ARCHON_MCP_READ_ONLY` | `false` | Set to `true` to block mutating tools |
+| `ARCHON_MCP_READ_ONLY` | `false` | Set to `true` to omit mutating tools from `tools/list` |
 
 ## Tools
 
-Read tools:
+The MCP server maps every Keymaster CLI command to one MCP tool. Tool names use the CLI command with `archon_` prefixed and hyphens changed to underscores.
+
+MCP-only helper tools:
 
 - `archon_get_version`
 - `archon_get_status`
-- `archon_list_registries`
-- `archon_list_ids`
 - `archon_get_current_id`
-- `archon_resolve_did`
-- `archon_resolve_id`
-- `archon_list_aliases`
-- `archon_get_alias`
-- `archon_list_addresses`
-- `archon_check_address`
-- `archon_list_assets`
-- `archon_get_asset`
 
-Mutating tools:
+CLI file commands use inline data instead of arbitrary local paths. Binary/text payloads use:
 
-- `archon_use_id`
-- `archon_create_id`
-- `archon_add_alias`
-- `archon_remove_alias`
-- `archon_add_address`
-- `archon_remove_address`
-- `archon_publish_address`
-- `archon_unpublish_address`
-- `archon_create_asset_json`
-- `archon_update_asset_json`
-- `archon_transfer_asset`
+```json
+{
+  "name": "example.txt",
+  "mimeType": "text/plain",
+  "encoding": "base64",
+  "data": "aGVsbG8="
+}
+```
+
+Use `"encoding": "utf8"` when passing plain text directly. Returned file-like data uses the same shape with base64 encoding.
+
+Destructive tools require `"confirm": true`, secret-revealing tools require `"reveal": true`, and Lightning payment/broadcast tools require `"confirmPayment": true`.
 
 Set `ARCHON_MCP_READ_ONLY=true` to omit mutating tools from the advertised MCP tool list.
 
-## Intentionally omitted from v1
+### Keymaster CLI mapping
 
-The v1 server does not expose wallet creation/recovery/mnemonic/passphrase tools, Gatekeeper admin tools, credentials, vaults, dmail, Nostr, Lightning, polls, groups, schemas, or binary file/image asset tools.
+| CLI command | MCP tool |
+| --- | --- |
+| `create-wallet` | `archon_create_wallet` |
+| `new-wallet` | `archon_new_wallet` |
+| `change-passphrase` | `archon_change_passphrase` |
+| `check-wallet` | `archon_check_wallet` |
+| `fix-wallet` | `archon_fix_wallet` |
+| `import-wallet` | `archon_import_wallet` |
+| `show-wallet` | `archon_show_wallet` |
+| `backup-wallet-file` | `archon_backup_wallet_file` |
+| `restore-wallet-file` | `archon_restore_wallet_file` |
+| `show-mnemonic` | `archon_show_mnemonic` |
+| `backup-wallet-did` | `archon_backup_wallet_did` |
+| `recover-wallet-did` | `archon_recover_wallet_did` |
+| `create-id` | `archon_create_id` |
+| `resolve-id` | `archon_resolve_id` |
+| `backup-id` | `archon_backup_id` |
+| `recover-id` | `archon_recover_id` |
+| `remove-id` | `archon_remove_id` |
+| `rename-id` | `archon_rename_id` |
+| `list-ids` | `archon_list_ids` |
+| `list-registries` | `archon_list_registries` |
+| `use-id` | `archon_use_id` |
+| `rotate-keys` | `archon_rotate_keys` |
+| `resolve-did` | `archon_resolve_did` |
+| `resolve-did-version` | `archon_resolve_did_version` |
+| `revoke-did` | `archon_revoke_did` |
+| `change-registry` | `archon_change_registry` |
+| `encrypt-message` | `archon_encrypt_message` |
+| `encrypt-file` | `archon_encrypt_file` |
+| `decrypt-did` | `archon_decrypt_did` |
+| `decrypt-json` | `archon_decrypt_json` |
+| `sign-file` | `archon_sign_file` |
+| `verify-file` | `archon_verify_file` |
+| `create-challenge` | `archon_create_challenge` |
+| `create-challenge-cc` | `archon_create_challenge_cc` |
+| `create-response` | `archon_create_response` |
+| `verify-response` | `archon_verify_response` |
+| `bind-credential` | `archon_bind_credential` |
+| `issue-credential` | `archon_issue_credential` |
+| `list-issued` | `archon_list_issued` |
+| `update-credential` | `archon_update_credential` |
+| `revoke-credential` | `archon_revoke_credential` |
+| `accept-credential` | `archon_accept_credential` |
+| `list-credentials` | `archon_list_credentials` |
+| `get-credential` | `archon_get_credential` |
+| `view-credential` | `archon_view_credential` |
+| `publish-credential` | `archon_publish_credential` |
+| `reveal-credential` | `archon_reveal_credential` |
+| `unpublish-credential` | `archon_unpublish_credential` |
+| `add-alias` | `archon_add_alias` |
+| `get-alias` | `archon_get_alias` |
+| `remove-alias` | `archon_remove_alias` |
+| `list-aliases` | `archon_list_aliases` |
+| `list-addresses` | `archon_list_addresses` |
+| `get-address` | `archon_get_address` |
+| `import-address` | `archon_import_address` |
+| `check-address` | `archon_check_address` |
+| `add-address` | `archon_add_address` |
+| `remove-address` | `archon_remove_address` |
+| `publish-address` | `archon_publish_address` |
+| `unpublish-address` | `archon_unpublish_address` |
+| `add-nostr` | `archon_add_nostr` |
+| `import-nostr` | `archon_import_nostr` |
+| `remove-nostr` | `archon_remove_nostr` |
+| `add-lightning` | `archon_add_lightning` |
+| `remove-lightning` | `archon_remove_lightning` |
+| `lightning-balance` | `archon_lightning_balance` |
+| `lightning-decode` | `archon_lightning_decode` |
+| `lightning-invoice` | `archon_lightning_invoice` |
+| `lightning-pay` | `archon_lightning_pay` |
+| `lightning-check` | `archon_lightning_check` |
+| `publish-lightning` | `archon_publish_lightning` |
+| `unpublish-lightning` | `archon_unpublish_lightning` |
+| `lightning-zap` | `archon_lightning_zap` |
+| `lightning-payments` | `archon_lightning_payments` |
+| `create-group` | `archon_create_group` |
+| `list-groups` | `archon_list_groups` |
+| `get-group` | `archon_get_group` |
+| `add-group-member` | `archon_add_group_member` |
+| `remove-group-member` | `archon_remove_group_member` |
+| `test-group` | `archon_test_group` |
+| `create-schema` | `archon_create_schema` |
+| `list-schemas` | `archon_list_schemas` |
+| `get-schema` | `archon_get_schema` |
+| `create-schema-template` | `archon_create_schema_template` |
+| `create-asset` | `archon_create_asset` |
+| `create-asset-json` | `archon_create_asset_json` |
+| `create-asset-image` | `archon_create_asset_image` |
+| `create-asset-file` | `archon_create_asset_file` |
+| `get-asset` | `archon_get_asset` |
+| `get-asset-json` | `archon_get_asset_json` |
+| `get-asset-image` | `archon_get_asset_image` |
+| `get-asset-file` | `archon_get_asset_file` |
+| `update-asset-json` | `archon_update_asset_json` |
+| `update-asset-image` | `archon_update_asset_image` |
+| `update-asset-file` | `archon_update_asset_file` |
+| `transfer-asset` | `archon_transfer_asset` |
+| `clone-asset` | `archon_clone_asset` |
+| `get-property` | `archon_get_property` |
+| `set-property` | `archon_set_property` |
+| `list-assets` | `archon_list_assets` |
+| `create-poll-template` | `archon_create_poll_template` |
+| `create-poll` | `archon_create_poll` |
+| `add-poll-voter` | `archon_add_poll_voter` |
+| `remove-poll-voter` | `archon_remove_poll_voter` |
+| `list-poll-voters` | `archon_list_poll_voters` |
+| `view-poll` | `archon_view_poll` |
+| `vote-poll` | `archon_vote_poll` |
+| `send-poll` | `archon_send_poll` |
+| `send-ballot` | `archon_send_ballot` |
+| `view-ballot` | `archon_view_ballot` |
+| `update-poll` | `archon_update_poll` |
+| `publish-poll` | `archon_publish_poll` |
+| `reveal-poll` | `archon_reveal_poll` |
+| `unpublish-poll` | `archon_unpublish_poll` |
+| `create-vault` | `archon_create_vault` |
+| `list-vault-items` | `archon_list_vault_items` |
+| `add-vault-member` | `archon_add_vault_member` |
+| `remove-vault-member` | `archon_remove_vault_member` |
+| `list-vault-members` | `archon_list_vault_members` |
+| `add-vault-item` | `archon_add_vault_item` |
+| `remove-vault-item` | `archon_remove_vault_item` |
+| `get-vault-item` | `archon_get_vault_item` |
+| `create-dmail` | `archon_create_dmail` |
+| `update-dmail` | `archon_update_dmail` |
+| `send-dmail` | `archon_send_dmail` |
+| `get-dmail` | `archon_get_dmail` |
+| `list-dmail` | `archon_list_dmail` |
+| `file-dmail` | `archon_file_dmail` |
+| `refresh-dmail` | `archon_refresh_dmail` |
+| `import-dmail` | `archon_import_dmail` |
+| `remove-dmail` | `archon_remove_dmail` |
+| `add-dmail-attachment` | `archon_add_dmail_attachment` |
+| `remove-dmail-attachment` | `archon_remove_dmail_attachment` |
+| `get-dmail-attachment` | `archon_get_dmail_attachment` |
+| `list-dmail-attachments` | `archon_list_dmail_attachments` |

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -67,6 +67,105 @@ Destructive tools require `"confirm": true`, secret-revealing tools require `"re
 
 Set `ARCHON_MCP_READ_ONLY=true` to omit mutating tools from the advertised MCP tool list.
 
+## Examples
+
+Create an ID:
+
+```json
+{
+  "name": "archon_create_id",
+  "arguments": {
+    "name": "alice",
+    "registry": "hyperswarm"
+  }
+}
+```
+
+Rotate the current ID keys:
+
+```json
+{
+  "name": "archon_rotate_keys",
+  "arguments": {
+    "confirm": true
+  }
+}
+```
+
+Create a JSON asset:
+
+```json
+{
+  "name": "archon_create_asset_json",
+  "arguments": {
+    "data": {
+      "title": "Example",
+      "status": "draft"
+    },
+    "alias": "example-asset"
+  }
+}
+```
+
+Create a file asset from inline data:
+
+```json
+{
+  "name": "archon_create_asset_file",
+  "arguments": {
+    "file": {
+      "name": "hello.txt",
+      "mimeType": "text/plain",
+      "encoding": "utf8",
+      "data": "hello"
+    },
+    "alias": "hello-file"
+  }
+}
+```
+
+Issue a credential from inline JSON:
+
+```json
+{
+  "name": "archon_issue_credential",
+  "arguments": {
+    "credential": {
+      "@context": ["https://www.w3.org/ns/credentials/v2"],
+      "type": ["VerifiableCredential"],
+      "issuer": "did:cid:issuer",
+      "credentialSubject": {
+        "id": "did:cid:subject"
+      }
+    }
+  }
+}
+```
+
+Reveal a credential in the current ID manifest:
+
+```json
+{
+  "name": "archon_reveal_credential",
+  "arguments": {
+    "did": "did:cid:credential",
+    "reveal": true
+  }
+}
+```
+
+Pay a Lightning invoice:
+
+```json
+{
+  "name": "archon_lightning_pay",
+  "arguments": {
+    "bolt11": "lnbc...",
+    "confirmPayment": true
+  }
+}
+```
+
 ### Keymaster CLI mapping
 
 | CLI command | MCP tool |

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Archon MCP server",
   "type": "module",
   "main": "./dist/index.js",
@@ -35,9 +35,9 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/cipher": "^0.2.11",
-    "@didcid/gatekeeper": "^0.4.11",
-    "@didcid/keymaster": "^0.4.11",
+    "@didcid/cipher": "^0.2.12",
+    "@didcid/gatekeeper": "^0.4.12",
+    "@didcid/keymaster": "^0.4.12",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^16.4.5",
     "zod": "^3.25.76"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Archon MCP server",
   "type": "module",
   "main": "./dist/index.js",
@@ -35,9 +35,9 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/cipher": "^0.2.12",
-    "@didcid/gatekeeper": "^0.4.12",
-    "@didcid/keymaster": "^0.4.12",
+    "@didcid/cipher": "^0.2.13",
+    "@didcid/gatekeeper": "^0.4.13",
+    "@didcid/keymaster": "^0.4.13",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^16.4.5",
     "zod": "^3.25.76"

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -8,7 +8,8 @@ export { loadConfig, walletLocation } from './config.js';
 export type { McpServerConfig, WalletType } from './config.js';
 export { createArchonRuntime, createWallet } from './runtime.js';
 export type { ArchonRuntime } from './runtime.js';
-export { registerArchonTools } from './tools.js';
+export { ARCHON_MCP_CLI_COMMANDS, ARCHON_MCP_TOOL_DEFINITIONS, registerArchonTools } from './tools.js';
+export type { ArchonToolDefinition } from './tools.js';
 
 export async function main(): Promise<void> {
     const config = loadConfig();

--- a/packages/mcp-server/src/redact.ts
+++ b/packages/mcp-server/src/redact.ts
@@ -1,6 +1,7 @@
-const QUOTED_SECRET_ASSIGNMENT = /\b(ARCHON_(?:ADMIN_API_KEY|PASSPHRASE|ENCRYPTED_PASSPHRASE)|api[_-]?key|apikey|token|access_token|passphrase|password)=("[^"]*"|'[^']*')/gi;
-const SPACED_SECRET_ASSIGNMENT = /\b(ARCHON_(?:PASSPHRASE|ENCRYPTED_PASSPHRASE)|passphrase|password)=([^&\r\n]*?)(?=\shttps?:\/\/|\s[A-Za-z_][A-Za-z0-9_-]*=|[&\r\n]|$)/gi;
-const SECRET_ASSIGNMENT = /\b(ARCHON_ADMIN_API_KEY|api[_-]?key|apikey|token|access_token)=([^&\s]+)/gi;
+const SECRET_KEYS = 'ARCHON_(?:ADMIN_API_KEY|PASSPHRASE|ENCRYPTED_PASSPHRASE)|api[_-]?key|apikey|token|access_token|passphrase|password|mnemonic|recovery[_-]?phrase|recoveryPhrase|nsec|bolt11|adminKey|invoiceKey';
+const QUOTED_SECRET_ASSIGNMENT = new RegExp(`\\b(${SECRET_KEYS})=("[^"]*"|'[^']*')`, 'gi');
+const SPACED_SECRET_ASSIGNMENT = /\b(ARCHON_(?:PASSPHRASE|ENCRYPTED_PASSPHRASE)|passphrase|password|mnemonic|recovery[_-]?phrase)=([^&\r\n]*?)(?=\shttps?:\/\/|\s[A-Za-z_][A-Za-z0-9_-]*=|[&\r\n]|$)/gi;
+const SECRET_ASSIGNMENT = new RegExp(`\\b(${SECRET_KEYS})=([^&\\s]+)`, 'gi');
 const URL_TEXT = /https?:\/\/[^\s"'<>]+/gi;
 const URL_SECRET_PARAMS = new Set(['api_key', 'apikey', 'access_token', 'token', 'key', 'password', 'passphrase']);
 const TOKEN_PATH_HOSTS = [

--- a/packages/mcp-server/src/redact.ts
+++ b/packages/mcp-server/src/redact.ts
@@ -1,6 +1,6 @@
 const SECRET_KEYS = 'ARCHON_(?:ADMIN_API_KEY|PASSPHRASE|ENCRYPTED_PASSPHRASE)|api[_-]?key|apikey|token|access_token|passphrase|password|mnemonic|recovery[_-]?phrase|recoveryPhrase|nsec|bolt11|adminKey|invoiceKey';
 const QUOTED_SECRET_ASSIGNMENT = new RegExp(`\\b(${SECRET_KEYS})=("[^"]*"|'[^']*')`, 'gi');
-const SPACED_SECRET_ASSIGNMENT = /\b(ARCHON_(?:PASSPHRASE|ENCRYPTED_PASSPHRASE)|passphrase|password|mnemonic|recovery[_-]?phrase)=([^&\r\n]*?)(?=\shttps?:\/\/|\s[A-Za-z_][A-Za-z0-9_-]*=|[&\r\n]|$)/gi;
+const SPACED_SECRET_ASSIGNMENT = /\b(ARCHON_(?:PASSPHRASE|ENCRYPTED_PASSPHRASE)|passphrase|password|mnemonic|recovery[_-]?phrase|recoveryPhrase)=([^&\r\n]*?)(?=\shttps?:\/\/|\s[A-Za-z_][A-Za-z0-9_-]*=|[&\r\n]|$)/gi;
 const SECRET_ASSIGNMENT = new RegExp(`\\b(${SECRET_KEYS})=([^&\\s]+)`, 'gi');
 const URL_TEXT = /https?:\/\/[^\s"'<>]+/gi;
 const URL_SECRET_PARAMS = new Set(['api_key', 'apikey', 'access_token', 'token', 'key', 'password', 'passphrase']);

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -225,11 +225,14 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
     tool({ name: 'archon_get_asset_json', cliCommand: 'get-asset-json', description: 'Return a JSON asset as an inline object.', schema: IdSchema.merge(ResolveOptionsSchema), handler: (runtime, { id, ...options }) => requireKeymaster(runtime).resolveAsset(id, compactOptions(options)) }),
     tool({ name: 'archon_get_asset_image', cliCommand: 'get-asset-image', description: 'Return an image asset as an inline base64 payload.', schema: IdSchema, handler: async (runtime, { id }) => {
         const image = await requireKeymaster(runtime).getImage(id);
-        return image?.file?.data ? { ...image, file: { ...image.file, data: inlineDataFromBuffer(Buffer.from(image.file.data), image.file.filename, image.file.type) } } : null;
+        return image?.file?.data ? {
+            file: inlineDataFromBuffer(Buffer.from(image.file.data), image.file.filename, image.file.type),
+            image: image.image,
+        } : null;
     } }),
     tool({ name: 'archon_get_asset_file', cliCommand: 'get-asset-file', description: 'Return a file asset as an inline base64 payload.', schema: IdSchema, handler: async (runtime, { id }) => {
         const file = await requireKeymaster(runtime).getFile(id);
-        return file?.data ? { ...file, data: inlineDataFromBuffer(Buffer.from(file.data), file.filename, file.type) } : null;
+        return file?.data ? inlineDataFromBuffer(Buffer.from(file.data), file.filename, file.type) : null;
     } }),
     tool({ name: 'archon_update_asset_json', cliCommand: 'update-asset-json', description: 'Merge JSON object data into an existing asset.', schema: IdSchema.extend({ data: JsonObjectSchema }), mutates: true, handler: (runtime, { id, data }) => requireKeymaster(runtime).mergeData(id, data) }),
     tool({ name: 'archon_update_asset_image', cliCommand: 'update-asset-image', description: 'Update an image asset from an inline payload.', schema: IdSchema.extend({ file: InlineDataSchema }), mutates: true, handler: (runtime, { id, file }) => requireKeymaster(runtime).updateImage(id, bufferFromInlineData(file), compactOptions({ filename: file.name })) }),

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -3,27 +3,47 @@ import { McpServerConfig } from './config.js';
 import { ArchonRuntime } from './runtime.js';
 import { errorMessage } from './redact.js';
 
-type ToolHandler<T> = (args: T) => Promise<unknown>;
+type ToolHandler = (runtime: ArchonRuntime, args: any) => Promise<unknown> | unknown;
 
 type RegisterableServer = {
     registerTool?: (name: string, config: any, handler: (args: unknown) => Promise<unknown>) => void;
     tool?: (name: string, description: string, schema: unknown, handler: (args: unknown) => Promise<unknown>) => void;
 };
 
+export type ArchonToolDefinition = {
+    name: string;
+    cliCommand?: string;
+    description: string;
+    schema: z.ZodTypeAny;
+    mutates?: boolean;
+    handler: ToolHandler;
+};
+
 const EmptySchema = z.object({});
+const IdSchema = z.object({ id: z.string() });
+const DidSchema = z.object({ did: z.string() });
+const AliasOptionsSchema = z.object({ alias: z.string().optional(), registry: z.string().optional() });
+const AssetOptionsSchema = AliasOptionsSchema.extend({
+    controller: z.string().optional(),
+    validUntil: z.string().optional(),
+});
+const VaultOptionsSchema = AliasOptionsSchema.extend({ secretMembers: z.boolean().optional() });
 const ResolveOptionsSchema = z.object({
     confirm: z.boolean().optional(),
     verify: z.boolean().optional(),
     versionTime: z.string().optional(),
     versionSequence: z.number().int().optional(),
 });
-
+const ConfirmSchema = z.object({ confirm: z.literal(true) });
+const RevealSchema = z.object({ reveal: z.literal(true) });
+const ConfirmPaymentSchema = z.object({ confirmPayment: z.literal(true) });
 const JsonObjectSchema = z.record(z.unknown());
-const AssetOptionsSchema = z.object({
-    alias: z.string().optional(),
-    registry: z.string().optional(),
-    controller: z.string().optional(),
-    validUntil: z.string().optional(),
+const JsonValueSchema = z.unknown();
+const InlineDataSchema = z.object({
+    name: z.string().optional(),
+    mimeType: z.string().optional(),
+    encoding: z.enum(['base64', 'utf8']).optional(),
+    data: z.string(),
 });
 
 function jsonResult(result: unknown) {
@@ -50,44 +70,7 @@ function requireKeymaster(runtime: ArchonRuntime) {
         throw new Error('ARCHON_PASSPHRASE is required for wallet-backed MCP tools');
     }
 
-    return runtime.keymaster;
-}
-
-function registerTool<T>(
-    server: RegisterableServer,
-    name: string,
-    description: string,
-    schema: z.ZodType<T>,
-    handler: ToolHandler<T>,
-    options: { mutates?: boolean; readOnly?: boolean } = {}
-) {
-    if (options.mutates && options.readOnly) {
-        return;
-    }
-
-    const wrapped = async (rawArgs: unknown) => {
-        try {
-            if (options.mutates && options.readOnly) {
-                throw new Error('Tool disabled by ARCHON_MCP_READ_ONLY=true');
-            }
-            const args = schema.parse(rawArgs ?? {});
-            return ok(await handler(args));
-        } catch (error) {
-            return fail(error);
-        }
-    };
-
-    if (server.registerTool) {
-        server.registerTool(name, { description, inputSchema: schema }, wrapped);
-        return;
-    }
-
-    if (server.tool && schema instanceof z.ZodObject) {
-        server.tool(name, description, schema.shape, wrapped);
-        return;
-    }
-
-    throw new Error('MCP server does not support tool registration');
+    return runtime.keymaster as any;
 }
 
 function compactOptions<T extends Record<string, unknown>>(options: T): Partial<T> | undefined {
@@ -95,81 +78,254 @@ function compactOptions<T extends Record<string, unknown>>(options: T): Partial<
     return entries.length > 0 ? Object.fromEntries(entries) as Partial<T> : undefined;
 }
 
-export function registerArchonTools(server: RegisterableServer, runtime: ArchonRuntime, config: McpServerConfig): void {
-    const mutating = { mutates: true, readOnly: config.readOnly };
+function bufferFromInlineData(input: z.infer<typeof InlineDataSchema>): Buffer {
+    return Buffer.from(input.data, input.encoding === 'utf8' ? 'utf8' : 'base64');
+}
 
-    registerTool(server, 'archon_get_version', 'Get Archon node version information.', EmptySchema, async () => runtime.node.getVersion());
-    registerTool(server, 'archon_get_status', 'Get Archon node status.', EmptySchema, async () => runtime.node.getStatus());
-    registerTool(server, 'archon_list_registries', 'List registries supported by the connected Archon node.', EmptySchema, async () => runtime.node.listRegistries());
+function inlineDataFromBuffer(buffer: Buffer, name?: string, mimeType?: string) {
+    return {
+        name,
+        mimeType,
+        encoding: 'base64',
+        data: buffer.toString('base64'),
+    };
+}
 
-    registerTool(server, 'archon_list_ids', 'List IDs in the local Keymaster wallet.', EmptySchema, async () => requireKeymaster(runtime).listIds());
-    registerTool(server, 'archon_get_current_id', 'Get the current local Keymaster wallet ID name.', EmptySchema, async () => requireKeymaster(runtime).getCurrentId());
-    registerTool(server, 'archon_use_id', 'Set the current local Keymaster wallet ID name.', z.object({ name: z.string() }), async ({ name }) => requireKeymaster(runtime).setCurrentId(name), mutating);
-    registerTool(
-        server,
-        'archon_create_id',
-        'Create a new local Keymaster wallet ID.',
-        z.object({ name: z.string(), registry: z.string().optional() }),
-        async ({ name, registry }) => requireKeymaster(runtime).createId(name, compactOptions({ registry })),
-        mutating
-    );
-    registerTool(
-        server,
-        'archon_resolve_did',
-        'Resolve a DID or DID-like Archon identifier.',
-        z.object({ did: z.string() }).merge(ResolveOptionsSchema),
-        async ({ did, ...options }) => requireKeymaster(runtime).resolveDID(did, compactOptions(options))
-    );
-    registerTool(
-        server,
-        'archon_resolve_id',
-        'Resolve a local ID name, alias, DID, or the current ID when id is omitted.',
-        z.object({ id: z.string().optional() }).merge(ResolveOptionsSchema),
-        async ({ id, ...options }) => {
-            const keymaster = requireKeymaster(runtime);
-            const resolvedId = id ?? await keymaster.getCurrentId();
-            if (!resolvedId) {
-                throw new Error('No current ID');
+function signableJson(input: unknown): object {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
+        throw new Error('object must be a JSON object');
+    }
+    return input as object;
+}
+
+function tool(definition: ArchonToolDefinition): ArchonToolDefinition {
+    return definition;
+}
+
+export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
+    tool({ name: 'archon_get_version', description: 'Get Archon node version information.', schema: EmptySchema, handler: runtime => runtime.node.getVersion() }),
+    tool({ name: 'archon_get_status', description: 'Get Archon node status.', schema: EmptySchema, handler: runtime => runtime.node.getStatus() }),
+
+    tool({ name: 'archon_create_wallet', cliCommand: 'create-wallet', description: 'Create or load the local wallet.', schema: EmptySchema, mutates: true, handler: runtime => requireKeymaster(runtime).loadWallet() }),
+    tool({ name: 'archon_new_wallet', cliCommand: 'new-wallet', description: 'Create a new local wallet, replacing the existing wallet.', schema: ConfirmSchema, mutates: true, handler: runtime => requireKeymaster(runtime).newWallet('', true) }),
+    tool({ name: 'archon_change_passphrase', cliCommand: 'change-passphrase', description: 'Re-encrypt the local wallet with a new passphrase.', schema: z.object({ newPassphrase: z.string() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { newPassphrase }) => requireKeymaster(runtime).changePassphrase(newPassphrase) }),
+    tool({ name: 'archon_check_wallet', cliCommand: 'check-wallet', description: 'Validate DIDs in the local wallet.', schema: EmptySchema, handler: runtime => requireKeymaster(runtime).checkWallet() }),
+    tool({ name: 'archon_fix_wallet', cliCommand: 'fix-wallet', description: 'Remove invalid DIDs from the local wallet.', schema: ConfirmSchema, mutates: true, handler: runtime => requireKeymaster(runtime).fixWallet() }),
+    tool({ name: 'archon_import_wallet', cliCommand: 'import-wallet', description: 'Create a new wallet from a recovery phrase.', schema: z.object({ recoveryPhrase: z.string() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { recoveryPhrase }) => requireKeymaster(runtime).newWallet(recoveryPhrase, true) }),
+    tool({ name: 'archon_show_wallet', cliCommand: 'show-wallet', description: 'Show the decrypted local wallet.', schema: RevealSchema, handler: runtime => requireKeymaster(runtime).loadWallet() }),
+    tool({ name: 'archon_backup_wallet_file', cliCommand: 'backup-wallet-file', description: 'Return the encrypted wallet backup payload.', schema: RevealSchema, handler: runtime => requireKeymaster(runtime).exportEncryptedWallet() }),
+    tool({ name: 'archon_restore_wallet_file', cliCommand: 'restore-wallet-file', description: 'Restore the local wallet from an encrypted wallet payload.', schema: z.object({ wallet: JsonObjectSchema }).merge(ConfirmSchema), mutates: true, handler: (runtime, { wallet }) => requireKeymaster(runtime).saveWallet(wallet, true) }),
+    tool({ name: 'archon_show_mnemonic', cliCommand: 'show-mnemonic', description: 'Reveal the wallet recovery phrase.', schema: RevealSchema, handler: runtime => requireKeymaster(runtime).decryptMnemonic() }),
+    tool({ name: 'archon_backup_wallet_did', cliCommand: 'backup-wallet-did', description: 'Backup wallet to an encrypted DID and seed bank.', schema: ConfirmSchema, mutates: true, handler: runtime => requireKeymaster(runtime).backupWallet() }),
+    tool({ name: 'archon_recover_wallet_did', cliCommand: 'recover-wallet-did', description: 'Recover wallet from seed bank or encrypted DID.', schema: z.object({ did: z.string().optional() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).recoverWallet(did) }),
+
+    tool({ name: 'archon_create_id', cliCommand: 'create-id', description: 'Create a new local Keymaster wallet ID.', schema: z.object({ name: z.string(), registry: z.string().optional() }), mutates: true, handler: (runtime, { name, registry }) => requireKeymaster(runtime).createId(name, compactOptions({ registry })) }),
+    tool({ name: 'archon_resolve_id', cliCommand: 'resolve-id', description: 'Resolve a local ID name, alias, DID, or the current ID when id is omitted.', schema: z.object({ id: z.string().optional() }).merge(ResolveOptionsSchema), handler: async (runtime, { id, ...options }) => {
+        const keymaster = requireKeymaster(runtime);
+        const resolvedId = id ?? await keymaster.getCurrentId();
+        if (!resolvedId) throw new Error('No current ID');
+        return keymaster.resolveDID(resolvedId, compactOptions(options));
+    } }),
+    tool({ name: 'archon_backup_id', cliCommand: 'backup-id', description: 'Backup the current or selected ID.', schema: z.object({ id: z.string().optional() }), mutates: true, handler: (runtime, { id }) => requireKeymaster(runtime).backupId(id) }),
+    tool({ name: 'archon_recover_id', cliCommand: 'recover-id', description: 'Recover an ID from a backup DID.', schema: DidSchema, mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).recoverId(did) }),
+    tool({ name: 'archon_remove_id', cliCommand: 'remove-id', description: 'Remove a local ID from the wallet.', schema: z.object({ name: z.string() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { name }) => requireKeymaster(runtime).removeId(name) }),
+    tool({ name: 'archon_rename_id', cliCommand: 'rename-id', description: 'Rename a local ID.', schema: z.object({ oldName: z.string(), newName: z.string() }), mutates: true, handler: (runtime, { oldName, newName }) => requireKeymaster(runtime).renameId(oldName, newName) }),
+    tool({ name: 'archon_list_ids', cliCommand: 'list-ids', description: 'List IDs in the local Keymaster wallet.', schema: EmptySchema, handler: runtime => requireKeymaster(runtime).listIds() }),
+    tool({ name: 'archon_list_registries', cliCommand: 'list-registries', description: 'List registries supported by the connected Archon node.', schema: EmptySchema, handler: runtime => runtime.node.listRegistries() }),
+    tool({ name: 'archon_get_current_id', description: 'Get the current local Keymaster wallet ID name.', schema: EmptySchema, handler: runtime => requireKeymaster(runtime).getCurrentId() }),
+    tool({ name: 'archon_use_id', cliCommand: 'use-id', description: 'Set the current local Keymaster wallet ID name.', schema: z.object({ name: z.string() }), mutates: true, handler: (runtime, { name }) => requireKeymaster(runtime).setCurrentId(name) }),
+    tool({ name: 'archon_rotate_keys', cliCommand: 'rotate-keys', description: 'Generate and publish new keys for the current ID.', schema: ConfirmSchema, mutates: true, handler: runtime => requireKeymaster(runtime).rotateKeys() }),
+
+    tool({ name: 'archon_resolve_did', cliCommand: 'resolve-did', description: 'Resolve a DID or DID-like Archon identifier.', schema: DidSchema.merge(ResolveOptionsSchema), handler: (runtime, { did, ...options }) => requireKeymaster(runtime).resolveDID(did, compactOptions(options)) }),
+    tool({ name: 'archon_resolve_did_version', cliCommand: 'resolve-did-version', description: 'Resolve a specific DID version.', schema: DidSchema.extend({ version: z.number().int() }), handler: (runtime, { did, version }) => requireKeymaster(runtime).resolveDID(did, { versionSequence: version }) }),
+    tool({ name: 'archon_revoke_did', cliCommand: 'revoke-did', description: 'Permanently revoke a DID.', schema: DidSchema.merge(ConfirmSchema), mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).revokeDID(did) }),
+    tool({ name: 'archon_change_registry', cliCommand: 'change-registry', description: 'Change the registry for an existing DID.', schema: IdSchema.extend({ registry: z.string() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { id, registry }) => requireKeymaster(runtime).changeRegistry(id, registry) }),
+
+    tool({ name: 'archon_encrypt_message', cliCommand: 'encrypt-message', description: 'Encrypt a message for a DID.', schema: z.object({ message: z.string(), did: z.string() }), mutates: true, handler: (runtime, { message, did }) => requireKeymaster(runtime).encryptMessage(message, did) }),
+    tool({ name: 'archon_encrypt_file', cliCommand: 'encrypt-file', description: 'Encrypt inline text data for a DID.', schema: z.object({ file: InlineDataSchema, did: z.string() }), mutates: true, handler: (runtime, { file, did }) => requireKeymaster(runtime).encryptMessage(bufferFromInlineData(file).toString('utf8'), did) }),
+    tool({ name: 'archon_decrypt_did', cliCommand: 'decrypt-did', description: 'Decrypt an encrypted message DID.', schema: DidSchema.merge(RevealSchema), handler: (runtime, { did }) => requireKeymaster(runtime).decryptMessage(did) }),
+    tool({ name: 'archon_decrypt_json', cliCommand: 'decrypt-json', description: 'Decrypt an encrypted JSON DID.', schema: DidSchema.merge(RevealSchema), handler: (runtime, { did }) => requireKeymaster(runtime).decryptJSON(did) }),
+    tool({ name: 'archon_sign_file', cliCommand: 'sign-file', description: 'Sign an inline JSON object.', schema: z.object({ object: JsonObjectSchema }), handler: (runtime, { object }) => requireKeymaster(runtime).addProof(signableJson(object)) }),
+    tool({ name: 'archon_verify_file', cliCommand: 'verify-file', description: 'Verify the proof in an inline JSON object.', schema: z.object({ object: JsonObjectSchema }), handler: (runtime, { object }) => requireKeymaster(runtime).verifyProof(object) }),
+
+    tool({ name: 'archon_create_challenge', cliCommand: 'create-challenge', description: 'Create a challenge DID.', schema: z.object({ challenge: JsonObjectSchema.optional(), alias: z.string().optional(), registry: z.string().optional() }), mutates: true, handler: (runtime, { challenge, alias, registry }) => requireKeymaster(runtime).createChallenge(challenge, compactOptions({ alias, registry })) }),
+    tool({ name: 'archon_create_challenge_cc', cliCommand: 'create-challenge-cc', description: 'Create a challenge from a credential DID.', schema: z.object({ did: z.string(), alias: z.string().optional(), registry: z.string().optional() }), mutates: true, handler: (runtime, { did, alias, registry }) => requireKeymaster(runtime).createChallenge({ credentials: [{ schema: did }] }, compactOptions({ alias, registry })) }),
+    tool({ name: 'archon_create_response', cliCommand: 'create-response', description: 'Create a response to a challenge.', schema: z.object({ challenge: z.string(), registry: z.string().optional(), validUntil: z.string().optional() }), mutates: true, handler: (runtime, { challenge, registry, validUntil }) => requireKeymaster(runtime).createResponse(challenge, compactOptions({ registry, validUntil })) }),
+    tool({ name: 'archon_verify_response', cliCommand: 'verify-response', description: 'Decrypt and validate a response to a challenge.', schema: z.object({ response: z.string() }), handler: (runtime, { response }) => requireKeymaster(runtime).verifyResponse(response) }),
+
+    tool({ name: 'archon_bind_credential', cliCommand: 'bind-credential', description: 'Create a bound credential for a subject.', schema: z.object({ schema: z.string(), subject: z.string(), claims: JsonObjectSchema.optional(), validFrom: z.string().optional(), validUntil: z.string().optional() }), handler: (runtime, { subject, schema, claims, validFrom, validUntil }) => requireKeymaster(runtime).bindCredential(subject, compactOptions({ schema, claims, validFrom, validUntil })) }),
+    tool({ name: 'archon_issue_credential', cliCommand: 'issue-credential', description: 'Sign and encrypt a bound credential.', schema: z.object({ credential: JsonObjectSchema, alias: z.string().optional(), registry: z.string().optional() }), mutates: true, handler: (runtime, { credential, alias, registry }) => requireKeymaster(runtime).issueCredential(credential, compactOptions({ alias, registry })) }),
+    tool({ name: 'archon_list_issued', cliCommand: 'list-issued', description: 'List issued credentials.', schema: z.object({ issuer: z.string().optional() }), handler: (runtime, { issuer }) => requireKeymaster(runtime).listIssued(issuer) }),
+    tool({ name: 'archon_update_credential', cliCommand: 'update-credential', description: 'Update an issued credential.', schema: z.object({ did: z.string(), credential: JsonObjectSchema }), mutates: true, handler: (runtime, { did, credential }) => requireKeymaster(runtime).updateCredential(did, credential) }),
+    tool({ name: 'archon_revoke_credential', cliCommand: 'revoke-credential', description: 'Revoke a verifiable credential.', schema: DidSchema.merge(ConfirmSchema), mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).revokeCredential(did) }),
+    tool({ name: 'archon_accept_credential', cliCommand: 'accept-credential', description: 'Save a verifiable credential for the current ID.', schema: DidSchema.extend({ alias: z.string().optional() }), mutates: true, handler: async (runtime, { did, alias }) => {
+        const keymaster = requireKeymaster(runtime);
+        const accepted = await keymaster.acceptCredential(did);
+        if (accepted && alias) await keymaster.addAlias(alias, did);
+        return accepted;
+    } }),
+    tool({ name: 'archon_list_credentials', cliCommand: 'list-credentials', description: 'List credentials held by an ID.', schema: z.object({ id: z.string().optional() }), handler: (runtime, { id }) => requireKeymaster(runtime).listCredentials(id) }),
+    tool({ name: 'archon_get_credential', cliCommand: 'get-credential', description: 'Get a credential by DID.', schema: DidSchema, handler: (runtime, { did }) => requireKeymaster(runtime).getCredential(did) }),
+    tool({ name: 'archon_view_credential', cliCommand: 'view-credential', description: 'Get a credential with proof validity.', schema: DidSchema, handler: async (runtime, { did }) => {
+        const keymaster = requireKeymaster(runtime);
+        const credential = await keymaster.getCredential(did);
+        return { credential, proofValid: credential ? await keymaster.verifyProof(credential) : false };
+    } }),
+    tool({ name: 'archon_publish_credential', cliCommand: 'publish-credential', description: 'Publish the existence of a credential to the current user manifest.', schema: DidSchema, mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).publishCredential(did, { reveal: false }) }),
+    tool({ name: 'archon_reveal_credential', cliCommand: 'reveal-credential', description: 'Reveal a credential to the current user manifest.', schema: DidSchema.merge(RevealSchema), mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).publishCredential(did, { reveal: true }) }),
+    tool({ name: 'archon_unpublish_credential', cliCommand: 'unpublish-credential', description: 'Remove a credential from the current user manifest.', schema: DidSchema, mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).unpublishCredential(did) }),
+
+    tool({ name: 'archon_add_alias', cliCommand: 'add-alias', description: 'Add a DID alias to the local Keymaster wallet.', schema: z.object({ alias: z.string(), did: z.string() }), mutates: true, handler: (runtime, { alias, did }) => requireKeymaster(runtime).addAlias(alias, did) }),
+    tool({ name: 'archon_get_alias', cliCommand: 'get-alias', description: 'Get the DID assigned to a local alias.', schema: z.object({ alias: z.string() }), handler: (runtime, { alias }) => requireKeymaster(runtime).getAlias(alias) }),
+    tool({ name: 'archon_remove_alias', cliCommand: 'remove-alias', description: 'Remove a DID alias from the local wallet.', schema: z.object({ alias: z.string() }), mutates: true, handler: (runtime, { alias }) => requireKeymaster(runtime).removeAlias(alias) }),
+    tool({ name: 'archon_list_aliases', cliCommand: 'list-aliases', description: 'List DID aliases in the local wallet.', schema: z.object({ includeIds: z.boolean().optional() }), handler: (runtime, { includeIds }) => requireKeymaster(runtime).listAliases(includeIds === undefined ? undefined : { includeIDs: includeIds }) }),
+
+    tool({ name: 'archon_list_addresses', cliCommand: 'list-addresses', description: 'List wallet addresses claimed through Herald domains.', schema: EmptySchema, handler: runtime => requireKeymaster(runtime).listAddresses() }),
+    tool({ name: 'archon_get_address', cliCommand: 'get-address', description: 'Get the current address for a domain.', schema: z.object({ domain: z.string() }), handler: (runtime, { domain }) => requireKeymaster(runtime).getAddress(domain) }),
+    tool({ name: 'archon_import_address', cliCommand: 'import-address', description: 'Import an existing address for the current ID from a domain.', schema: z.object({ domain: z.string() }), mutates: true, handler: (runtime, { domain }) => requireKeymaster(runtime).importAddress(domain) }),
+    tool({ name: 'archon_check_address', cliCommand: 'check-address', description: 'Check whether a Herald address is available.', schema: z.object({ address: z.string() }), handler: (runtime, { address }) => requireKeymaster(runtime).checkAddress(address) }),
+    tool({ name: 'archon_add_address', cliCommand: 'add-address', description: 'Claim a Herald address for the current ID.', schema: z.object({ address: z.string() }), mutates: true, handler: (runtime, { address }) => requireKeymaster(runtime).addAddress(address) }),
+    tool({ name: 'archon_remove_address', cliCommand: 'remove-address', description: 'Remove a Herald address from the current ID.', schema: z.object({ address: z.string() }), mutates: true, handler: (runtime, { address }) => requireKeymaster(runtime).removeAddress(address) }),
+    tool({ name: 'archon_publish_address', cliCommand: 'publish-address', description: 'Publish a stored Herald address on a DID document.', schema: z.object({ address: z.string().optional(), id: z.string().optional() }), mutates: true, handler: (runtime, { address, id }) => requireKeymaster(runtime).publishAddress(address, id) }),
+    tool({ name: 'archon_unpublish_address', cliCommand: 'unpublish-address', description: 'Remove a published Herald address from a DID document.', schema: z.object({ id: z.string().optional() }), mutates: true, handler: (runtime, { id }) => requireKeymaster(runtime).unpublishAddress(id) }),
+
+    tool({ name: 'archon_add_nostr', cliCommand: 'add-nostr', description: 'Derive and add Nostr keys to an agent DID.', schema: z.object({ id: z.string().optional() }), mutates: true, handler: (runtime, { id }) => requireKeymaster(runtime).addNostr(id) }),
+    tool({ name: 'archon_import_nostr', cliCommand: 'import-nostr', description: 'Import Nostr keys from an nsec private key.', schema: z.object({ nsec: z.string(), id: z.string().optional() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { nsec, id }) => requireKeymaster(runtime).importNostr(nsec, id) }),
+    tool({ name: 'archon_remove_nostr', cliCommand: 'remove-nostr', description: 'Remove Nostr keys from an agent DID.', schema: z.object({ id: z.string().optional() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { id }) => requireKeymaster(runtime).removeNostr(id) }),
+
+    tool({ name: 'archon_add_lightning', cliCommand: 'add-lightning', description: 'Create a Lightning wallet for a DID.', schema: z.object({ id: z.string().optional() }), mutates: true, handler: (runtime, { id }) => requireKeymaster(runtime).addLightning(id) }),
+    tool({ name: 'archon_remove_lightning', cliCommand: 'remove-lightning', description: 'Remove Lightning wallet from a DID.', schema: z.object({ id: z.string().optional() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { id }) => requireKeymaster(runtime).removeLightning(id) }),
+    tool({ name: 'archon_lightning_balance', cliCommand: 'lightning-balance', description: 'Check Lightning wallet balance.', schema: z.object({ id: z.string().optional() }), handler: (runtime, { id }) => requireKeymaster(runtime).getLightningBalance(id) }),
+    tool({ name: 'archon_lightning_decode', cliCommand: 'lightning-decode', description: 'Decode a Lightning BOLT11 invoice.', schema: z.object({ bolt11: z.string() }), handler: (runtime, { bolt11 }) => requireKeymaster(runtime).decodeLightningInvoice(bolt11) }),
+    tool({ name: 'archon_lightning_invoice', cliCommand: 'lightning-invoice', description: 'Create a Lightning invoice.', schema: z.object({ amount: z.number().int().positive(), memo: z.string(), id: z.string().optional() }), mutates: true, handler: (runtime, { amount, memo, id }) => requireKeymaster(runtime).createLightningInvoice(amount, memo, id) }),
+    tool({ name: 'archon_lightning_pay', cliCommand: 'lightning-pay', description: 'Pay a Lightning invoice.', schema: z.object({ bolt11: z.string(), id: z.string().optional() }).merge(ConfirmPaymentSchema), mutates: true, handler: (runtime, { bolt11, id }) => requireKeymaster(runtime).payLightningInvoice(bolt11, id) }),
+    tool({ name: 'archon_lightning_check', cliCommand: 'lightning-check', description: 'Check status of a Lightning payment.', schema: z.object({ paymentHash: z.string(), id: z.string().optional() }), handler: (runtime, { paymentHash, id }) => requireKeymaster(runtime).checkLightningPayment(paymentHash, id) }),
+    tool({ name: 'archon_publish_lightning', cliCommand: 'publish-lightning', description: 'Publish Lightning service endpoint for a DID.', schema: z.object({ id: z.string().optional() }), mutates: true, handler: (runtime, { id }) => requireKeymaster(runtime).publishLightning(id) }),
+    tool({ name: 'archon_unpublish_lightning', cliCommand: 'unpublish-lightning', description: 'Remove Lightning service endpoint from a DID.', schema: z.object({ id: z.string().optional() }), mutates: true, handler: (runtime, { id }) => requireKeymaster(runtime).unpublishLightning(id) }),
+    tool({ name: 'archon_lightning_zap', cliCommand: 'lightning-zap', description: 'Send sats via Lightning to a DID, alias, or Lightning address.', schema: z.object({ recipient: z.string(), amount: z.number().int().positive(), memo: z.string().optional(), id: z.string().optional() }).merge(ConfirmPaymentSchema), mutates: true, handler: (runtime, { recipient, amount, memo, id }) => requireKeymaster(runtime).zapLightning(recipient, amount, memo, id) }),
+    tool({ name: 'archon_lightning_payments', cliCommand: 'lightning-payments', description: 'Show Lightning payment history.', schema: z.object({ id: z.string().optional() }), handler: (runtime, { id }) => requireKeymaster(runtime).getLightningPayments(id) }),
+
+    tool({ name: 'archon_create_group', cliCommand: 'create-group', description: 'Create a new group.', schema: z.object({ groupName: z.string() }).merge(AliasOptionsSchema), mutates: true, handler: (runtime, { groupName, alias, registry }) => requireKeymaster(runtime).createGroup(groupName, compactOptions({ alias, registry })) }),
+    tool({ name: 'archon_list_groups', cliCommand: 'list-groups', description: 'List groups owned by an ID.', schema: z.object({ owner: z.string().optional() }), handler: (runtime, { owner }) => requireKeymaster(runtime).listGroups(owner) }),
+    tool({ name: 'archon_get_group', cliCommand: 'get-group', description: 'Get a group by DID.', schema: DidSchema, handler: (runtime, { did }) => requireKeymaster(runtime).getGroup(did) }),
+    tool({ name: 'archon_add_group_member', cliCommand: 'add-group-member', description: 'Add a member to a group.', schema: z.object({ group: z.string(), member: z.string() }), mutates: true, handler: (runtime, { group, member }) => requireKeymaster(runtime).addGroupMember(group, member) }),
+    tool({ name: 'archon_remove_group_member', cliCommand: 'remove-group-member', description: 'Remove a member from a group.', schema: z.object({ group: z.string(), member: z.string() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { group, member }) => requireKeymaster(runtime).removeGroupMember(group, member) }),
+    tool({ name: 'archon_test_group', cliCommand: 'test-group', description: 'Determine if a member is in a group.', schema: z.object({ group: z.string(), member: z.string().optional() }), handler: (runtime, { group, member }) => requireKeymaster(runtime).testGroup(group, member) }),
+
+    tool({ name: 'archon_create_schema', cliCommand: 'create-schema', description: 'Create a schema DID from inline JSON.', schema: z.object({ schema: JsonObjectSchema, alias: z.string().optional(), registry: z.string().optional() }), mutates: true, handler: (runtime, { schema, alias, registry }) => requireKeymaster(runtime).createSchema(schema, compactOptions({ alias, registry })) }),
+    tool({ name: 'archon_list_schemas', cliCommand: 'list-schemas', description: 'List schemas owned by an ID.', schema: z.object({ owner: z.string().optional() }), handler: (runtime, { owner }) => requireKeymaster(runtime).listSchemas(owner) }),
+    tool({ name: 'archon_get_schema', cliCommand: 'get-schema', description: 'Get a schema by DID.', schema: DidSchema, handler: (runtime, { did }) => requireKeymaster(runtime).getSchema(did) }),
+    tool({ name: 'archon_create_schema_template', cliCommand: 'create-schema-template', description: 'Create a JSON template from a schema.', schema: z.object({ schema: z.string() }), handler: (runtime, { schema }) => requireKeymaster(runtime).createTemplate(schema) }),
+
+    tool({ name: 'archon_create_asset', cliCommand: 'create-asset', description: 'Create an empty JSON asset.', schema: AssetOptionsSchema, mutates: true, handler: (runtime, options) => requireKeymaster(runtime).createAsset({}, compactOptions(options)) }),
+    tool({ name: 'archon_create_asset_json', cliCommand: 'create-asset-json', description: 'Create a JSON asset DID from inline JSON data.', schema: z.object({ data: JsonObjectSchema }).merge(AssetOptionsSchema), mutates: true, handler: (runtime, { data, ...options }) => requireKeymaster(runtime).createAsset(data, compactOptions(options)) }),
+    tool({ name: 'archon_create_asset_image', cliCommand: 'create-asset-image', description: 'Create an image asset DID from an inline base64 payload.', schema: z.object({ file: InlineDataSchema }).merge(AssetOptionsSchema), mutates: true, handler: (runtime, { file, ...options }) => requireKeymaster(runtime).createImage(bufferFromInlineData(file), compactOptions({ ...options, filename: file.name })) }),
+    tool({ name: 'archon_create_asset_file', cliCommand: 'create-asset-file', description: 'Create a file asset DID from an inline payload.', schema: z.object({ file: InlineDataSchema }).merge(AssetOptionsSchema), mutates: true, handler: (runtime, { file, ...options }) => requireKeymaster(runtime).createFile(bufferFromInlineData(file), compactOptions({ ...options, filename: file.name, contentType: file.mimeType })) }),
+    tool({ name: 'archon_get_asset', cliCommand: 'get-asset', description: 'Resolve an asset by local name, alias, or DID.', schema: IdSchema.merge(ResolveOptionsSchema), handler: (runtime, { id, ...options }) => requireKeymaster(runtime).resolveAsset(id, compactOptions(options)) }),
+    tool({ name: 'archon_get_asset_json', cliCommand: 'get-asset-json', description: 'Return a JSON asset as an inline object.', schema: IdSchema.merge(ResolveOptionsSchema), handler: (runtime, { id, ...options }) => requireKeymaster(runtime).resolveAsset(id, compactOptions(options)) }),
+    tool({ name: 'archon_get_asset_image', cliCommand: 'get-asset-image', description: 'Return an image asset as an inline base64 payload.', schema: IdSchema, handler: async (runtime, { id }) => {
+        const image = await requireKeymaster(runtime).getImage(id);
+        return image?.file?.data ? { ...image, file: { ...image.file, data: inlineDataFromBuffer(Buffer.from(image.file.data), image.file.filename, image.file.type) } } : null;
+    } }),
+    tool({ name: 'archon_get_asset_file', cliCommand: 'get-asset-file', description: 'Return a file asset as an inline base64 payload.', schema: IdSchema, handler: async (runtime, { id }) => {
+        const file = await requireKeymaster(runtime).getFile(id);
+        return file?.data ? { ...file, data: inlineDataFromBuffer(Buffer.from(file.data), file.filename, file.type) } : null;
+    } }),
+    tool({ name: 'archon_update_asset_json', cliCommand: 'update-asset-json', description: 'Merge JSON object data into an existing asset.', schema: IdSchema.extend({ data: JsonObjectSchema }), mutates: true, handler: (runtime, { id, data }) => requireKeymaster(runtime).mergeData(id, data) }),
+    tool({ name: 'archon_update_asset_image', cliCommand: 'update-asset-image', description: 'Update an image asset from an inline payload.', schema: IdSchema.extend({ file: InlineDataSchema }), mutates: true, handler: (runtime, { id, file }) => requireKeymaster(runtime).updateImage(id, bufferFromInlineData(file), compactOptions({ filename: file.name })) }),
+    tool({ name: 'archon_update_asset_file', cliCommand: 'update-asset-file', description: 'Update a file asset from an inline payload.', schema: IdSchema.extend({ file: InlineDataSchema }), mutates: true, handler: (runtime, { id, file }) => requireKeymaster(runtime).updateFile(id, bufferFromInlineData(file), compactOptions({ filename: file.name, contentType: file.mimeType })) }),
+    tool({ name: 'archon_transfer_asset', cliCommand: 'transfer-asset', description: 'Transfer an asset to a new controller DID.', schema: IdSchema.extend({ controller: z.string() }), mutates: true, handler: (runtime, { id, controller }) => requireKeymaster(runtime).transferAsset(id, controller) }),
+    tool({ name: 'archon_clone_asset', cliCommand: 'clone-asset', description: 'Clone an asset.', schema: IdSchema.merge(AliasOptionsSchema), mutates: true, handler: (runtime, { id, alias, registry }) => requireKeymaster(runtime).cloneAsset(id, compactOptions({ alias, registry })) }),
+    tool({ name: 'archon_get_property', cliCommand: 'get-property', description: 'Get a property from a DID document data object.', schema: IdSchema.extend({ key: z.string() }), handler: async (runtime, { id, key }) => (await requireKeymaster(runtime).resolveDID(id)).didDocumentData?.[key] }),
+    tool({ name: 'archon_set_property', cliCommand: 'set-property', description: 'Set a property on a DID document data object.', schema: IdSchema.extend({ key: z.string(), value: JsonValueSchema.nullable().optional() }), mutates: true, handler: (runtime, { id, key, value }) => requireKeymaster(runtime).mergeData(id, { [key]: value ?? null }) }),
+    tool({ name: 'archon_list_assets', cliCommand: 'list-assets', description: 'List assets owned by an ID.', schema: z.object({ owner: z.string().optional() }), handler: (runtime, { owner }) => requireKeymaster(runtime).listAssets(owner) }),
+
+    tool({ name: 'archon_create_poll_template', cliCommand: 'create-poll-template', description: 'Create a poll config template.', schema: EmptySchema, handler: runtime => requireKeymaster(runtime).pollTemplate() }),
+    tool({ name: 'archon_create_poll', cliCommand: 'create-poll', description: 'Create a poll from inline JSON config.', schema: z.object({ config: JsonObjectSchema }).merge(VaultOptionsSchema), mutates: true, handler: (runtime, { config, ...options }) => requireKeymaster(runtime).createPoll(config, compactOptions(options)) }),
+    tool({ name: 'archon_add_poll_voter', cliCommand: 'add-poll-voter', description: 'Add a voter to a poll.', schema: z.object({ poll: z.string(), member: z.string() }), mutates: true, handler: (runtime, { poll, member }) => requireKeymaster(runtime).addPollVoter(poll, member) }),
+    tool({ name: 'archon_remove_poll_voter', cliCommand: 'remove-poll-voter', description: 'Remove a voter from a poll.', schema: z.object({ poll: z.string(), member: z.string() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { poll, member }) => requireKeymaster(runtime).removePollVoter(poll, member) }),
+    tool({ name: 'archon_list_poll_voters', cliCommand: 'list-poll-voters', description: 'List eligible voters in a poll.', schema: z.object({ poll: z.string() }), handler: (runtime, { poll }) => requireKeymaster(runtime).listPollVoters(poll) }),
+    tool({ name: 'archon_view_poll', cliCommand: 'view-poll', description: 'View poll details.', schema: z.object({ poll: z.string() }), handler: (runtime, { poll }) => requireKeymaster(runtime).viewPoll(poll) }),
+    tool({ name: 'archon_vote_poll', cliCommand: 'vote-poll', description: 'Vote in a poll.', schema: z.object({ poll: z.string(), vote: z.number().int(), registry: z.string().optional(), validUntil: z.string().optional() }), mutates: true, handler: (runtime, { poll, vote, registry, validUntil }) => requireKeymaster(runtime).votePoll(poll, vote, compactOptions({ registry, validUntil })) }),
+    tool({ name: 'archon_send_poll', cliCommand: 'send-poll', description: 'Send a poll notice to voters.', schema: z.object({ poll: z.string() }), mutates: true, handler: (runtime, { poll }) => requireKeymaster(runtime).sendPoll(poll) }),
+    tool({ name: 'archon_send_ballot', cliCommand: 'send-ballot', description: 'Send a ballot to the poll owner.', schema: z.object({ ballot: z.string(), poll: z.string() }), mutates: true, handler: (runtime, { ballot, poll }) => requireKeymaster(runtime).sendBallot(ballot, poll) }),
+    tool({ name: 'archon_view_ballot', cliCommand: 'view-ballot', description: 'View ballot details.', schema: z.object({ ballot: z.string() }), handler: (runtime, { ballot }) => requireKeymaster(runtime).viewBallot(ballot) }),
+    tool({ name: 'archon_update_poll', cliCommand: 'update-poll', description: 'Add a ballot to a poll.', schema: z.object({ ballot: z.string() }), mutates: true, handler: (runtime, { ballot }) => requireKeymaster(runtime).updatePoll(ballot) }),
+    tool({ name: 'archon_publish_poll', cliCommand: 'publish-poll', description: 'Publish poll results without revealing ballots.', schema: z.object({ poll: z.string() }), mutates: true, handler: (runtime, { poll }) => requireKeymaster(runtime).publishPoll(poll) }),
+    tool({ name: 'archon_reveal_poll', cliCommand: 'reveal-poll', description: 'Publish poll results and reveal ballots.', schema: z.object({ poll: z.string() }).merge(RevealSchema), mutates: true, handler: (runtime, { poll }) => requireKeymaster(runtime).publishPoll(poll, { reveal: true }) }),
+    tool({ name: 'archon_unpublish_poll', cliCommand: 'unpublish-poll', description: 'Remove results from a poll.', schema: z.object({ poll: z.string() }), mutates: true, handler: (runtime, { poll }) => requireKeymaster(runtime).unpublishPoll(poll) }),
+
+    tool({ name: 'archon_create_vault', cliCommand: 'create-vault', description: 'Create a vault.', schema: VaultOptionsSchema, mutates: true, handler: (runtime, options) => requireKeymaster(runtime).createVault(compactOptions(options)) }),
+    tool({ name: 'archon_list_vault_items', cliCommand: 'list-vault-items', description: 'List items in a vault.', schema: IdSchema.merge(ResolveOptionsSchema), handler: (runtime, { id, ...options }) => requireKeymaster(runtime).listVaultItems(id, compactOptions(options)) }),
+    tool({ name: 'archon_add_vault_member', cliCommand: 'add-vault-member', description: 'Add a member to a vault.', schema: IdSchema.extend({ member: z.string() }), mutates: true, handler: (runtime, { id, member }) => requireKeymaster(runtime).addVaultMember(id, member) }),
+    tool({ name: 'archon_remove_vault_member', cliCommand: 'remove-vault-member', description: 'Remove a member from a vault.', schema: IdSchema.extend({ member: z.string() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { id, member }) => requireKeymaster(runtime).removeVaultMember(id, member) }),
+    tool({ name: 'archon_list_vault_members', cliCommand: 'list-vault-members', description: 'List members of a vault.', schema: IdSchema, handler: (runtime, { id }) => requireKeymaster(runtime).listVaultMembers(id) }),
+    tool({ name: 'archon_add_vault_item', cliCommand: 'add-vault-item', description: 'Add an inline item to a vault.', schema: IdSchema.extend({ item: InlineDataSchema }), mutates: true, handler: (runtime, { id, item }) => requireKeymaster(runtime).addVaultItem(id, item.name ?? 'item', bufferFromInlineData(item)) }),
+    tool({ name: 'archon_remove_vault_item', cliCommand: 'remove-vault-item', description: 'Remove an item from a vault.', schema: IdSchema.extend({ item: z.string() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { id, item }) => requireKeymaster(runtime).removeVaultItem(id, item) }),
+    tool({ name: 'archon_get_vault_item', cliCommand: 'get-vault-item', description: 'Return a vault item as inline base64 data.', schema: IdSchema.extend({ item: z.string() }).merge(ResolveOptionsSchema), handler: async (runtime, { id, item, ...options }) => {
+        const buffer = await requireKeymaster(runtime).getVaultItem(id, item, compactOptions(options));
+        return buffer ? inlineDataFromBuffer(Buffer.from(buffer), item) : null;
+    } }),
+
+    tool({ name: 'archon_create_dmail', cliCommand: 'create-dmail', description: 'Create a dmail from inline JSON.', schema: z.object({ message: JsonObjectSchema }).merge(VaultOptionsSchema), mutates: true, handler: (runtime, { message, ...options }) => requireKeymaster(runtime).createDmail(message, compactOptions(options)) }),
+    tool({ name: 'archon_update_dmail', cliCommand: 'update-dmail', description: 'Update an existing dmail from inline JSON.', schema: DidSchema.extend({ message: JsonObjectSchema }), mutates: true, handler: (runtime, { did, message }) => requireKeymaster(runtime).updateDmail(did, message) }),
+    tool({ name: 'archon_send_dmail', cliCommand: 'send-dmail', description: 'Send a dmail and return the notice DID.', schema: DidSchema, mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).sendDmail(did) }),
+    tool({ name: 'archon_get_dmail', cliCommand: 'get-dmail', description: 'Get a dmail message by DID.', schema: DidSchema.merge(ResolveOptionsSchema), handler: (runtime, { did, ...options }) => requireKeymaster(runtime).getDmailMessage(did, compactOptions(options)) }),
+    tool({ name: 'archon_list_dmail', cliCommand: 'list-dmail', description: 'List dmails for the current ID.', schema: EmptySchema, handler: runtime => requireKeymaster(runtime).listDmail() }),
+    tool({ name: 'archon_file_dmail', cliCommand: 'file-dmail', description: 'Assign tags to a dmail.', schema: DidSchema.extend({ tags: z.array(z.string()) }), mutates: true, handler: (runtime, { did, tags }) => requireKeymaster(runtime).fileDmail(did, tags) }),
+    tool({ name: 'archon_refresh_dmail', cliCommand: 'refresh-dmail', description: 'Check for new dmails and clean up expired notices.', schema: EmptySchema, mutates: true, handler: runtime => requireKeymaster(runtime).refreshNotices() }),
+    tool({ name: 'archon_import_dmail', cliCommand: 'import-dmail', description: 'Import a dmail into the inbox.', schema: DidSchema, mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).importDmail(did) }),
+    tool({ name: 'archon_remove_dmail', cliCommand: 'remove-dmail', description: 'Delete a dmail from the local list.', schema: DidSchema.merge(ConfirmSchema), mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).removeDmail(did) }),
+    tool({ name: 'archon_add_dmail_attachment', cliCommand: 'add-dmail-attachment', description: 'Add an inline attachment to a dmail.', schema: DidSchema.extend({ attachment: InlineDataSchema }), mutates: true, handler: (runtime, { did, attachment }) => requireKeymaster(runtime).addDmailAttachment(did, attachment.name ?? 'attachment', bufferFromInlineData(attachment)) }),
+    tool({ name: 'archon_remove_dmail_attachment', cliCommand: 'remove-dmail-attachment', description: 'Remove an attachment from a dmail.', schema: DidSchema.extend({ name: z.string() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { did, name }) => requireKeymaster(runtime).removeDmailAttachment(did, name) }),
+    tool({ name: 'archon_get_dmail_attachment', cliCommand: 'get-dmail-attachment', description: 'Return a dmail attachment as inline base64 data.', schema: DidSchema.extend({ name: z.string() }), handler: async (runtime, { did, name }) => {
+        const buffer = await requireKeymaster(runtime).getDmailAttachment(did, name);
+        return buffer ? inlineDataFromBuffer(Buffer.from(buffer), name) : null;
+    } }),
+    tool({ name: 'archon_list_dmail_attachments', cliCommand: 'list-dmail-attachments', description: 'List attachments of a dmail.', schema: DidSchema.merge(ResolveOptionsSchema), handler: (runtime, { did, ...options }) => requireKeymaster(runtime).listDmailAttachments(did, compactOptions(options)) }),
+];
+
+export const ARCHON_MCP_CLI_COMMANDS = ARCHON_MCP_TOOL_DEFINITIONS
+    .map(definition => definition.cliCommand)
+    .filter((command): command is string => !!command);
+
+function registerToolDefinition(
+    server: RegisterableServer,
+    runtime: ArchonRuntime,
+    config: McpServerConfig,
+    definition: ArchonToolDefinition
+) {
+    if (definition.mutates && config.readOnly) {
+        return;
+    }
+
+    const wrapped = async (rawArgs: unknown) => {
+        try {
+            if (definition.mutates && config.readOnly) {
+                throw new Error('Tool disabled by ARCHON_MCP_READ_ONLY=true');
             }
-            return keymaster.resolveDID(resolvedId, compactOptions(options));
+            const args = definition.schema.parse(rawArgs ?? {});
+            return ok(await definition.handler(runtime, args));
+        } catch (error) {
+            return fail(error);
         }
-    );
+    };
 
-    registerTool(server, 'archon_list_aliases', 'List DID aliases in the local Keymaster wallet.', EmptySchema, async () => requireKeymaster(runtime).listAliases());
-    registerTool(server, 'archon_add_alias', 'Add a DID alias to the local Keymaster wallet.', z.object({ alias: z.string(), did: z.string() }), async ({ alias, did }) => requireKeymaster(runtime).addAlias(alias, did), mutating);
-    registerTool(server, 'archon_get_alias', 'Get the DID assigned to a local alias.', z.object({ alias: z.string() }), async ({ alias }) => requireKeymaster(runtime).getAlias(alias));
-    registerTool(server, 'archon_remove_alias', 'Remove a DID alias from the local Keymaster wallet.', z.object({ alias: z.string() }), async ({ alias }) => requireKeymaster(runtime).removeAlias(alias), mutating);
+    if (server.registerTool) {
+        server.registerTool(definition.name, { description: definition.description, inputSchema: definition.schema }, wrapped);
+        return;
+    }
 
-    registerTool(server, 'archon_list_addresses', 'List wallet addresses claimed through Herald domains.', EmptySchema, async () => requireKeymaster(runtime).listAddresses());
-    registerTool(server, 'archon_check_address', 'Check whether a Herald address is available.', z.object({ address: z.string() }), async ({ address }) => requireKeymaster(runtime).checkAddress(address));
-    registerTool(server, 'archon_add_address', 'Claim a Herald address for the current ID.', z.object({ address: z.string() }), async ({ address }) => requireKeymaster(runtime).addAddress(address), mutating);
-    registerTool(server, 'archon_remove_address', 'Remove a Herald address from the current ID.', z.object({ address: z.string() }), async ({ address }) => requireKeymaster(runtime).removeAddress(address), mutating);
-    registerTool(server, 'archon_publish_address', 'Publish a stored Herald address on a DID document.', z.object({ address: z.string().optional(), id: z.string().optional() }), async ({ address, id }) => requireKeymaster(runtime).publishAddress(address, id), mutating);
-    registerTool(server, 'archon_unpublish_address', 'Remove a published Herald address from a DID document.', z.object({ id: z.string().optional() }), async ({ id }) => requireKeymaster(runtime).unpublishAddress(id), mutating);
+    if (server.tool && definition.schema instanceof z.ZodObject) {
+        server.tool(definition.name, definition.description, definition.schema.shape, wrapped);
+        return;
+    }
 
-    registerTool(server, 'archon_list_assets', 'List assets owned by the current local ID.', EmptySchema, async () => requireKeymaster(runtime).listAssets());
-    registerTool(
-        server,
-        'archon_create_asset_json',
-        'Create a JSON asset DID from inline JSON data.',
-        z.object({ data: JsonObjectSchema }).merge(AssetOptionsSchema),
-        async ({ data, ...options }) => requireKeymaster(runtime).createAsset(data, compactOptions(options)),
-        mutating
-    );
-    registerTool(
-        server,
-        'archon_get_asset',
-        'Resolve an asset by local name, alias, or DID.',
-        z.object({ id: z.string() }).merge(ResolveOptionsSchema),
-        async ({ id, ...options }) => requireKeymaster(runtime).resolveAsset(id, compactOptions(options))
-    );
-    registerTool(
-        server,
-        'archon_update_asset_json',
-        'Merge JSON object data into an existing asset.',
-        z.object({ id: z.string(), data: JsonObjectSchema }),
-        async ({ id, data }) => requireKeymaster(runtime).mergeData(id, data),
-        mutating
-    );
-    registerTool(server, 'archon_transfer_asset', 'Transfer an asset to a new controller DID.', z.object({ id: z.string(), controller: z.string() }), async ({ id, controller }) => requireKeymaster(runtime).transferAsset(id, controller), mutating);
+    throw new Error('MCP server does not support tool registration');
+}
+
+export function registerArchonTools(server: RegisterableServer, runtime: ArchonRuntime, config: McpServerConfig): void {
+    for (const definition of ARCHON_MCP_TOOL_DEFINITIONS) {
+        registerToolDefinition(server, runtime, config, definition);
+    }
 }

--- a/tests/mcp-server/parity.test.ts
+++ b/tests/mcp-server/parity.test.ts
@@ -1,0 +1,29 @@
+import { ARCHON_MCP_CLI_COMMANDS, ARCHON_MCP_TOOL_DEFINITIONS } from '@didcid/mcp-server';
+import fs from 'fs';
+
+function normalizeCliCommand(command: string): string {
+    return command.split(/\s+/)[0];
+}
+
+describe('mcp server CLI parity', () => {
+    it('maps every Keymaster CLI command to one MCP tool', () => {
+        const cliSource = fs.readFileSync('packages/keymaster/src/cli.ts', 'utf8');
+        const cliCommands = [...cliSource.matchAll(/\.command\('([^']+)'/g)]
+            .map(match => normalizeCliCommand(match[1]))
+            .sort();
+        const mcpCommands = [...ARCHON_MCP_CLI_COMMANDS].sort();
+
+        expect(mcpCommands).toStrictEqual(cliCommands);
+    });
+
+    it('uses one MCP tool name per CLI command mapping', () => {
+        const mappedCommands = ARCHON_MCP_TOOL_DEFINITIONS
+            .filter(definition => definition.cliCommand)
+            .map(definition => definition.cliCommand);
+        const uniqueCommands = new Set(mappedCommands);
+        const uniqueToolNames = new Set(ARCHON_MCP_TOOL_DEFINITIONS.map(definition => definition.name));
+
+        expect(uniqueCommands.size).toBe(mappedCommands.length);
+        expect(uniqueToolNames.size).toBe(ARCHON_MCP_TOOL_DEFINITIONS.length);
+    });
+});

--- a/tests/mcp-server/parity.test.ts
+++ b/tests/mcp-server/parity.test.ts
@@ -26,4 +26,37 @@ describe('mcp server CLI parity', () => {
         expect(uniqueCommands.size).toBe(mappedCommands.length);
         expect(uniqueToolNames.size).toBe(ARCHON_MCP_TOOL_DEFINITIONS.length);
     });
+
+    it('requires confirmation or reveal arguments for high-risk catalog entries', () => {
+        const guardedInputs: Record<string, Record<string, unknown>> = {
+            archon_revoke_did: { did: 'did:cid:alice' },
+            archon_revoke_credential: { did: 'did:cid:credential' },
+            archon_remove_id: { name: 'alice' },
+            archon_new_wallet: {},
+            archon_import_wallet: { recoveryPhrase: 'seed words' },
+            archon_show_mnemonic: {},
+            archon_show_wallet: {},
+            archon_reveal_credential: { did: 'did:cid:credential' },
+            archon_reveal_poll: { poll: 'did:cid:poll' },
+            archon_lightning_pay: { bolt11: 'lnbc...' },
+            archon_lightning_zap: { recipient: 'alice@example.com', amount: 1 },
+        };
+
+        for (const [toolName, args] of Object.entries(guardedInputs)) {
+            const definition = ARCHON_MCP_TOOL_DEFINITIONS.find(item => item.name === toolName);
+            expect(definition?.schema.safeParse(args).success).toBe(false);
+        }
+
+        expect(ARCHON_MCP_TOOL_DEFINITIONS.find(item => item.name === 'archon_revoke_did')?.schema.safeParse({
+            did: 'did:cid:alice',
+            confirm: true,
+        }).success).toBe(true);
+        expect(ARCHON_MCP_TOOL_DEFINITIONS.find(item => item.name === 'archon_show_mnemonic')?.schema.safeParse({
+            reveal: true,
+        }).success).toBe(true);
+        expect(ARCHON_MCP_TOOL_DEFINITIONS.find(item => item.name === 'archon_lightning_pay')?.schema.safeParse({
+            bolt11: 'lnbc...',
+            confirmPayment: true,
+        }).success).toBe(true);
+    });
 });

--- a/tests/mcp-server/stdio.test.ts
+++ b/tests/mcp-server/stdio.test.ts
@@ -1,0 +1,62 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { execFileSync } from 'child_process';
+import { ARCHON_MCP_TOOL_DEFINITIONS } from '@didcid/mcp-server';
+
+function parseToolResult(response: any) {
+    return JSON.parse(response.content[0].text);
+}
+
+describe('mcp server stdio smoke', () => {
+    beforeAll(() => {
+        execFileSync('npm', ['run', 'build', '-w', '@didcid/mcp-server'], {
+            cwd: process.cwd(),
+            stdio: 'pipe',
+        });
+    }, 30000);
+
+    it('lists tools and calls read and guarded write tools over stdio', async () => {
+        const client = new Client({ name: 'archon-mcp-smoke', version: '0.0.0' });
+        const transport = new StdioClientTransport({
+            command: 'node',
+            args: ['packages/mcp-server/dist/cli.js'],
+            cwd: process.cwd(),
+            stderr: 'pipe',
+            env: {
+                ARCHON_NODE_URL: 'http://127.0.0.1:1',
+                ARCHON_WALLET_PATH: './wallet.json',
+            },
+        });
+
+        try {
+            await client.connect(transport);
+
+            const listed = await client.listTools();
+            const toolNames = listed.tools.map(tool => tool.name);
+
+            expect(toolNames).toContain('archon_get_version');
+            expect(toolNames).toContain('archon_create_id');
+            expect(toolNames.length).toBe(ARCHON_MCP_TOOL_DEFINITIONS.length);
+
+            const readResult = parseToolResult(await client.callTool({
+                name: 'archon_list_ids',
+                arguments: {},
+            }));
+            expect(readResult).toStrictEqual({
+                ok: false,
+                error: 'ARCHON_PASSPHRASE is required for wallet-backed MCP tools',
+            });
+
+            const writeResult = parseToolResult(await client.callTool({
+                name: 'archon_create_id',
+                arguments: { name: 'alice' },
+            }));
+            expect(writeResult).toStrictEqual({
+                ok: false,
+                error: 'ARCHON_PASSPHRASE is required for wallet-backed MCP tools',
+            });
+        } finally {
+            await client.close();
+        }
+    }, 30000);
+});

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { registerArchonTools, McpServerConfig } from '@didcid/mcp-server';
+import { ARCHON_MCP_TOOL_DEFINITIONS, registerArchonTools, McpServerConfig } from '@didcid/mcp-server';
 
 type ToolHandler = (args?: unknown) => Promise<any>;
 
@@ -20,62 +20,137 @@ const baseConfig: McpServerConfig = {
     readOnly: false,
 };
 
-const mutatingTools = [
-    'archon_add_address',
-    'archon_add_alias',
-    'archon_create_asset_json',
-    'archon_create_id',
-    'archon_publish_address',
-    'archon_remove_address',
-    'archon_remove_alias',
-    'archon_transfer_asset',
-    'archon_unpublish_address',
-    'archon_update_asset_json',
-    'archon_use_id',
-];
-
-const readTools = [
-    'archon_check_address',
-    'archon_get_alias',
-    'archon_get_asset',
-    'archon_get_current_id',
-    'archon_get_status',
-    'archon_get_version',
-    'archon_list_addresses',
-    'archon_list_aliases',
-    'archon_list_assets',
-    'archon_list_ids',
-    'archon_list_registries',
-    'archon_resolve_did',
-    'archon_resolve_id',
-];
+const mutatingTools = ARCHON_MCP_TOOL_DEFINITIONS.filter(definition => definition.mutates).map(definition => definition.name);
+const readTools = ARCHON_MCP_TOOL_DEFINITIONS.filter(definition => !definition.mutates).map(definition => definition.name);
 
 function parseToolResult(response: any) {
     return JSON.parse(response.content[0].text);
 }
 
 function mockRuntime(overrides: Record<string, unknown> = {}) {
-    const keymaster = {
+    const defaults: Record<string, any> = {
+        loadWallet: jest.fn().mockResolvedValue({ version: 2, ids: {} }),
+        newWallet: jest.fn().mockResolvedValue({ version: 2, ids: {} }),
+        changePassphrase: jest.fn().mockResolvedValue(true),
+        checkWallet: jest.fn().mockResolvedValue({ checked: 0, invalid: 0, deleted: 0 }),
+        fixWallet: jest.fn().mockResolvedValue({ idsRemoved: 0, ownedRemoved: 0, heldRemoved: 0, aliasesRemoved: 0 }),
+        exportEncryptedWallet: jest.fn().mockResolvedValue({ version: 2, mnemonicEnc: 'encrypted' }),
+        saveWallet: jest.fn().mockResolvedValue(true),
+        decryptMnemonic: jest.fn().mockResolvedValue('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'),
+        backupWallet: jest.fn().mockResolvedValue('did:cid:wallet'),
+        recoverWallet: jest.fn().mockResolvedValue({ version: 2, ids: {} }),
         listIds: jest.fn().mockResolvedValue(['alice']),
         getCurrentId: jest.fn().mockResolvedValue('alice'),
         setCurrentId: jest.fn().mockResolvedValue(true),
         createId: jest.fn().mockResolvedValue('did:cid:new'),
+        backupId: jest.fn().mockResolvedValue(true),
+        recoverId: jest.fn().mockResolvedValue('alice'),
+        removeId: jest.fn().mockResolvedValue(true),
+        renameId: jest.fn().mockResolvedValue(true),
+        rotateKeys: jest.fn().mockResolvedValue(true),
+        revokeDID: jest.fn().mockResolvedValue(true),
+        changeRegistry: jest.fn().mockResolvedValue(true),
+        encryptMessage: jest.fn().mockResolvedValue('did:cid:encrypted'),
+        decryptMessage: jest.fn().mockResolvedValue('plaintext'),
+        decryptJSON: jest.fn().mockResolvedValue({ hello: 'world' }),
+        addProof: jest.fn().mockResolvedValue({ proof: {} }),
+        verifyProof: jest.fn().mockResolvedValue(true),
+        createChallenge: jest.fn().mockResolvedValue('did:cid:challenge'),
+        createResponse: jest.fn().mockResolvedValue('did:cid:response'),
+        verifyResponse: jest.fn().mockResolvedValue({ match: true }),
+        bindCredential: jest.fn().mockResolvedValue({ type: ['VerifiableCredential'] }),
+        issueCredential: jest.fn().mockResolvedValue('did:cid:credential'),
+        listIssued: jest.fn().mockResolvedValue(['did:cid:credential']),
+        updateCredential: jest.fn().mockResolvedValue(true),
+        revokeCredential: jest.fn().mockResolvedValue(true),
+        acceptCredential: jest.fn().mockResolvedValue(true),
+        listCredentials: jest.fn().mockResolvedValue(['did:cid:credential']),
+        getCredential: jest.fn().mockResolvedValue({ type: ['VerifiableCredential'] }),
+        publishCredential: jest.fn().mockResolvedValue({ type: ['VerifiableCredential'] }),
+        unpublishCredential: jest.fn().mockResolvedValue('OK'),
         resolveDID: jest.fn().mockResolvedValue({ didDocument: { id: 'did:cid:alice' } }),
         listAliases: jest.fn().mockResolvedValue({ me: 'did:cid:alice' }),
         addAlias: jest.fn().mockResolvedValue(true),
         getAlias: jest.fn().mockResolvedValue('did:cid:alice'),
         removeAlias: jest.fn().mockResolvedValue(true),
         listAddresses: jest.fn().mockResolvedValue({}),
+        getAddress: jest.fn().mockResolvedValue({ address: 'alice@example.com' }),
+        importAddress: jest.fn().mockResolvedValue({}),
         checkAddress: jest.fn().mockResolvedValue({ available: true }),
         addAddress: jest.fn().mockResolvedValue(true),
         removeAddress: jest.fn().mockResolvedValue(true),
         publishAddress: jest.fn().mockResolvedValue(true),
         unpublishAddress: jest.fn().mockResolvedValue(true),
+        addNostr: jest.fn().mockResolvedValue({ npub: 'npub...' }),
+        importNostr: jest.fn().mockResolvedValue({ npub: 'npub...' }),
+        removeNostr: jest.fn().mockResolvedValue(true),
+        addLightning: jest.fn().mockResolvedValue({ walletId: 'wallet' }),
+        removeLightning: jest.fn().mockResolvedValue(true),
+        getLightningBalance: jest.fn().mockResolvedValue({ balance: 0 }),
+        decodeLightningInvoice: jest.fn().mockResolvedValue({ amount: '1 sats' }),
+        createLightningInvoice: jest.fn().mockResolvedValue({ bolt11: 'lnbc...' }),
+        payLightningInvoice: jest.fn().mockResolvedValue({ paymentHash: 'hash' }),
+        checkLightningPayment: jest.fn().mockResolvedValue({ paid: true }),
+        publishLightning: jest.fn().mockResolvedValue(true),
+        unpublishLightning: jest.fn().mockResolvedValue(true),
+        zapLightning: jest.fn().mockResolvedValue({ paymentHash: 'hash' }),
+        getLightningPayments: jest.fn().mockResolvedValue([]),
+        createGroup: jest.fn().mockResolvedValue('did:cid:group'),
+        listGroups: jest.fn().mockResolvedValue(['did:cid:group']),
+        getGroup: jest.fn().mockResolvedValue({ members: [] }),
+        addGroupMember: jest.fn().mockResolvedValue(true),
+        removeGroupMember: jest.fn().mockResolvedValue(true),
+        testGroup: jest.fn().mockResolvedValue(true),
+        createSchema: jest.fn().mockResolvedValue('did:cid:schema'),
+        listSchemas: jest.fn().mockResolvedValue(['did:cid:schema']),
+        getSchema: jest.fn().mockResolvedValue({ type: 'object' }),
+        createTemplate: jest.fn().mockResolvedValue({ propertyName: 'TBD' }),
         listAssets: jest.fn().mockResolvedValue(['asset']),
         createAsset: jest.fn().mockResolvedValue('did:cid:asset'),
+        createImage: jest.fn().mockResolvedValue('did:cid:image'),
+        createFile: jest.fn().mockResolvedValue('did:cid:file'),
         resolveAsset: jest.fn().mockResolvedValue({ hello: 'world' }),
+        getImage: jest.fn().mockResolvedValue({ file: { filename: 'image.png', type: 'image/png', data: Buffer.from('image') }, image: { width: 1, height: 1 } }),
+        getFile: jest.fn().mockResolvedValue({ filename: 'file.txt', type: 'text/plain', data: Buffer.from('file') }),
         mergeData: jest.fn().mockResolvedValue(true),
+        updateImage: jest.fn().mockResolvedValue(true),
+        updateFile: jest.fn().mockResolvedValue(true),
         transferAsset: jest.fn().mockResolvedValue(true),
+        cloneAsset: jest.fn().mockResolvedValue('did:cid:clone'),
+        pollTemplate: jest.fn().mockResolvedValue({ version: 2 }),
+        createPoll: jest.fn().mockResolvedValue('did:cid:poll'),
+        addPollVoter: jest.fn().mockResolvedValue(true),
+        removePollVoter: jest.fn().mockResolvedValue(true),
+        listPollVoters: jest.fn().mockResolvedValue({}),
+        viewPoll: jest.fn().mockResolvedValue({}),
+        votePoll: jest.fn().mockResolvedValue('did:cid:ballot'),
+        sendPoll: jest.fn().mockResolvedValue('did:cid:notice'),
+        sendBallot: jest.fn().mockResolvedValue('did:cid:notice'),
+        viewBallot: jest.fn().mockResolvedValue({}),
+        updatePoll: jest.fn().mockResolvedValue(true),
+        publishPoll: jest.fn().mockResolvedValue(true),
+        unpublishPoll: jest.fn().mockResolvedValue(true),
+        createVault: jest.fn().mockResolvedValue('did:cid:vault'),
+        listVaultItems: jest.fn().mockResolvedValue({}),
+        addVaultMember: jest.fn().mockResolvedValue(true),
+        removeVaultMember: jest.fn().mockResolvedValue(true),
+        listVaultMembers: jest.fn().mockResolvedValue({}),
+        addVaultItem: jest.fn().mockResolvedValue(true),
+        removeVaultItem: jest.fn().mockResolvedValue(true),
+        getVaultItem: jest.fn().mockResolvedValue(Buffer.from('vault')),
+        createDmail: jest.fn().mockResolvedValue('did:cid:dmail'),
+        updateDmail: jest.fn().mockResolvedValue(true),
+        sendDmail: jest.fn().mockResolvedValue('did:cid:notice'),
+        getDmailMessage: jest.fn().mockResolvedValue({ subject: 'hello' }),
+        listDmail: jest.fn().mockResolvedValue({}),
+        fileDmail: jest.fn().mockResolvedValue(true),
+        refreshNotices: jest.fn().mockResolvedValue(true),
+        importDmail: jest.fn().mockResolvedValue(true),
+        removeDmail: jest.fn().mockResolvedValue(true),
+        addDmailAttachment: jest.fn().mockResolvedValue(true),
+        removeDmailAttachment: jest.fn().mockResolvedValue(true),
+        getDmailAttachment: jest.fn().mockResolvedValue(Buffer.from('attachment')),
+        listDmailAttachments: jest.fn().mockResolvedValue({}),
         ...overrides,
     };
 
@@ -85,16 +160,16 @@ function mockRuntime(overrides: Record<string, unknown> = {}) {
             getStatus: jest.fn().mockResolvedValue({ ready: true }),
             listRegistries: jest.fn().mockResolvedValue(['hyperswarm']),
         },
-        keymaster,
+        keymaster: defaults,
     };
 }
 
 describe('mcp server tools', () => {
-    it('registers the v1 tool surface', () => {
+    it('registers the CLI-complete tool surface', () => {
         const server = new FakeServer();
         registerArchonTools(server, mockRuntime() as any, baseConfig);
 
-        expect([...server.tools.keys()].sort()).toStrictEqual([...mutatingTools, ...readTools].sort());
+        expect([...server.tools.keys()].sort()).toStrictEqual(ARCHON_MCP_TOOL_DEFINITIONS.map(definition => definition.name).sort());
     });
 
     it('calls read tools and returns compact JSON payloads', async () => {
@@ -118,6 +193,32 @@ describe('mcp server tools', () => {
             expect(server.tools.has(tool)).toBe(false);
         }
         expect(runtime.keymaster.createId).not.toHaveBeenCalled();
+    });
+
+    it('requires explicit confirmation for destructive tools', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const response = await server.tools.get('archon_revoke_did')!.handler({ did: 'did:cid:alice' });
+        const result = parseToolResult(response);
+
+        expect(result.ok).toBe(false);
+        expect(result.error).toContain('Invalid literal value');
+        expect(runtime.keymaster.revokeDID).not.toHaveBeenCalled();
+    });
+
+    it('requires explicit reveal for secret-revealing tools', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const response = await server.tools.get('archon_show_mnemonic')!.handler({});
+        const result = parseToolResult(response);
+
+        expect(result.ok).toBe(false);
+        expect(result.error).toContain('Invalid literal value');
+        expect(runtime.keymaster.decryptMnemonic).not.toHaveBeenCalled();
     });
 
     it('returns a clear passphrase error for wallet-backed tools without keymaster runtime', async () => {
@@ -163,11 +264,32 @@ describe('mcp server tools', () => {
         );
     });
 
+    it('passes inline base64 payloads to file-like tools', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const response = await server.tools.get('archon_create_asset_file')!.handler({
+            file: {
+                name: 'hello.txt',
+                mimeType: 'text/plain',
+                data: Buffer.from('hello').toString('base64'),
+            },
+            alias: 'hello',
+        });
+
+        expect(parseToolResult(response)).toStrictEqual({ ok: true, result: 'did:cid:file' });
+        expect(runtime.keymaster.createFile).toHaveBeenCalledWith(
+            Buffer.from('hello'),
+            { alias: 'hello', filename: 'hello.txt', contentType: 'text/plain' }
+        );
+    });
+
     it('redacts secrets from tool errors', async () => {
         const server = new FakeServer();
         const runtime = mockRuntime({
             listIds: jest.fn().mockRejectedValue(
-                new Error('failed ARCHON_PASSPHRASE="my secret phrase" https://user:pass@bitcoin-mainnet.g.alchemy.com/v3/api-token?api_key=123')
+                new Error('failed ARCHON_PASSPHRASE="my secret phrase" recoveryPhrase=seed words nsec=nsec-secret bolt11=lnbc-secret https://user:pass@bitcoin-mainnet.g.alchemy.com/v3/api-token?api_key=123')
             ),
         });
         registerArchonTools(server, runtime as any, baseConfig);
@@ -180,6 +302,8 @@ describe('mcp server tools', () => {
         expect(result.error).toContain('https://<redacted>@bitcoin-mainnet.g.alchemy.com/v3/<redacted>?api_key=<redacted>');
         expect(result.error).not.toContain('secret');
         expect(result.error).not.toContain('phrase');
+        expect(result.error).not.toContain('nsec-secret');
+        expect(result.error).not.toContain('lnbc-secret');
         expect(result.error).not.toContain('api-token');
     });
 });

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -285,6 +285,40 @@ describe('mcp server tools', () => {
         );
     });
 
+    it('returns file-like assets as inline payloads', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const fileResponse = await server.tools.get('archon_get_asset_file')!.handler({ id: 'did:cid:file' });
+        expect(parseToolResult(fileResponse)).toStrictEqual({
+            ok: true,
+            result: {
+                name: 'file.txt',
+                mimeType: 'text/plain',
+                encoding: 'base64',
+                data: Buffer.from('file').toString('base64'),
+            },
+        });
+
+        const imageResponse = await server.tools.get('archon_get_asset_image')!.handler({ id: 'did:cid:image' });
+        expect(parseToolResult(imageResponse)).toStrictEqual({
+            ok: true,
+            result: {
+                file: {
+                    name: 'image.png',
+                    mimeType: 'image/png',
+                    encoding: 'base64',
+                    data: Buffer.from('image').toString('base64'),
+                },
+                image: {
+                    width: 1,
+                    height: 1,
+                },
+            },
+        });
+    });
+
     it('redacts secrets from tool errors', async () => {
         const server = new FakeServer();
         const runtime = mockRuntime({
@@ -302,6 +336,8 @@ describe('mcp server tools', () => {
         expect(result.error).toContain('https://<redacted>@bitcoin-mainnet.g.alchemy.com/v3/<redacted>?api_key=<redacted>');
         expect(result.error).not.toContain('secret');
         expect(result.error).not.toContain('phrase');
+        expect(result.error).not.toContain('seed');
+        expect(result.error).not.toContain('words');
         expect(result.error).not.toContain('nsec-secret');
         expect(result.error).not.toContain('lnbc-secret');
         expect(result.error).not.toContain('api-token');


### PR DESCRIPTION
## Summary
- replace hand-written MCP tool registration with a central catalog that maps every Keymaster CLI command to one MCP tool
- add inline JSON/text/base64 payload conventions for file-like CLI commands and expose wallet, crypto, credential, Nostr, Lightning, group, schema, asset, poll, vault, and dmail tools
- add confirmation/reveal/payment guards for destructive, secret-revealing, and payment-style tools while preserving read-only tool omission
- document the full CLI-to-MCP command matrix and export the catalog for tests

## Tests
- npm run build -w @didcid/mcp-server
- node --experimental-vm-modules node_modules/.bin/jest tests/mcp-server --runInBand --verbose
- npx eslint packages/mcp-server/src tests/mcp-server apps/herald-client/src/App.tsx
- npm pack --dry-run -w @didcid/mcp-server
- npm run build