### PR TITLE
fix: pass ARCHON_DRAWBRIDGE_PUBLIC_HOST to the drawbridge service (#639)

### DIFF
--- a/docker/compose/drawbridge.yml
+++ b/docker/compose/drawbridge.yml
@@ -91,6 +91,9 @@ services:
       - ARCHON_GATEKEEPER_URL=http://gatekeeper:4224
       - ARCHON_LIGHTNING_MEDIATOR_URL=http://lightning-mediator:4235
       - ARCHON_DIDCOMM_URL=http://didcomm:4236
+      # Public base URL advertised by GET /api/v1/didcomm-endpoint (used by
+      # publish-didcomm). Without this the endpoint falls back to the Tor onion.
+      - ARCHON_DRAWBRIDGE_PUBLIC_HOST=${ARCHON_DRAWBRIDGE_PUBLIC_HOST:-}
       - ARCHON_REDIS_URL=redis://redis:6379
       - ARCHON_DRAWBRIDGE_L402_ENABLED=${ARCHON_DRAWBRIDGE_L402_ENABLED:-false}
       - ARCHON_DRAWBRIDGE_MACAROON_SECRET=${ARCHON_DRAWBRIDGE_MACAROON_SECRET:-}


### PR DESCRIPTION
Fixes #639.

## Problem
The drawbridge service *reads* `ARCHON_DRAWBRIDGE_PUBLIC_HOST` ([config.ts](services/drawbridge/server/src/config.ts)) to advertise the DIDComm endpoint via `GET /api/v1/didcomm-endpoint`, but the variable was **never listed in the drawbridge service's `environment:` block** in [docker/compose/drawbridge.yml](docker/compose/drawbridge.yml). So in Docker it never reached the container, `config.publicHost` was always empty, and the endpoint fell back to the Tor onion — even when the operator set a clearnet host. (`herald` and `lightning-mediator` in the same fragment already pass it through; the `drawbridge` service block was the gap.)

## Fix
One line — add the passthrough to the drawbridge service `environment:`:

```yaml
- ARCHON_DRAWBRIDGE_PUBLIC_HOST=${ARCHON_DRAWBRIDGE_PUBLIC_HOST:-}
```

## Verification
```
$ ARCHON_DRAWBRIDGE_PUBLIC_HOST=https://example.com docker compose config | grep -A1 DIDCOMM_URL
      ARCHON_DIDCOMM_URL: http://didcomm:4236
      ARCHON_DRAWBRIDGE_PUBLIC_HOST: https://example.com
```
The var now reaches the container, so `/api/v1/didcomm-endpoint` returns `<publicHost>/didcomm` and `publish-didcomm` advertises the configured clearnet URL. Compose still validates.

Compose-only change (no code, no new deps). Thanks @macterra for the precise report + workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)