### PR TITLE
chore: Purge stale did:mdip / KeychainMDIP references

### DIFF
--- a/.github/workflows/lockfile-consistency.yml
+++ b/.github/workflows/lockfile-consistency.yml
@@ -33,6 +33,25 @@ jobs:
             [ -z "$manifest" ] && continue
             dir="$(dirname "$manifest")"
 
+            # Skip manifests whose dependency-relevant fields are unchanged.
+            # The lockfile only tracks resolution fields (name, version,
+            # dependency maps, engines, bin, os, cpu, workspaces, overrides),
+            # so edits limited to metadata (bugs, homepage, description,
+            # keywords, scripts, ...) cannot change it and must not be gated.
+            # Added/removed manifests or parse failures fall through and are
+            # still required to update the lockfile.
+            base_manifest="$(git show "$BASE_SHA:$manifest" 2>/dev/null || true)"
+            head_manifest="$(git show "$HEAD_SHA:$manifest" 2>/dev/null || true)"
+            if [ -n "$base_manifest" ] && [ -n "$head_manifest" ]; then
+              relevant='{name, version, dependencies, devDependencies, peerDependencies, optionalDependencies, peerDependenciesMeta, bundleDependencies, bundledDependencies, workspaces, overrides, engines, bin, os, cpu}'
+              base_relevant="$(printf '%s' "$base_manifest" | jq -S "$relevant" 2>/dev/null || echo base-parse-error)"
+              head_relevant="$(printf '%s' "$head_manifest" | jq -S "$relevant" 2>/dev/null || echo head-parse-error)"
+              if [ "$base_relevant" = "$head_relevant" ]; then
+                echo "Skipping $manifest (no dependency-relevant changes)"
+                continue
+              fi
+            fi
+
             if [ "$manifest" = "package.json" ]; then
               lockfile="package-lock.json"
             elif [ -f "$dir/package-lock.json" ]; then

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -5221,7 +5221,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                 onChange={(e) => setSchemaPackDID(e.target.value.trim())}
                                                 fullWidth
                                                 margin="normal"
-                                                placeholder="did:mdip:..."
+                                                placeholder="did:cid:..."
                                             />
                                         </Grid>
                                         <Grid item>

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -5221,7 +5221,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                 onChange={(e) => setSchemaPackDID(e.target.value.trim())}
                                                 fullWidth
                                                 margin="normal"
-                                                placeholder="did:mdip:..."
+                                                placeholder="did:cid:..."
                                             />
                                         </Grid>
                                         <Grid item>

--- a/packages/browser-hdkey/package.json
+++ b/packages/browser-hdkey/package.json
@@ -25,10 +25,6 @@
     "deterministic",
     "crypto"
   ],
-  "bugs": {
-    "url": "https://github.com/KeychainMDIP/browser-hdkey/issues"
-  },
-  "homepage": "https://github.com/KeychainMDIP/browser-hdkey",
   "publishConfig": {
     "registry": "https://registry.npmjs.org",
     "access": "public"

--- a/tests/pinning/mediator.test.ts
+++ b/tests/pinning/mediator.test.ts
@@ -12,11 +12,6 @@ import type { PinningServiceProvider, ProviderPinRequest } from '../../services/
 function op(id: string, registry = 'BTC:mainnet'): Operation {
     return {
         type: 'create',
-        mdip: {
-            version: 1,
-            type: 'agent',
-            registry,
-        },
         publicJwk: { kid: id },
         registration: {
             version: 1,

--- a/tests/wallet/zcash-wallet.test.ts
+++ b/tests/wallet/zcash-wallet.test.ts
@@ -138,7 +138,7 @@ describe('zcash-wallet RPC-backed behavior', () => {
             },
         });
 
-        await expect(anchorData(rpc, TEST_MNEMONIC, 'mainnet', `did:mdip:${'a'.repeat(54)}`)).resolves.toEqual({
+        await expect(anchorData(rpc, TEST_MNEMONIC, 'mainnet', `did:cid:${'a'.repeat(54)}`)).resolves.toEqual({
             txid: 'broadcast-txid',
             fee: 0.0002,
         });


### PR DESCRIPTION
Clears the last `did:mdip` / `KeychainMDIP` remnants that survived the rename to `did:cid`. Live source is overwhelmingly `did:cid` (25 vs 2); this removes the stragglers.

### 1. Purge stale references (`chore`)
- **KeymasterUI placeholders** (`gatekeeper-client`, `keymaster-client`) — the *Schema Pack DID* field showed `did:mdip:...` (user-facing) → `did:cid:...`
- **zcash-wallet test** — `did:mdip:` fixture → `did:cid:`
- **pinning mediator test** — `op()` helper carried a stale `mdip` block duplicating `registration` (the field the code actually reads at `sync.ts:23`); the `as unknown as Operation` cast had masked that it no longer matched the `Operation` type. Removed.
- **browser-hdkey package.json** — `bugs`/`homepage` pointed at upstream `KeychainMDIP/browser-hdkey` while `repository` already points at `archetech/archon`. Removed.

Left untouched: auto-generated `CHANGELOG.md` history.

**Tests:** `tests/wallet/zcash-wallet.test.ts` 8/8, `tests/pinning/mediator.test.ts` 8/8.

### 2. Fix a `lockfile-consistency` false positive (`ci`)
Removing `bugs`/`homepage` is a manifest change, but the lockfile only records resolution fields (name, version, dependency maps, engines, bin, os, cpu, workspaces, overrides) — never metadata. So the edit produces *no possible* lockfile diff, yet the old gate required `package-lock.json` to change alongside any `package.json`, making it un-passable for metadata-only edits.

The check now compares the dependency-relevant subset of each manifest (base vs head, via `jq`) and only requires a lockfile update when that subset actually changed. Added/removed manifests and parse failures still fall through to the requirement, so genuine dependency changes remain gated.

Verified locally: metadata-only edit → pass; real dependency change without lockfile → fail; real dependency change with lockfile → pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)