### PR TITLE
fix: read DIDComm mailbox via the local gateway, not the public endpoint

### DIFF
--- a/docs/didcomm-design.md
+++ b/docs/didcomm-design.md
@@ -321,6 +321,14 @@ the relay e2e routes every send through `/deliver`; a unit test asserts the no-g
 Privacy: the service sees recipient DIDs + timing, not content. (`ARCHON_DIDCOMM_ALLOW_PRIVATE_EGRESS=true`
 permits loopback destinations for dev/test.)
 
+**Reading your own mailbox uses the same local gateway.** `receiveDidComm`/`mediateDidComm`
+(challenge → fetch → unpack → ack) connect to **`<nodeURL>/didcomm`** as well — *not* the identity's
+published `DIDCommMessaging` endpoint. That published endpoint is for *others sending to you* and may
+be a `.onion`; dialing it from the client to read your own mailbox would route out through Tor to reach
+your own relay (and fails outright on a client with no Tor — the original symptom). All three operations
+now share one derivation (`didcommGatewayBase` / `_didcomm_gateway_base`); an explicit `--endpoint` still
+overrides for ad-hoc use.
+
 ## Risks & open questions
 
 - **Cross-ecosystem resolution.** External agents must resolve `did:cid`. Archon-to-Archon

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2605,25 +2605,34 @@ export default class Keymaster implements KeymasterInterface {
         return this.resolveKeyAgreement(doc);
     }
 
+    // The local DIDComm gateway: Drawbridge's `/didcomm` proxy in front of the
+    // relay, derived from the node URL the keymaster already uses — exactly as
+    // publishLightning derives its endpoint — so there is no dedicated config.
+    // Every gateway interaction (sending, and reading your own mailbox) goes here.
+    // Reading your mailbox must NOT use your published public endpoint: that may be
+    // a `.onion` the client can't dial directly, and routing out through Tor to
+    // reach your own relay is nonsense. An explicit endpoint (e.g. CLI --endpoint)
+    // wins; didcommServiceURL is an in-process / test override (gatekeeper has no url).
+    private didcommGatewayBase(override?: string): string {
+        const nodeUrl = (this.gatekeeper as { url?: string }).url;
+        const base = (override ?? this.didcommServiceURL ?? (nodeUrl ? `${nodeUrl}/didcomm` : undefined))?.replace(/\/+$/, '');
+        if (!base) {
+            throw new KeymasterError('cannot reach the DIDComm gateway: no node URL configured');
+        }
+        return base;
+    }
+
     // Pack a message and hand each sealed envelope to the DIDComm service for
     // delivery. The keymaster does crypto only (pack, resolve, Forward-wrap); the
     // service owns transport — egress, retries, and Tor for `.onion` recipients —
-    // so this never dials recipients directly. The egress is reached through the
-    // node's gateway (Drawbridge's `/didcomm` proxy), derived from the node URL the
-    // keymaster already uses — exactly as publishLightning derives its endpoint —
-    // so there is no dedicated config. (didcommServiceURL is an explicit override
-    // for in-process / test use, where the gatekeeper has no url.)
+    // so this never dials recipients directly.
     // Returns the stored message ids per delivery.
     async sendDidComm(
         message: Record<string, unknown>,
         to: string | string[],
         options: { sign?: boolean; anoncrypt?: boolean; encryption?: DidCommEnc; name?: string } = {}
     ): Promise<string[]> {
-        const nodeUrl = (this.gatekeeper as { url?: string }).url;
-        const serviceBase = (this.didcommServiceURL ?? (nodeUrl ? `${nodeUrl}/didcomm` : undefined))?.replace(/\/+$/, '');
-        if (!serviceBase) {
-            throw new KeymasterError('cannot send DIDComm: no node URL to reach the DIDComm gateway');
-        }
+        const serviceBase = this.didcommGatewayBase();
         const recipientDids = Array.isArray(to) ? to : [to];
         const packed = await this.packDidComm(message, recipientDids, options);
 
@@ -2679,11 +2688,9 @@ export default class Keymaster implements KeymasterInterface {
     ): Promise<DidCommUnpackResult[]> {
         const { name } = options;
         const id = await this.fetchIdInfo(name);
-        const resolved = options.endpoint ? { uri: options.endpoint } : await this.resolveDidCommEndpoint(id.did);
-        if (!resolved) {
-            throw new KeymasterError('identity has no DIDCommMessaging endpoint; publishDidComm with an endpoint first');
-        }
-        const base = resolved.uri.replace(/\/+$/, '');
+        // Read our own mailbox through the local gateway, not our published public
+        // endpoint (which may be an unreachable `.onion`). --endpoint still overrides.
+        const base = this.didcommGatewayBase(options.endpoint);
         const keypair = await this.fetchKeyPair(name);
         if (!keypair) {
             throw new KeymasterError('unable to resolve signing key');
@@ -2691,6 +2698,9 @@ export default class Keymaster implements KeymasterInterface {
 
         const sign = async (): Promise<{ challenge: string; signature: string }> => {
             const challengeResponse = await fetch(`${base}/api/v1/challenge`);
+            if (!challengeResponse.ok) {
+                throw new KeymasterError(`DIDComm receive failed: gateway challenge request returned ${challengeResponse.status}`);
+            }
             const { challenge } = await challengeResponse.json();
             const signature = this.cipher.signHash(this.cipher.hashMessage(challenge), keypair.privateJwk);
             return { challenge, signature };
@@ -2739,11 +2749,8 @@ export default class Keymaster implements KeymasterInterface {
     ): Promise<{ relayed: number; skipped: number }> {
         const { name } = options;
         const id = await this.fetchIdInfo(name);
-        const resolved = options.endpoint ? { uri: options.endpoint } : await this.resolveDidCommEndpoint(id.did);
-        if (!resolved) {
-            throw new KeymasterError('mediator identity has no DIDCommMessaging endpoint');
-        }
-        const base = resolved.uri.replace(/\/+$/, '');
+        // Mediators read their own mailbox through the local gateway too. --endpoint overrides.
+        const base = this.didcommGatewayBase(options.endpoint);
         const keypair = await this.fetchKeyPair(name);
         if (!keypair) {
             throw new KeymasterError('unable to resolve signing key');
@@ -2754,6 +2761,9 @@ export default class Keymaster implements KeymasterInterface {
 
         const sign = async (): Promise<{ challenge: string; signature: string }> => {
             const challengeResponse = await fetch(`${base}/api/v1/challenge`);
+            if (!challengeResponse.ok) {
+                throw new KeymasterError(`mediator fetch failed: gateway challenge request returned ${challengeResponse.status}`);
+            }
             const { challenge } = await challengeResponse.json();
             return { challenge, signature: this.cipher.signHash(this.cipher.hashMessage(challenge), keypair.privateJwk) };
         };

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2615,7 +2615,7 @@ export default class Keymaster implements KeymasterInterface {
     // wins; didcommServiceURL is an in-process / test override (gatekeeper has no url).
     private didcommGatewayBase(override?: string): string {
         const nodeUrl = (this.gatekeeper as { url?: string }).url;
-        const base = (override ?? this.didcommServiceURL ?? (nodeUrl ? `${nodeUrl}/didcomm` : undefined))?.replace(/\/+$/, '');
+        const base = (override ?? this.didcommServiceURL ?? (nodeUrl ? `${nodeUrl.replace(/\/+$/, '')}/didcomm` : undefined))?.replace(/\/+$/, '');
         if (!base) {
             throw new KeymasterError('cannot reach the DIDComm gateway: no node URL configured');
         }

--- a/python/keymaster/src/keymaster/core.py
+++ b/python/keymaster/src/keymaster/core.py
@@ -3647,14 +3647,14 @@ class Keymaster:
         # must NOT use our published public endpoint (it may be an unreachable .onion).
         # An explicit endpoint wins; didcomm_service_url is an in-process / test override.
         node_url = getattr(self.gatekeeper, "url", None)
-        base = override or self.didcomm_service_url or (f"{node_url}/didcomm" if node_url else None)
+        base = override or self.didcomm_service_url or (f"{node_url.rstrip('/')}/didcomm" if node_url else None)
         if not base:
             raise KeymasterError("cannot reach the DIDComm gateway: no node URL configured")
         return base.rstrip("/")
 
     async def _didcomm_challenge_auth(self, client: httpx.AsyncClient, base: str, keypair: dict[str, dict[str, str]]) -> dict[str, str]:
         response = await client.get(f"{base}/api/v1/challenge")
-        if response.status_code >= 400:
+        if not response.is_success:
             raise KeymasterError(f"DIDComm gateway challenge request returned {response.status_code}")
         challenge = response.json()["challenge"]
         return {"challenge": challenge, "signature": sign_hash(hash_message(challenge), keypair["privateJwk"])}
@@ -3694,7 +3694,7 @@ class Keymaster:
                 # Authenticated hand-off to the service (signed challenge proving
                 # control of sender_did); it delivers the opaque envelope.
                 challenge_response = await client.get(f"{service_base}/api/v1/challenge")
-                if challenge_response.status_code >= 400:
+                if not challenge_response.is_success:
                     raise KeymasterError(f"DIDComm delivery to {recipient_did} failed: gateway challenge request returned {challenge_response.status_code}")
                 challenge = challenge_response.json()["challenge"]
                 signature = sign_hash(hash_message(challenge), keypair["privateJwk"])

--- a/python/keymaster/src/keymaster/core.py
+++ b/python/keymaster/src/keymaster/core.py
@@ -3640,8 +3640,22 @@ class Keymaster:
 
         return {"message": inner, "metadata": metadata}
 
+    def _didcomm_gateway_base(self, override: str | None = None) -> str:
+        # The local DIDComm gateway: Drawbridge's /didcomm proxy in front of the relay,
+        # derived from the node URL the keymaster already uses (like publish_lightning) —
+        # no dedicated config. Used for sending AND for reading our own mailbox; reading
+        # must NOT use our published public endpoint (it may be an unreachable .onion).
+        # An explicit endpoint wins; didcomm_service_url is an in-process / test override.
+        node_url = getattr(self.gatekeeper, "url", None)
+        base = override or self.didcomm_service_url or (f"{node_url}/didcomm" if node_url else None)
+        if not base:
+            raise KeymasterError("cannot reach the DIDComm gateway: no node URL configured")
+        return base.rstrip("/")
+
     async def _didcomm_challenge_auth(self, client: httpx.AsyncClient, base: str, keypair: dict[str, dict[str, str]]) -> dict[str, str]:
         response = await client.get(f"{base}/api/v1/challenge")
+        if response.status_code >= 400:
+            raise KeymasterError(f"DIDComm gateway challenge request returned {response.status_code}")
         challenge = response.json()["challenge"]
         return {"challenge": challenge, "signature": sign_hash(hash_message(challenge), keypair["privateJwk"])}
 
@@ -3653,11 +3667,7 @@ class Keymaster:
         # no dedicated config. (didcomm_service_url is an explicit override for
         # in-process / test use.)
         options = options or {}
-        node_url = getattr(self.gatekeeper, "url", None)
-        service_base = self.didcomm_service_url or (f"{node_url}/didcomm" if node_url else None)
-        if not service_base:
-            raise KeymasterError("cannot send DIDComm: no node URL to reach the DIDComm gateway")
-        service_base = service_base.rstrip("/")
+        service_base = self._didcomm_gateway_base()
         recipient_dids = to if isinstance(to, list) else [to]
         packed = await self.pack_didcomm(message, recipient_dids, options)
 
@@ -3701,10 +3711,9 @@ class Keymaster:
         options = options or {}
         name = options.get("name")
         id_info = await self.fetch_id_info(name)
-        resolved = {"uri": options["endpoint"]} if options.get("endpoint") else await self._resolve_didcomm_endpoint(id_info["did"])
-        if not resolved:
-            raise KeymasterError("identity has no DIDCommMessaging endpoint; publish_didcomm with an endpoint first")
-        base = resolved["uri"].rstrip("/")
+        # Read our own mailbox through the local gateway, not our published public
+        # endpoint (which may be an unreachable .onion). endpoint option still overrides.
+        base = self._didcomm_gateway_base(options.get("endpoint"))
         keypair = await self.fetch_key_pair(name)
         if not keypair:
             raise KeymasterError("unable to resolve signing key")
@@ -3735,10 +3744,8 @@ class Keymaster:
         options = options or {}
         name = options.get("name")
         id_info = await self.fetch_id_info(name)
-        resolved = {"uri": options["endpoint"]} if options.get("endpoint") else await self._resolve_didcomm_endpoint(id_info["did"])
-        if not resolved:
-            raise KeymasterError("mediator identity has no DIDCommMessaging endpoint")
-        base = resolved["uri"].rstrip("/")
+        # Mediators read their own mailbox through the local gateway too. endpoint option overrides.
+        base = self._didcomm_gateway_base(options.get("endpoint"))
         keypair = await self.fetch_key_pair(name)
         if not keypair:
             raise KeymasterError("unable to resolve signing key")


### PR DESCRIPTION
## Problem (field report)
`keymaster receive-didcomm` failed with a bare **"fetch failed"**.

Root cause: `receiveDidComm`/`mediateDidComm` resolved the identity's **published** `DIDCommMessaging` endpoint and dialed it directly to read the owner's *own* mailbox. With no `ARCHON_DRAWBRIDGE_PUBLIC_HOST` set, auto-discovery publishes that endpoint as the **Tor onion** (`…onion:4222/didcomm`) — which a client with no Tor can't reach (undici's generic "fetch failed"). Even with Tor it's wrong: it routes out through the onion to reach your own relay.

## Fix
Reading your own mailbox is a **local-gateway** operation — the mirror of Phase 8 sends. The node-URL derivation is factored out of `sendDidComm` into a shared helper (`didcommGatewayBase` / `_didcomm_gateway_base`) and used by all three:

- **send / receive / mediate** all reach **`<nodeURL>/didcomm`** (Drawbridge's `/didcomm` proxy → relay), derived from the single node URL the keymaster already uses — never the published public endpoint.
- The published endpoint keeps its real purpose: *others* sending **to** you.
- An explicit `--endpoint` still overrides (e.g. `--endpoint http://localhost:4236`).
- Also guards the challenge `fetch` in receive/mediate so a non-2xx gateway response is a clean `KeymasterError` instead of a raw `.json()` throw.

> Note: as with Lightning, the keymaster's node URL must be the **gateway/Drawbridge** (`:4222`), not a bare gatekeeper (`:4224`) — only Drawbridge serves `/didcomm`.

## Parity & validation
- JS + Python in lockstep; `docs/didcomm-design.md` updated.
- JS e2e **7/7**, JS didcomm units **62**, Python didcomm **17**.
- **Live CLI confirmed**: `keymaster receive-didcomm` (no flags) reads the mailbox through the gateway and unpacks an authcrypt Basic Message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)