### PR TITLE
spike: DIDComm Phase 0 — didcomm-node round-trip

### DIFF
--- a/spike/didcomm-phase0/.gitignore
+++ b/spike/didcomm-phase0/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/spike/didcomm-phase0/README.md
+++ b/spike/didcomm-phase0/README.md
@@ -1,0 +1,65 @@
+# DIDComm — Phase 0 spike
+
+Throwaway spike for the [DIDComm design doc](../../docs/didcomm-design.md). It
+de-risks the build-vs-buy and curve decisions by packing/unpacking real DIDComm
+v2 envelopes between two Archon-shaped DIDs using the
+[`didcomm-node`](https://www.npmjs.com/package/didcomm-node) library through the
+two adapter interfaces (`DIDResolver`, `SecretsResolver`) that later phases will
+back with the gatekeeper and the wallet.
+
+This is **not** wired into the monorepo (root `workspaces` is only `packages/*`)
+— it is a standalone, self-contained project.
+
+## Run
+
+```sh
+cd spike/didcomm-phase0
+npm ci          # installs didcomm-node@0.4.1 (WASM, Node target)
+node spike.mjs
+```
+
+Expected output: three `PASS` lines (anoncrypt, authcrypt, authcrypt+sign).
+
+## What it does
+
+- Generates X25519 key-agreement keys (Alice + Bob) and a **secp256k1** signing
+  key for Alice, via Node's built-in `crypto` exported as JWK.
+- Builds Archon-shaped (normalized) DID documents — `{ id, keyAgreement[],
+  authentication[], verificationMethod[] (publicKeyJwk), service[] }` with a
+  `DIDCommMessaging` service — served from an in-memory `DIDResolver`.
+- Exposes the private keys via an in-memory `SecretsResolver`
+  (`get_secret` / `find_secrets`, keyed by full DID-fragment kids).
+- Runs three pack→unpack round-trips and asserts the plaintext + metadata.
+
+## Findings
+
+| Test | Result | Algorithm selected by the library |
+|---|---|---|
+| anoncrypt (anonymous sender) | PASS | `XC20P` + `ECDH-ES+A256KW` over X25519 |
+| authcrypt (authenticated sender) | PASS | `A256CBC-HS512` + `ECDH-1PU+A256KW` over X25519 |
+| authcrypt + sign | PASS | encryption as above; signature **`ES256K`** (secp256k1) |
+
+### Decisions locked
+
+- **Use `didcomm-node`** (not the `didcomm` package — that one is a
+  bundler/WASM target that does not load under plain Node). The adapter surface
+  is small and exactly what Phase 2 needs.
+- **X25519 for key agreement.** The library's encryption curves are X25519 and
+  P-256 only; secp256k1 cannot do key agreement.
+- **secp256k1 keys sign DIDComm as-is** via `ES256K` — confirmed by a valid JWS
+  with `non_repudiation: true`. So each Archon identity needs only a *new*
+  X25519 key-agreement key; existing keys keep signing.
+
+### Notes for Phase 1/2
+
+- Verification-method `id`s must be full DID fragments (`did:cid:x#key-…`) and
+  the wallet secret `id`s must match the DID-doc vm `id`s exactly.
+- `forward: false` is required for direct two-party delivery; the default
+  (`true`) invokes the Forward/mediator routing protocol (Phase 3/6).
+
+### Caveats (validated-by-construction, not against live Archon)
+
+- DID docs here are **mocks** shaped like the gatekeeper's normalized output —
+  Phase 1 must prove a real `DidCidDocument` normalizes cleanly.
+- X25519 keys are generated ad hoc, not derived from a wallet HD seed — that
+  deterministic derivation is the first Phase 1 task.

--- a/spike/didcomm-phase0/package-lock.json
+++ b/spike/didcomm-phase0/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "didcomm-phase0-spike",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "didcomm-phase0-spike",
+      "version": "0.0.0",
+      "dependencies": {
+        "didcomm-node": "^0.4.1"
+      }
+    },
+    "node_modules/didcomm-node": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/didcomm-node/-/didcomm-node-0.4.1.tgz",
+      "integrity": "sha512-5vR2T6AyFhw20LI3Hu7Xps1nYimpooEIbefweIAsZ964p8sSnWW07qulvnRwd1fMihtUaAK+DlwGkR4jZIf6Mg==",
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/spike/didcomm-phase0/package.json
+++ b/spike/didcomm-phase0/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "didcomm-phase0-spike",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "didcomm-node": "^0.4.1"
+  }
+}

--- a/spike/didcomm-phase0/spike.mjs
+++ b/spike/didcomm-phase0/spike.mjs
@@ -1,0 +1,126 @@
+// DIDComm Phase 0 spike — validate didcomm-node pack/unpack between two
+// Archon-shaped DIDs carrying X25519 key-agreement keys, via thin
+// DIDResolver / SecretsResolver adapters. Throwaway.
+import { createRequire } from 'node:module';
+import crypto from 'node:crypto';
+
+const require = createRequire(import.meta.url);
+const { Message } = require('didcomm-node');
+
+// --- keygen via Node crypto, exported as standard JWK (no extra deps) ---
+const jwkPair = (type, opts) => {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync(type, opts);
+  return { pub: publicKey.export({ format: 'jwk' }), priv: privateKey.export({ format: 'jwk' }) };
+};
+const genX25519 = () => jwkPair('x25519');
+const genSecp256k1 = () => jwkPair('ec', { namedCurve: 'secp256k1' });
+
+const ALICE = 'did:cid:alice';
+const BOB = 'did:cid:bob';
+
+const aliceKA = genX25519();
+const aliceSig = genSecp256k1(); // Archon's existing key type — for signing (ES256K)
+const bobKA = genX25519();
+
+const aliceKAId = `${ALICE}#key-agreement-1`;
+const aliceSigId = `${ALICE}#key-signing-1`;
+const bobKAId = `${BOB}#key-agreement-1`;
+
+// --- Archon-shaped (normalized) DID documents the gatekeeper adapter would emit ---
+function didDoc(id, ka, sig) {
+  const vm = [{ id: ka.id, type: 'JsonWebKey2020', controller: id, publicKeyJwk: ka.jwk }];
+  const doc = {
+    id,
+    keyAgreement: [ka.id],
+    authentication: [],
+    verificationMethod: vm,
+    service: [{
+      id: `${id}#didcomm`,
+      type: 'DIDCommMessaging',
+      serviceEndpoint: { uri: `https://example.org/didcomm/${id.split(':').pop()}`, accept: ['didcomm/v2'], routing_keys: [] },
+    }],
+  };
+  if (sig) {
+    vm.push({ id: sig.id, type: 'JsonWebKey2020', controller: id, publicKeyJwk: sig.jwk });
+    doc.authentication.push(sig.id);
+  }
+  return doc;
+}
+
+const DOCS = {
+  [ALICE]: didDoc(ALICE, { id: aliceKAId, jwk: aliceKA.pub }, { id: aliceSigId, jwk: aliceSig.pub }),
+  [BOB]: didDoc(BOB, { id: bobKAId, jwk: bobKA.pub }),
+};
+
+// --- adapters (the two pieces Phase 2 will back with gatekeeper + wallet) ---
+class DIDResolver {
+  constructor(docs) { this.docs = docs; }
+  async resolve(did) { return this.docs[did] ?? null; }
+}
+class SecretsResolver {
+  constructor(secrets) { this.secrets = secrets; }
+  async get_secret(id) { return this.secrets[id] ?? null; }
+  async find_secrets(ids) { return ids.filter((i) => i in this.secrets); }
+}
+
+const resolver = new DIDResolver(DOCS);
+const aliceSecrets = new SecretsResolver({
+  [aliceKAId]: { id: aliceKAId, type: 'JsonWebKey2020', privateKeyJwk: aliceKA.priv },
+  [aliceSigId]: { id: aliceSigId, type: 'JsonWebKey2020', privateKeyJwk: aliceSig.priv },
+});
+const bobSecrets = new SecretsResolver({
+  [bobKAId]: { id: bobKAId, type: 'JsonWebKey2020', privateKeyJwk: bobKA.priv },
+});
+
+const PLAINTEXT = 'hello from Archon over DIDComm';
+const makeMsg = (withFrom) => new Message({
+  id: 'spike-' + crypto.randomUUID(),
+  typ: 'application/didcomm-plain+json',
+  type: 'https://example.org/spike/1.0/hello',
+  ...(withFrom ? { from: ALICE } : {}),
+  to: [BOB],
+  body: { text: PLAINTEXT },
+  created_time: 1718900000,
+});
+
+const opts = { forward: false }; // two-party direct delivery; no mediator routing
+
+const ok = (b) => (b ? 'PASS' : 'FAIL');
+const m = (meta) => JSON.stringify(meta);
+
+async function run() {
+  console.log('node', process.version, '| didcomm-node', require('didcomm-node/package.json').version);
+  console.log('alice KA jwk:', JSON.stringify(aliceKA.pub), '\nalice sig jwk:', JSON.stringify(aliceSig.pub), '\n');
+
+  // 1) anoncrypt (ECDH-ES, anonymous sender)
+  {
+    const [packed] = await makeMsg(false).pack_encrypted(BOB, null, null, resolver, aliceSecrets, opts);
+    const [unpacked, meta] = await Message.unpack(packed, resolver, bobSecrets, {});
+    const v = unpacked.as_value();
+    console.log('[1] anoncrypt          ', ok(v.body.text === PLAINTEXT && meta.encrypted && !meta.authenticated));
+    console.log('    meta:', m(meta));
+    console.log('    envelope head:', packed.slice(0, 70), '...\n');
+  }
+
+  // 2) authcrypt (ECDH-1PU, authenticated sender via X25519)
+  {
+    const [packed] = await makeMsg(true).pack_encrypted(BOB, ALICE, null, resolver, aliceSecrets, opts);
+    const [unpacked, meta] = await Message.unpack(packed, resolver, bobSecrets, {});
+    const v = unpacked.as_value();
+    console.log('[2] authcrypt          ', ok(v.body.text === PLAINTEXT && meta.encrypted && meta.authenticated && v.from === ALICE));
+    console.log('    meta:', m(meta), '\n');
+  }
+
+  // 3) authcrypt + sign with Archon's secp256k1 key (ES256K) — the key Archon-specific claim
+  {
+    const [packed] = await makeMsg(true).pack_encrypted(BOB, ALICE, aliceSigId, resolver, aliceSecrets, opts);
+    const [unpacked, meta] = await Message.unpack(packed, resolver, bobSecrets, {});
+    const v = unpacked.as_value();
+    console.log('[3] authcrypt+sign ES256K', ok(v.body.text === PLAINTEXT && meta.encrypted && meta.authenticated && meta.non_repudiation && meta.sign_from === aliceSigId));
+    console.log('    meta:', m(meta), '\n');
+  }
+
+  console.log('DONE');
+}
+
+run().catch((e) => { console.error('SPIKE ERROR:', e); process.exit(1); });


### PR DESCRIPTION
Phase 0 of the [DIDComm design doc](../blob/main/docs/didcomm-design.md): a self-contained, throwaway spike that de-risks the build-vs-buy and curve decisions before any real implementation.

It packs/unpacks DIDComm v2 envelopes between two Archon-shaped DIDs (`did:cid:alice`/`did:cid:bob`) using [`didcomm-node`](https://www.npmjs.com/package/didcomm-node) through the two adapter interfaces (`DIDResolver`, `SecretsResolver`) that Phase 2 will back with the gatekeeper and the wallet.

### Results — all three round-trips pass
| Test | Algorithm chosen by the library |
|---|---|
| anoncrypt (anonymous sender) | `XC20P` + `ECDH-ES+A256KW` over X25519 |
| authcrypt (authenticated sender) | `A256CBC-HS512` + `ECDH-1PU+A256KW` over X25519 |
| authcrypt + sign | encryption as above; signature **`ES256K`** (secp256k1) |

### Decisions locked
- **Use `didcomm-node`** — the plain `didcomm` package is a bundler/WASM target that won't load under Node. Adapter surface is small and exactly what Phase 2 needs (no hand-rolled crypto).
- **X25519 for key agreement** — the library's encryption curves are X25519/P-256 only; secp256k1 can't do key agreement.
- **secp256k1 keys sign DIDComm as-is** via `ES256K` (valid JWS, `non_repudiation: true`) — so each identity needs only a *new* X25519 key-agreement key; existing keys keep signing.

### Notes
- Not wired into the monorepo (root `workspaces` is `packages/*` only). Runs standalone: `cd spike/didcomm-phase0 && npm ci && node spike.mjs`.
- **Caveats:** DID docs are mocks shaped like the gatekeeper's normalized output, and X25519 keys are generated ad hoc rather than derived from a wallet seed — both are the first Phase 1 tasks.
- This is exploratory; it can be merged for reference or closed once Phase 1 lands. The `spike/` tree is intended to be removed before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)