### PR TITLE
feat: node capability manifest + client gating for optional services (Option C)

### DIFF
--- a/docker/compose/drawbridge.yml
+++ b/docker/compose/drawbridge.yml
@@ -89,8 +89,13 @@ services:
       - ARCHON_BIND_ADDRESS=${ARCHON_BIND_ADDRESS:-0.0.0.0}
       - ARCHON_ADMIN_API_KEY=${ARCHON_ADMIN_API_KEY}
       - ARCHON_GATEKEEPER_URL=http://gatekeeper:4224
-      - ARCHON_LIGHTNING_MEDIATOR_URL=http://lightning-mediator:4235
-      - ARCHON_DIDCOMM_URL=http://didcomm:4236
+      # Optional-service URLs use ${VAR-default} (single dash): an explicitly EMPTY
+      # value disables the service (capability false + 501), while unset keeps the
+      # default. didcomm defaults EMPTY (off) — it's opt-in, not in the default
+      # COMPOSE_PROFILES; to enable, add `didcomm` to COMPOSE_PROFILES AND set
+      # ARCHON_DIDCOMM_URL=http://didcomm:4236.
+      - ARCHON_LIGHTNING_MEDIATOR_URL=${ARCHON_LIGHTNING_MEDIATOR_URL-http://lightning-mediator:4235}
+      - ARCHON_DIDCOMM_URL=${ARCHON_DIDCOMM_URL-}
       # Public base URL advertised by GET /api/v1/didcomm-endpoint (used by
       # publish-didcomm). Without this the endpoint falls back to the Tor onion.
       - ARCHON_DRAWBRIDGE_PUBLIC_HOST=${ARCHON_DRAWBRIDGE_PUBLIC_HOST:-}
@@ -101,7 +106,7 @@ services:
       - ARCHON_DRAWBRIDGE_INVOICE_EXPIRY=${ARCHON_DRAWBRIDGE_INVOICE_EXPIRY:-3600}
       - ARCHON_DRAWBRIDGE_RATE_LIMIT_MAX=${ARCHON_DRAWBRIDGE_RATE_LIMIT_MAX:-100}
       - ARCHON_DRAWBRIDGE_RATE_LIMIT_WINDOW=${ARCHON_DRAWBRIDGE_RATE_LIMIT_WINDOW:-60}
-      - ARCHON_HERALD_URL=http://herald:4230
+      - ARCHON_HERALD_URL=${ARCHON_HERALD_URL-http://herald:4230}
     user: "${ARCHON_UID}:${ARCHON_GID}"
     ports:
       - ${ARCHON_DRAWBRIDGE_PORT:-4222}:4222

--- a/docs/didcomm-design.md
+++ b/docs/didcomm-design.md
@@ -329,6 +329,21 @@ your own relay (and fails outright on a client with no Tor — the original symp
 now share one derivation (`didcommGatewayBase` / `_didcomm_gateway_base`); an explicit `--endpoint` still
 overrides for ad-hoc use.
 
+**DIDComm is an optional node service, advertised via a capability manifest.** Drawbridge serves
+`GET /api/v1/capabilities` → `{ didcomm, lightning, names }`, where each flag reflects whether the
+downstream service URL is configured (an operator opts a service *out* by setting its URL empty, e.g.
+`ARCHON_DIDCOMM_URL=`; an unset var keeps the default). When off, the corresponding proxy mount
+(`/didcomm`, `/lightning`, `/names`) returns **501** rather than proxying to nothing. The keymaster
+fetches the manifest once (memoized) and gates the relevant verbs: `send`/`receive`/`mediate`/`publishDidComm`
+on `didcomm`, all Lightning ops on `lightning` (via the single `getLightningConfig` chokepoint). A node
+that explicitly disables a service yields a clear *"this node does not offer …"* error; a node with **no
+manifest** (older node, or a node URL that is a bare gatekeeper) is treated **permissively** — the
+operation proceeds and fails later with a transport error, so existing nodes never regress. `publishDidComm`
+on a DIDComm-less node publishes **key-only** (no dead `DIDCommMessaging` endpoint advertised). The flag
+reflects node *intent*, not live health — a configured-but-crashed service still surfaces a runtime error
+(an unreachable gateway now reports *"could not reach the DIDComm gateway at …"* instead of a bare
+`fetch failed`). *Wallet/CLI UI feature-gating off this manifest is a tracked follow-up.*
+
 ## Risks & open questions
 
 - **Cross-ecosystem resolution.** External agents must resolve `did:cid`. Archon-to-Archon

--- a/docs/services/drawbridge/README.md
+++ b/docs/services/drawbridge/README.md
@@ -468,7 +468,7 @@ shared with the reference TypeScript service.
 | `ARCHON_GATEKEEPER_URL` | `http://localhost:4224` | Upstream Gatekeeper. |
 | `ARCHON_HERALD_URL` | `http://localhost:4230` | Upstream Herald (for `/.well-known/*` and `/names/*`). Set **empty** to disable name resolution (capability `names:false`, `/names` → 501). |
 | `ARCHON_LIGHTNING_MEDIATOR_URL` | `http://localhost:4235` | Upstream for Lightning routes + L402 invoice/pending storage. Set **empty** to disable Lightning (capability `lightning:false`, `/lightning` + `/invoice/:did` → 501). |
-| `ARCHON_DIDCOMM_URL` | `http://localhost:4236` | Upstream DIDComm relay proxied at `/didcomm`. Set **empty** to disable DIDComm (capability `didcomm:false`, `/didcomm` → 501). |
+| `ARCHON_DIDCOMM_URL` | `http://localhost:4236` | Upstream DIDComm relay proxied at `/didcomm`. Set **empty** to disable DIDComm (capability `didcomm:false`, `/didcomm` → 501). *The bundled compose defaults this **empty** (DIDComm is opt-in, off by default); enabling requires the `didcomm` profile **and** setting this URL.* |
 | `ARCHON_DRAWBRIDGE_PUBLIC_HOST` | empty | Public base URL this node is reachable at (clearnet host or Tor onion). Used by `/didcomm-endpoint` to advertise `<host>/didcomm`. |
 | `ARCHON_DRAWBRIDGE_TOR_HOSTNAME_FILE` | `/data/tor/hostname` | When `PUBLIC_HOST` is empty, `/didcomm-endpoint` falls back to the Tor onion read from this shared hidden-service hostname file. |
 | `ARCHON_REDIS_URL` | `redis://localhost:6379` | Macaroon/payment/rate-limit store. |

--- a/docs/services/drawbridge/README.md
+++ b/docs/services/drawbridge/README.md
@@ -2,8 +2,9 @@
 
 Language-agnostic contract for **Drawbridge** — the public-facing API
 gateway that fronts the [Gatekeeper](../gatekeeper/README.md), the
-[Lightning mediator](../mediators/lightning/README.md), and the
-[Herald](../herald/README.md) name service. It enforces an
+[Lightning mediator](../mediators/lightning/README.md), the
+[Herald](../herald/README.md) name service, and the
+[DIDComm relay](../didcomm/README.md). It enforces an
 [L402](https://docs.lightning.engineering/the-lightning-network/l402)
 ("Lightning HTTP 402") paywall and a subscription-credential
 alternative on every protected route, then proxies the request upstream.
@@ -37,11 +38,29 @@ has three jobs:
    (`/api/v1/did`, `/dids`, `/ipfs/*`, `/block/*`, `/search`, `/query`)
    are forwarded to the local Gatekeeper. Lightning routes are
    forwarded to the local Lightning mediator. Herald routes
-   (`/.well-known/*`, `/names/*`) are forwarded to the local Herald.
+   (`/.well-known/*`, `/names/*`) are forwarded to the local Herald. The
+   DIDComm relay is fronted at `/didcomm/*` (not paywalled — DIDComm has
+   its own signed-challenge auth).
 3. **Public surface for the Lightning + name layers.** A few unprotected
    endpoints exist for clients that need to learn about the node before
-   authenticating: `/ready`, `/version`, `/status`, `/invoice/:did`,
-   the Herald well-known endpoints.
+   authenticating: `/ready`, `/version`, `/status`, `/capabilities`,
+   `/didcomm-endpoint`, `/invoice/:did`, the Herald well-known endpoints.
+
+### Optional services
+
+DIDComm, Lightning, and Herald name resolution are **optional** — a node
+may not deploy them. Each is "offered" iff its downstream URL is
+configured (see [§8.2](#82-environment-variables)); an operator opts a
+service *out* by setting its URL **empty** (e.g. `ARCHON_DIDCOMM_URL=`).
+When a service is off:
+
+- `GET /api/v1/capabilities` reports it `false`, and
+- its proxy mount (`/didcomm`, `/api/v1/lightning`, `/invoice/:did`,
+  `/names`) returns **HTTP 501** `{ "error": "<service> is not enabled
+  on this node" }` rather than proxying to an absent upstream.
+
+Clients (e.g. keymaster) read the manifest once and fail fast with a
+clear message instead of discovering absence via a transport error.
 
 It carries no key material. The macaroon root secret
 (`ARCHON_DRAWBRIDGE_MACAROON_SECRET`) is the only sensitive material on
@@ -61,11 +80,14 @@ Binds to `${ARCHON_BIND_ADDRESS}:${ARCHON_DRAWBRIDGE_PORT}` (default
 | --- | --- | --- |
 | `GET` | `/api/v1/ready` | Returns `<bool>` — proxies upstream Gatekeeper readiness. `false` on connect failure. |
 | `GET` | `/api/v1/version` | `{ version, commit }` (commit is `GIT_COMMIT` sliced to 7 chars; the sentinel string `"unknown"` is returned when `GIT_COMMIT` is unset). |
+| `GET` | `/api/v1/capabilities` | `{ didcomm, lightning, names }` — which optional services this node offers (each `true` iff its downstream URL is configured). Reflects node *intent* (config), not live health. See [Optional services](#optional-services). |
 | `GET` | `/api/v1/status` | `{ service: "drawbridge", upstream: GatekeeperStatus, uptime: <seconds>, memoryUsage: <node memUsage> }`. HTTP 502 if Gatekeeper is unreachable. |
+| `GET` | `/api/v1/didcomm-endpoint` | `{ endpoint: <string\|null> }` — this node's public DIDComm relay endpoint for `publish-didcomm` auto-discovery: `<ARCHON_DRAWBRIDGE_PUBLIC_HOST>/didcomm`, else the Tor onion fronting this node, else `null`. |
 | `POST` | `/api/v1/l402/pay` | Final step of L402 flow. Body: `{ paymentHash }`. Marks the matching macaroon as paid + returns the bearer credential. See [§4.4](#44-payment-completion). |
-| `GET` | `/invoice/:did` | Forwarded to lightning-mediator's `/invoice/:did`. Returns `{ paymentRequest, paymentHash, ... }`. Used by external zappers to pay any DID that has published a Lightning service. |
+| `GET` | `/invoice/:did` | Forwarded to lightning-mediator's `/invoice/:did`. Returns `{ paymentRequest, paymentHash, ... }`. Used by external zappers to pay any DID that has published a Lightning service. **501** if Lightning is disabled. |
+| `*` | `/didcomm/**` | Forwarded to the local DIDComm relay (path prefix `/didcomm` stripped). Carries the relay's own routes (mailbox `messages/*`, signed-`challenge`, egress `deliver`). Not paywalled — DIDComm authenticates with its own signed challenge. **501** if DIDComm is disabled. `application/didcomm-encrypted+json` bodies are captured as text and forwarded verbatim. |
 | `GET` | `/.well-known/*` | Forwarded to Herald (e.g. `lnurlp/<name>`, `webfinger`, `names`). |
-| `GET\|POST\|PUT\|DELETE` | `/names/*` | Forwarded to Herald (`/api/*`). |
+| `GET\|POST\|PUT\|DELETE` | `/names/*` | Forwarded to Herald (`/api/*`). **501** if name resolution is disabled. |
 | `GET` | `/metrics` | Prometheus exposition. |
 
 ### 2.2 L402 admin routes
@@ -124,9 +146,11 @@ The path tail is appended onto the upstream URL untouched. See the
 ### 2.4 Body limits
 
 Global Express limits (`json`, `urlencoded`, `text`, `raw` for
-`application/octet-stream`): **10 MB** each. The IPFS stream POST
-(`/api/v1/ipfs/stream`) explicitly bypasses the raw parser so the
-upstream Kubo client can stream the request body directly.
+`application/octet-stream`): **10 MB** each. A dedicated `text` parser
+for `application/didcomm-encrypted+json` (also 10 MB) captures DIDComm
+envelopes so they survive proxying to the relay byte-for-byte. The IPFS
+stream POST (`/api/v1/ipfs/stream`) explicitly bypasses the raw parser
+so the upstream Kubo client can stream the request body directly.
 
 ### 2.5 CORS
 
@@ -146,7 +170,9 @@ status codes:
 - `402` — L402 challenge (with `WWW-Authenticate` header)
 - `403` — admin not configured / scope insufficient
 - `429` — rate-limited
-- `502` — upstream Gatekeeper / Lightning / Herald unreachable
+- `501` — the requested optional service (DIDComm / Lightning / names) is not enabled on this node
+- `502` — upstream Gatekeeper / Lightning / Herald / DIDComm unreachable
+- `503` — Lightning service unavailable (L402 invoice creation failed)
 
 ### 2.7 Route-normalization for metrics
 
@@ -193,13 +219,17 @@ The L402 middleware (mounted on the `/api/v1` router) has a hard-coded
 bypass list for paths that should never be paywalled. Paths are matched
 against the request path with the `/api/v1` prefix stripped:
 
-- Exact matches (any method): `/ready`, `/version`, `/status`, `/metrics`
+- Exact matches (any method): `/ready`, `/version`, `/status`, `/metrics`, `/capabilities`, `/didcomm-endpoint`
 - Prefix matches (any method): anything under `/l402/`
 - GET-only prefix matches: anything under `/did/` or `/ipfs/`
 
+(Auth is also applied per-route — only the protected proxy routes spread
+the auth middleware into their handler chain — so the public routes
+above carry no auth regardless; the bypass list is belt-and-suspenders.)
+
 All other routes are handled outside this router and so are not subject
-to the L402 middleware at all (e.g. `/invoice/:did`, `/.well-known/*`,
-`/names/*`).
+to the L402 middleware at all (e.g. `/invoice/:did`, `/didcomm/*`,
+`/.well-known/*`, `/names/*`).
 
 Implementations MUST honor this list — clients depend on at least
 `/ready`, `/version`, and the GET DID/IPFS read paths being free.
@@ -436,8 +466,11 @@ shared with the reference TypeScript service.
 | `ARCHON_DRAWBRIDGE_PORT` | `4222` | HTTP listen port. |
 | `ARCHON_BIND_ADDRESS` | `0.0.0.0` | |
 | `ARCHON_GATEKEEPER_URL` | `http://localhost:4224` | Upstream Gatekeeper. |
-| `ARCHON_HERALD_URL` | `http://localhost:4230` | Upstream Herald (for `/.well-known/*` and `/names/*`). |
-| `ARCHON_LIGHTNING_MEDIATOR_URL` | `http://localhost:4235` | Upstream for Lightning routes + L402 invoice/pending storage. |
+| `ARCHON_HERALD_URL` | `http://localhost:4230` | Upstream Herald (for `/.well-known/*` and `/names/*`). Set **empty** to disable name resolution (capability `names:false`, `/names` → 501). |
+| `ARCHON_LIGHTNING_MEDIATOR_URL` | `http://localhost:4235` | Upstream for Lightning routes + L402 invoice/pending storage. Set **empty** to disable Lightning (capability `lightning:false`, `/lightning` + `/invoice/:did` → 501). |
+| `ARCHON_DIDCOMM_URL` | `http://localhost:4236` | Upstream DIDComm relay proxied at `/didcomm`. Set **empty** to disable DIDComm (capability `didcomm:false`, `/didcomm` → 501). |
+| `ARCHON_DRAWBRIDGE_PUBLIC_HOST` | empty | Public base URL this node is reachable at (clearnet host or Tor onion). Used by `/didcomm-endpoint` to advertise `<host>/didcomm`. |
+| `ARCHON_DRAWBRIDGE_TOR_HOSTNAME_FILE` | `/data/tor/hostname` | When `PUBLIC_HOST` is empty, `/didcomm-endpoint` falls back to the Tor onion read from this shared hidden-service hostname file. |
 | `ARCHON_REDIS_URL` | `redis://localhost:6379` | Macaroon/payment/rate-limit store. |
 | `ARCHON_ADMIN_API_KEY` | empty | Required for L402 admin routes. Empty → admin routes 403. |
 | `ARCHON_DRAWBRIDGE_L402_ENABLED` | `false` | When `false`, all proxy routes open. |
@@ -450,6 +483,13 @@ shared with the reference TypeScript service.
 | `ARCHON_DRAWBRIDGE_PRICE_RESOLVE_DID` | unset | Sats price for `resolveDID` (must be `> 0`). |
 | `ARCHON_DRAWBRIDGE_PRICING` | unset | JSON pricing override; `{ "operations": { "<scope>": { "amountSat": <n>, "description": "..." } } }`. Merged on top of the per-operation env vars. |
 | `GIT_COMMIT` | `unknown` | Build commit. |
+
+> **Off-switch semantics.** The optional-service URLs
+> (`ARCHON_DIDCOMM_URL`, `ARCHON_LIGHTNING_MEDIATOR_URL`,
+> `ARCHON_HERALD_URL`) are read with `??`, not `||`: an **unset** var
+> falls back to the default (service on), while an **explicitly empty**
+> value disables the service. This is what drives `/capabilities` and
+> the 501 gating.
 
 ### 8.3 Shutdown
 
@@ -504,6 +544,10 @@ A conformant third implementation MUST:
 - Honor the route table in [§2](#2-http-api-contract) including the
   bypass list in [§3.1](#31-bypass-routes), the body limits, and the
   Herald-CORS exception.
+- Serve `GET /api/v1/capabilities` and apply the optional-service
+  off-switch + 501 gating ([§1 Optional services](#optional-services)):
+  a service whose downstream URL is empty reports `false` and its proxy
+  mount returns 501.
 - Validate the macaroon secret length and exit on failure.
 - Implement the L402 challenge wire format exactly: HTTP 402,
   `WWW-Authenticate: L402 macaroon="...", invoice="..."`, JSON body

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -177,6 +177,10 @@ export default class Keymaster implements KeymasterInterface {
     private readonly maxAliasLength: number;
     private readonly maxDataLength: number;
     private readonly didcommServiceURL?: string;
+    // Node capability manifest (`<nodeURL>/api/v1/capabilities`), fetched once and
+    // memoized. `undefined` = not yet fetched; `null` = node has no manifest
+    // (older node / not a gateway) → callers proceed lazily rather than regress.
+    private _nodeCapabilities?: Record<string, boolean> | null;
     private _walletCache?: WalletFile;
     private _hdkeyCache?: any;
 
@@ -2312,10 +2316,15 @@ export default class Keymaster implements KeymasterInterface {
         // relay endpoint from the gateway (as publishLightning learns its public
         // host). A plain Gatekeeper returns nothing, so we publish the
         // key-agreement key only — pass an explicit endpoint to override.
+        // If the node doesn't offer DIDComm, don't advertise a dead endpoint:
+        // publish key-only (an explicit endpoint still overrides this).
         if (!endpoint) {
-            const gateway = this.gatekeeper as Partial<DrawbridgeInterface>;
-            if (typeof gateway.getDidCommEndpoint === 'function') {
-                endpoint = (await gateway.getDidCommEndpoint()) || undefined;
+            const caps = await this.getNodeCapabilities();
+            if (!caps || caps.didcomm !== false) {
+                const gateway = this.gatekeeper as Partial<DrawbridgeInterface>;
+                if (typeof gateway.getDidCommEndpoint === 'function') {
+                    endpoint = (await gateway.getDidCommEndpoint()) || undefined;
+                }
             }
         }
         const id = await this.fetchIdInfo(name);
@@ -2605,6 +2614,58 @@ export default class Keymaster implements KeymasterInterface {
         return this.resolveKeyAgreement(doc);
     }
 
+    // Fetch (once, memoized) the node's capability manifest. Returns null when the
+    // node exposes no manifest (older node, or the node URL is a bare gatekeeper) —
+    // callers then proceed lazily so we never regress against existing nodes.
+    private async getNodeCapabilities(): Promise<Record<string, boolean> | null> {
+        if (this._nodeCapabilities !== undefined) {
+            return this._nodeCapabilities;
+        }
+        const nodeUrl = (this.gatekeeper as { url?: string }).url;
+        if (!nodeUrl) {
+            this._nodeCapabilities = null;
+            return null;
+        }
+        try {
+            // Timeout so a slow/black-hole node fails fast to "unknown" (permissive)
+            // rather than stalling every gated op on this extra preflight.
+            const response = await fetch(`${nodeUrl.replace(/\/+$/, '')}/api/v1/capabilities`, {
+                signal: AbortSignal.timeout(5000),
+            });
+            this._nodeCapabilities = response.ok ? await response.json() : null;
+        }
+        catch {
+            this._nodeCapabilities = null;
+        }
+        return this._nodeCapabilities ?? null;
+    }
+
+    // Throw a clear error when the node explicitly does not offer a capability.
+    // Unknown (no manifest) is permissive — the operation proceeds and fails later
+    // with a transport error if the service really is absent.
+    private async requireNodeCapability(capability: string, humanName: string): Promise<void> {
+        const caps = await this.getNodeCapabilities();
+        if (caps && caps[capability] === false) {
+            throw new KeymasterError(`this node does not offer ${humanName}`);
+        }
+    }
+
+    // GET a challenge from the DIDComm gateway, turning an unreachable gateway into
+    // a clear error (not undici's bare "fetch failed") and a non-2xx into a status.
+    private async fetchDidCommChallenge(base: string, context: string): Promise<string> {
+        let response: Response;
+        try {
+            response = await fetch(`${base}/api/v1/challenge`);
+        }
+        catch {
+            throw new KeymasterError(`${context}: could not reach the DIDComm gateway at ${base}`);
+        }
+        if (!response.ok) {
+            throw new KeymasterError(`${context}: gateway challenge request returned ${response.status}`);
+        }
+        return (await response.json()).challenge;
+    }
+
     // The local DIDComm gateway: Drawbridge's `/didcomm` proxy in front of the
     // relay, derived from the node URL the keymaster already uses — exactly as
     // publishLightning derives its endpoint — so there is no dedicated config.
@@ -2633,6 +2694,9 @@ export default class Keymaster implements KeymasterInterface {
         options: { sign?: boolean; anoncrypt?: boolean; encryption?: DidCommEnc; name?: string } = {}
     ): Promise<string[]> {
         const serviceBase = this.didcommGatewayBase();
+        if (!this.didcommServiceURL) {
+            await this.requireNodeCapability('didcomm', 'DIDComm messaging');
+        }
         const recipientDids = Array.isArray(to) ? to : [to];
         const packed = await this.packDidComm(message, recipientDids, options);
 
@@ -2661,11 +2725,7 @@ export default class Keymaster implements KeymasterInterface {
 
             // Authenticated hand-off to the service (signed challenge proving we
             // control senderDid), which delivers the opaque envelope to the recipient.
-            const challengeResponse = await fetch(`${serviceBase}/api/v1/challenge`);
-            if (!challengeResponse.ok) {
-                throw new KeymasterError(`DIDComm delivery to ${recipientDid} failed: gateway challenge request returned ${challengeResponse.status}`);
-            }
-            const { challenge } = await challengeResponse.json();
+            const challenge = await this.fetchDidCommChallenge(serviceBase, `DIDComm delivery to ${recipientDid} failed`);
             const signature = this.cipher.signHash(this.cipher.hashMessage(challenge), keypair.privateJwk);
             const response = await fetch(`${serviceBase}/api/v1/deliver`, {
                 method: 'POST',
@@ -2691,17 +2751,16 @@ export default class Keymaster implements KeymasterInterface {
         // Read our own mailbox through the local gateway, not our published public
         // endpoint (which may be an unreachable `.onion`). --endpoint still overrides.
         const base = this.didcommGatewayBase(options.endpoint);
+        if (!this.didcommServiceURL && !options.endpoint) {
+            await this.requireNodeCapability('didcomm', 'DIDComm messaging');
+        }
         const keypair = await this.fetchKeyPair(name);
         if (!keypair) {
             throw new KeymasterError('unable to resolve signing key');
         }
 
         const sign = async (): Promise<{ challenge: string; signature: string }> => {
-            const challengeResponse = await fetch(`${base}/api/v1/challenge`);
-            if (!challengeResponse.ok) {
-                throw new KeymasterError(`DIDComm receive failed: gateway challenge request returned ${challengeResponse.status}`);
-            }
-            const { challenge } = await challengeResponse.json();
+            const challenge = await this.fetchDidCommChallenge(base, 'DIDComm receive failed');
             const signature = this.cipher.signHash(this.cipher.hashMessage(challenge), keypair.privateJwk);
             return { challenge, signature };
         };
@@ -2751,6 +2810,9 @@ export default class Keymaster implements KeymasterInterface {
         const id = await this.fetchIdInfo(name);
         // Mediators read their own mailbox through the local gateway too. --endpoint overrides.
         const base = this.didcommGatewayBase(options.endpoint);
+        if (!this.didcommServiceURL && !options.endpoint) {
+            await this.requireNodeCapability('didcomm', 'DIDComm messaging');
+        }
         const keypair = await this.fetchKeyPair(name);
         if (!keypair) {
             throw new KeymasterError('unable to resolve signing key');
@@ -2760,11 +2822,7 @@ export default class Keymaster implements KeymasterInterface {
         const ownKa = this.resolveKeyAgreement(ownDoc);
 
         const sign = async (): Promise<{ challenge: string; signature: string }> => {
-            const challengeResponse = await fetch(`${base}/api/v1/challenge`);
-            if (!challengeResponse.ok) {
-                throw new KeymasterError(`mediator fetch failed: gateway challenge request returned ${challengeResponse.status}`);
-            }
-            const { challenge } = await challengeResponse.json();
+            const challenge = await this.fetchDidCommChallenge(base, 'mediator fetch failed');
             return { challenge, signature: this.cipher.signHash(this.cipher.hashMessage(challenge), keypair.privateJwk) };
         };
 
@@ -2970,6 +3028,10 @@ export default class Keymaster implements KeymasterInterface {
 
     private async getLightningConfig(name?: string): Promise<LightningConfig> {
         const drawbridge = this.requireDrawbridge();
+        // Single chokepoint for every Lightning network op (balance/invoice/pay/
+        // check/zap/publish/addLightning all route through here): fail clearly if
+        // the node doesn't offer Lightning, before reporting a missing wallet.
+        await this.requireNodeCapability('lightning', 'Lightning');
         const url = drawbridge.url;
         let wallet = await this.loadWallet();
         let idInfo = await this.fetchIdInfo(name, wallet);

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2626,16 +2626,24 @@ export default class Keymaster implements KeymasterInterface {
             this._nodeCapabilities = null;
             return null;
         }
+        // Timeout so a slow/black-hole node fails fast to "unknown" (permissive)
+        // rather than stalling every gated op on this extra preflight. Use
+        // AbortController + setTimeout (not AbortSignal.timeout, which is missing in
+        // some browser/WebView runtimes this package targets) and clear the timer so
+        // it never keeps the event loop alive.
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 5000);
         try {
-            // Timeout so a slow/black-hole node fails fast to "unknown" (permissive)
-            // rather than stalling every gated op on this extra preflight.
             const response = await fetch(`${nodeUrl.replace(/\/+$/, '')}/api/v1/capabilities`, {
-                signal: AbortSignal.timeout(5000),
+                signal: controller.signal,
             });
             this._nodeCapabilities = response.ok ? await response.json() : null;
         }
         catch {
             this._nodeCapabilities = null;
+        }
+        finally {
+            clearTimeout(timer);
         }
         return this._nodeCapabilities ?? null;
     }

--- a/python/keymaster/src/keymaster/core.py
+++ b/python/keymaster/src/keymaster/core.py
@@ -69,6 +69,10 @@ class PollItems:
     RESULTS = "results"
 
 
+# Sentinel distinguishing "capabilities not yet fetched" from "node has no manifest" (None).
+_UNFETCHED = object()
+
+
 class KeymasterError(Exception):
     pass
 
@@ -132,6 +136,10 @@ class Keymaster:
         self._wallet_cache: dict[str, Any] | None = None
         self._root_cache = None
         self._lock = asyncio.Lock()
+        # Node capability manifest (<nodeURL>/api/v1/capabilities), fetched once and
+        # memoized. _UNFETCHED until first read; None = node has no manifest (older
+        # node / not a gateway) → callers proceed lazily rather than regress.
+        self._node_capabilities: Any = _UNFETCHED
 
     def _upgrade_wallet(self, wallet: dict[str, Any]) -> dict[str, Any]:
         version = wallet.get("version")
@@ -559,6 +567,10 @@ class Keymaster:
 
     async def get_lightning_config(self, name: str | None = None) -> dict[str, Any]:
         drawbridge = self.require_drawbridge()
+        # Single chokepoint for every Lightning network op (balance/invoice/pay/
+        # check/zap/publish/add all route through here): fail clearly if the node
+        # doesn't offer Lightning, before reporting a missing wallet.
+        await self._require_node_capability("lightning", "Lightning")
         url = drawbridge.url
         wallet = await self.load_wallet()
         id_info = await self.fetch_id_info(name, wallet)
@@ -3483,13 +3495,17 @@ class Keymaster:
         # relay endpoint from the gateway (as publish_lightning learns its public
         # host). A plain Gatekeeper returns nothing, so we publish the
         # key-agreement key only — pass an explicit endpoint to override.
+        # If the node doesn't offer DIDComm, don't advertise a dead endpoint:
+        # publish key-only (an explicit endpoint still overrides this).
         if endpoint is None:
-            getter = getattr(self.gatekeeper, "get_didcomm_endpoint", None)
-            if getter:
-                try:
-                    endpoint = await getter()
-                except Exception:
-                    endpoint = None
+            caps = await self._get_node_capabilities()
+            if caps is None or caps.get("didcomm") is not False:
+                getter = getattr(self.gatekeeper, "get_didcomm_endpoint", None)
+                if getter:
+                    try:
+                        endpoint = await getter()
+                    except Exception:
+                        endpoint = None
 
         id_info = await self.fetch_id_info(name)
         did = id_info["did"]
@@ -3652,8 +3668,36 @@ class Keymaster:
             raise KeymasterError("cannot reach the DIDComm gateway: no node URL configured")
         return base.rstrip("/")
 
+    async def _get_node_capabilities(self) -> dict[str, bool] | None:
+        # Fetch (once, memoized) the node's capability manifest. None when the node
+        # exposes no manifest (older node, or node URL is a bare gatekeeper) — callers
+        # then proceed lazily so we never regress against existing nodes.
+        if self._node_capabilities is not _UNFETCHED:
+            return self._node_capabilities
+        node_url = getattr(self.gatekeeper, "url", None)
+        if not node_url:
+            self._node_capabilities = None
+            return None
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(f"{node_url.rstrip('/')}/api/v1/capabilities")
+            self._node_capabilities = response.json() if response.is_success else None
+        except Exception:
+            self._node_capabilities = None
+        return self._node_capabilities
+
+    async def _require_node_capability(self, capability: str, human_name: str) -> None:
+        # Throw clearly when the node explicitly does not offer a capability. Unknown
+        # (no manifest) is permissive — the op proceeds and fails later if truly absent.
+        caps = await self._get_node_capabilities()
+        if caps is not None and caps.get(capability) is False:
+            raise KeymasterError(f"this node does not offer {human_name}")
+
     async def _didcomm_challenge_auth(self, client: httpx.AsyncClient, base: str, keypair: dict[str, dict[str, str]]) -> dict[str, str]:
-        response = await client.get(f"{base}/api/v1/challenge")
+        try:
+            response = await client.get(f"{base}/api/v1/challenge")
+        except (httpx.HTTPError, OSError):
+            raise KeymasterError(f"could not reach the DIDComm gateway at {base}")
         if not response.is_success:
             raise KeymasterError(f"DIDComm gateway challenge request returned {response.status_code}")
         challenge = response.json()["challenge"]
@@ -3668,6 +3712,8 @@ class Keymaster:
         # in-process / test use.)
         options = options or {}
         service_base = self._didcomm_gateway_base()
+        if not self.didcomm_service_url:
+            await self._require_node_capability("didcomm", "DIDComm messaging")
         recipient_dids = to if isinstance(to, list) else [to]
         packed = await self.pack_didcomm(message, recipient_dids, options)
 
@@ -3693,7 +3739,10 @@ class Keymaster:
 
                 # Authenticated hand-off to the service (signed challenge proving
                 # control of sender_did); it delivers the opaque envelope.
-                challenge_response = await client.get(f"{service_base}/api/v1/challenge")
+                try:
+                    challenge_response = await client.get(f"{service_base}/api/v1/challenge")
+                except (httpx.HTTPError, OSError):
+                    raise KeymasterError(f"DIDComm delivery to {recipient_did} failed: could not reach the DIDComm gateway at {service_base}")
                 if not challenge_response.is_success:
                     raise KeymasterError(f"DIDComm delivery to {recipient_did} failed: gateway challenge request returned {challenge_response.status_code}")
                 challenge = challenge_response.json()["challenge"]
@@ -3714,6 +3763,8 @@ class Keymaster:
         # Read our own mailbox through the local gateway, not our published public
         # endpoint (which may be an unreachable .onion). endpoint option still overrides.
         base = self._didcomm_gateway_base(options.get("endpoint"))
+        if not self.didcomm_service_url and not options.get("endpoint"):
+            await self._require_node_capability("didcomm", "DIDComm messaging")
         keypair = await self.fetch_key_pair(name)
         if not keypair:
             raise KeymasterError("unable to resolve signing key")
@@ -3746,6 +3797,8 @@ class Keymaster:
         id_info = await self.fetch_id_info(name)
         # Mediators read their own mailbox through the local gateway too. endpoint option overrides.
         base = self._didcomm_gateway_base(options.get("endpoint"))
+        if not self.didcomm_service_url and not options.get("endpoint"):
+            await self._require_node_capability("didcomm", "DIDComm messaging")
         keypair = await self.fetch_key_pair(name)
         if not keypair:
             raise KeymasterError("unable to resolve signing key")

--- a/python/keymaster/src/keymaster/core.py
+++ b/python/keymaster/src/keymaster/core.py
@@ -3679,7 +3679,7 @@ class Keymaster:
             self._node_capabilities = None
             return None
         try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
+            async with httpx.AsyncClient(timeout=5.0) as client:  # fail-fast, matches the JS client
                 response = await client.get(f"{node_url.rstrip('/')}/api/v1/capabilities")
             self._node_capabilities = response.json() if response.is_success else None
         except Exception:

--- a/python/keymaster/tests/test_didcomm.py
+++ b/python/keymaster/tests/test_didcomm.py
@@ -164,6 +164,48 @@ def test_send_didcomm_requires_a_node_gateway():
         asyncio.run(km.send_didcomm({"type": "t", "body": {}}, "did:cid:bob"))
 
 
+def test_capability_gating_blocks_unavailable_services():
+    # When the node's manifest says a service is off, the relevant verb fails with
+    # a clear "does not offer …" error (before any network/crypto/wallet work).
+    import asyncio
+    import pytest
+    from keymaster.core import Keymaster, KeymasterError
+
+    class _Gw:
+        url = "http://node.test"
+
+        async def create_lightning_wallet(self, name):  # lets require_drawbridge pass
+            return {}
+
+    km = Keymaster(gatekeeper=_Gw(), wallet_store=object(), passphrase="pass")
+    km._node_capabilities = {"didcomm": False, "lightning": False}  # preset cache, no fetch
+
+    with pytest.raises(KeymasterError, match="does not offer DIDComm"):
+        asyncio.run(km.send_didcomm({"type": "t", "body": {}}, "did:cid:bob"))
+    with pytest.raises(KeymasterError, match="does not offer Lightning"):
+        asyncio.run(km.get_lightning_config())
+
+
+def test_capability_gating_permissive_when_manifest_absent():
+    # No manifest (older node / bare gatekeeper) -> the gate is permissive; the verb
+    # proceeds and fails later for a different reason, never "does not offer".
+    import asyncio
+    import pytest
+    from keymaster.core import Keymaster, KeymasterError
+
+    class _Gw:
+        url = "http://node.test"
+
+    km = Keymaster(gatekeeper=_Gw(), wallet_store=object(), passphrase="pass")
+    km._node_capabilities = None  # node exposes no manifest
+
+    # Gets past the gate, then fails at crypto/resolve against the bare fake gateway —
+    # the point is the error is NOT the capability gate.
+    with pytest.raises(Exception) as exc:
+        asyncio.run(km.send_didcomm({"type": "t", "body": {}}, "did:cid:bob"))
+    assert "does not offer" not in str(exc.value)
+
+
 def test_coordinate_mediation_builders():
     assert p.mediate_request()["type"] == p.MEDIATE_REQUEST_TYPE
     grant = p.mediate_grant("did:cid:mediator", "req-1")

--- a/sample.env
+++ b/sample.env
@@ -11,6 +11,8 @@ ARCHON_NODE_NAME=mynodeName
 # keymaster-client, react-wallet, observability, btc-mainnet, btc-signet,
 # btc-testnet4, btc-testnet4-hosted, lightning, drawbridge, didcomm, zcash-mainnet, eth-mainnet, eth-sepolia, sol-mainnet, sol-devnet,
 # pinning, filecoin.
+# NOTE: the `didcomm` profile also requires ARCHON_DIDCOMM_URL to be set (see below) —
+# the profile runs the relay; the URL tells Drawbridge to offer it. Both or neither.
 COMPOSE_PROFILES=hyperswarm,cli,explorer,gatekeeper-client,keymaster-client,react-wallet,observability,btc-mainnet,btc-signet,lightning,drawbridge
 
 # Security — set these in production deployments
@@ -205,14 +207,16 @@ ARCHON_DRAWBRIDGE_RATE_LIMIT_MAX=100
 ARCHON_DRAWBRIDGE_RATE_LIMIT_WINDOW=60
 # Drawbridge only needs the macaroon secret locally; Lightning backends now live in lightning-mediator.
 # ARCHON_DRAWBRIDGE_MACAROON_SECRET=
-# URL of the DIDComm relay that Drawbridge reverse-proxies at /didcomm (set by
-# the drawbridge compose fragment; override only for a non-default relay host).
-# OPTIONAL SERVICE / OFF-SWITCH: set this EMPTY (ARCHON_DIDCOMM_URL=) to declare
-# that this node does not offer DIDComm — /capabilities then reports didcomm:false,
-# the /didcomm mount returns 501, and keymaster clients fail fast with a clear
-# message instead of a transport error. (Same pattern for ARCHON_LIGHTNING_MEDIATOR_URL
-# and ARCHON_HERALD_URL.) An UNSET var keeps the default; only an explicit empty disables.
+# DIDComm relay URL that Drawbridge reverse-proxies at /didcomm. OPTIONAL SERVICE,
+# OFF BY DEFAULT: when empty, /capabilities reports didcomm:false, the /didcomm
+# mount returns 501, and keymaster clients fail fast with a clear message instead
+# of a transport error. To ENABLE DIDComm you need BOTH of:
+#   1. add `didcomm` to COMPOSE_PROFILES (runs the relay container), and
+#   2. uncomment the line below (point Drawbridge at the relay).
 # ARCHON_DIDCOMM_URL=http://didcomm:4236
+# (Lightning + names work the same way: ARCHON_LIGHTNING_MEDIATOR_URL and
+# ARCHON_HERALD_URL default ON since they're in the default profiles — set either
+# empty to disable that service. Empty disables; unset keeps the default.)
 
 # DIDComm relay (mailbox) — optional, enable with the `didcomm` profile.
 # Store-and-forward relay for DIDComm v2 encrypted messages, addressed by

--- a/sample.env
+++ b/sample.env
@@ -207,6 +207,11 @@ ARCHON_DRAWBRIDGE_RATE_LIMIT_WINDOW=60
 # ARCHON_DRAWBRIDGE_MACAROON_SECRET=
 # URL of the DIDComm relay that Drawbridge reverse-proxies at /didcomm (set by
 # the drawbridge compose fragment; override only for a non-default relay host).
+# OPTIONAL SERVICE / OFF-SWITCH: set this EMPTY (ARCHON_DIDCOMM_URL=) to declare
+# that this node does not offer DIDComm — /capabilities then reports didcomm:false,
+# the /didcomm mount returns 501, and keymaster clients fail fast with a clear
+# message instead of a transport error. (Same pattern for ARCHON_LIGHTNING_MEDIATOR_URL
+# and ARCHON_HERALD_URL.) An UNSET var keeps the default; only an explicit empty disables.
 # ARCHON_DIDCOMM_URL=http://didcomm:4236
 
 # DIDComm relay (mailbox) — optional, enable with the `didcomm` profile.

--- a/services/drawbridge/server/src/config.ts
+++ b/services/drawbridge/server/src/config.ts
@@ -6,9 +6,11 @@ const config = {
     port: process.env.ARCHON_DRAWBRIDGE_PORT ? parseInt(process.env.ARCHON_DRAWBRIDGE_PORT) : 4222,
     bindAddress: process.env.ARCHON_BIND_ADDRESS || '0.0.0.0',
     gatekeeperURL: process.env.ARCHON_GATEKEEPER_URL || 'http://localhost:4224',
-    heraldURL: process.env.ARCHON_HERALD_URL || 'http://localhost:4230',
-    lightningMediatorURL: process.env.ARCHON_LIGHTNING_MEDIATOR_URL || 'http://localhost:4235',
-    didcommURL: process.env.ARCHON_DIDCOMM_URL || 'http://localhost:4236',
+    // `??` (not `||`) so an explicitly-empty value disables the optional service
+    // (the capability off-switch), while an unset var falls back to the default.
+    heraldURL: process.env.ARCHON_HERALD_URL ?? 'http://localhost:4230',
+    lightningMediatorURL: process.env.ARCHON_LIGHTNING_MEDIATOR_URL ?? 'http://localhost:4235',
+    didcommURL: process.env.ARCHON_DIDCOMM_URL ?? 'http://localhost:4236',
     // Public base URL this node is reachable at (clearnet host or Tor onion).
     // Used to advertise the DIDComm relay endpoint (`<publicHost>/didcomm`).
     publicHost: process.env.ARCHON_DRAWBRIDGE_PUBLIC_HOST || '',

--- a/services/drawbridge/server/src/drawbridge-api.ts
+++ b/services/drawbridge/server/src/drawbridge-api.ts
@@ -426,6 +426,20 @@ async function main() {
         res.json({ version: serviceVersion, commit: serviceCommit });
     });
 
+    // Advertise which optional services this node offers, so clients can gate
+    // features and fail clearly instead of discovering absence via transport
+    // errors. A service is "offered" when its downstream URL is configured
+    // (non-empty); an operator opts out by setting the URL empty. This reflects
+    // node *intent*, not live health — a configured-but-down service still
+    // surfaces a runtime error to the caller.
+    v1router.get('/capabilities', (_req, res) => {
+        res.json({
+            didcomm: config.didcommURL !== '',
+            lightning: config.lightningMediatorURL !== '',
+            names: config.heraldURL !== '',
+        });
+    });
+
     // Public DIDComm relay endpoint, so `publishDidComm` can auto-discover it
     // (the way publishLightning learns its public host): an explicit public host,
     // else the Tor onion fronting this Drawbridge. Null when neither is available.
@@ -680,6 +694,10 @@ async function main() {
     // --- Lightning routes proxied to lightning-mediator ---
 
     v1router.use('/lightning', async (req, res) => {
+        if (config.lightningMediatorURL === '') {
+            res.status(501).json({ error: 'Lightning is not enabled on this node' });
+            return;
+        }
         try {
             await proxyLightningMediatorRequest(req, res, req.originalUrl);
         } catch (error: any) {
@@ -690,6 +708,10 @@ async function main() {
 
     // Public invoice endpoint — no auth required
     app.get('/invoice/:did', async (req, res) => {
+        if (config.lightningMediatorURL === '') {
+            res.status(501).json({ error: 'Lightning is not enabled on this node' });
+            return;
+        }
         try {
             await proxyLightningMediatorRequest(req, res, req.originalUrl);
         } catch (error: any) {
@@ -708,6 +730,10 @@ async function main() {
     });
 
     app.use('/names', async (req, res) => {
+        if (config.heraldURL === '') {
+            res.status(501).json({ error: 'Name resolution is not enabled on this node' });
+            return;
+        }
         try {
             await proxyHeraldRequest(req, res);
         } catch (error: any) {
@@ -718,7 +744,13 @@ async function main() {
 
     // Public face for the DIDComm relay (mailbox). The published
     // DIDCommMessaging endpoint is `<drawbridge public host>/didcomm`.
+    // Optional service: when the relay URL is unconfigured the node does not
+    // offer DIDComm — say so clearly (501) rather than proxying to nothing (502).
     app.use('/didcomm', async (req, res) => {
+        if (config.didcommURL === '') {
+            res.status(501).json({ error: 'DIDComm is not enabled on this node' });
+            return;
+        }
         try {
             await proxyRequest(req, res, config.didcommURL, '/didcomm');
         } catch (error: any) {

--- a/services/drawbridge/server/src/middleware/l402-auth.ts
+++ b/services/drawbridge/server/src/middleware/l402-auth.ts
@@ -28,7 +28,7 @@ import type {
 } from '../types.js';
 
 // Routes that bypass L402 auth
-const UNPROTECTED_PATHS = ['/ready', '/version', '/status', '/metrics', '/didcomm-endpoint'];
+const UNPROTECTED_PATHS = ['/ready', '/version', '/status', '/metrics', '/capabilities', '/didcomm-endpoint'];
 const UNPROTECTED_PREFIXES = ['/l402/'];
 // GET-only prefixes: read operations that should be publicly accessible
 const UNPROTECTED_GET_PREFIXES = ['/did/', '/ipfs/'];

--- a/tests/keymaster/didcomm.test.ts
+++ b/tests/keymaster/didcomm.test.ts
@@ -286,3 +286,36 @@ describe('packDidComm / unpackDidComm (cross-method: Archon did:cid <-> did:key)
         expect(metadata.sender).toBe(bob.kid);
     });
 });
+
+describe('node capability gating', () => {
+    // The capability manifest is fetched once and memoized in _nodeCapabilities;
+    // preset it here so the gate resolves without a network call.
+    it('blocks sendDidComm when the node does not offer DIDComm', async () => {
+        await keymaster.createId('Alice');
+        (gatekeeper as any).url = 'http://node.test';
+        (keymaster as any)._nodeCapabilities = { didcomm: false, lightning: true };
+
+        await expect(
+            keymaster.sendDidComm({ type: 'x', body: {} } as any, 'did:cid:bob')
+        ).rejects.toThrow(/does not offer DIDComm/);
+    });
+
+    it('blocks Lightning when the node does not offer it', async () => {
+        await keymaster.createId('Alice');
+        (gatekeeper as any).url = 'http://node.test';
+        (gatekeeper as any).createLightningWallet = async () => ({}); // pass requireDrawbridge
+        (keymaster as any)._nodeCapabilities = { didcomm: true, lightning: false };
+
+        await expect(keymaster.getLightningBalance()).rejects.toThrow(/does not offer Lightning/);
+    });
+
+    it('proceeds lazily when the node exposes no manifest', async () => {
+        const alice = await keymaster.createId('Alice');
+        (gatekeeper as any).url = 'http://node.test';
+        (keymaster as any)._nodeCapabilities = null; // no manifest -> permissive
+
+        // Gets past the gate, then fails for a different reason (unresolvable recipient).
+        const err = await keymaster.sendDidComm({ type: 'x', body: {} } as any, alice).catch(e => e);
+        expect(String(err)).not.toMatch(/does not offer/);
+    });
+});

--- a/tests/keymaster/lightning.test.ts
+++ b/tests/keymaster/lightning.test.ts
@@ -91,6 +91,10 @@ beforeEach(() => {
     keymaster = new Keymaster({
         gatekeeper, wallet, cipher, passphrase: 'passphrase',
     });
+    // The stubbed gatekeeper.url is a black-hole host; preset the memoized node
+    // capability manifest so the gating fetch doesn't hit the network (a real node
+    // offering Lightning would return this).
+    (keymaster as any)._nodeCapabilities = { didcomm: true, lightning: true };
 });
 
 describe('addLightning', () => {


### PR DESCRIPTION
Implements **Option C** from the optional-services design discussion (#647): nodes advertise which optional services they offer, and clients gate features off that instead of discovering absence via transport failures.

## Node side (Drawbridge)
- **`GET /api/v1/capabilities`** (unauthenticated) → `{ didcomm, lightning, names }`. Each flag is true when the downstream service URL is configured. Source of truth is node **intent (config), not live health** — a configured-but-crashed service still surfaces a runtime error.
- **Off-switch:** set a service's URL empty (e.g. `ARCHON_DIDCOMM_URL=`) to declare it off. `config.ts` switched from `||` to `??` so an *explicit empty* disables while an *unset* var keeps the default.
- The matching proxy mounts (`/didcomm`, `/lightning`, `/names`) return **501** when off, rather than proxying into nothing (502).

## Client side (keymaster — JS + Python, in parity)
- Fetches the manifest **once, memoized** (5s fetch timeout / httpx timeout → fail-fast).
- Gates the verbs: `send`/`receive`/`mediate`/`publishDidComm` on `didcomm`; **all** Lightning ops on `lightning` via the single `getLightningConfig` chokepoint.
- Explicit-off → clear **`this node does not offer …`**.
- **No manifest** (older node / bare gatekeeper) → **permissive**: the op proceeds and fails lazily, so existing nodes never regress.
- `publishDidComm` on a DIDComm-less node publishes **key-only** (no dead `DIDCommMessaging` endpoint).
- Folds in clearer transport errors: an unreachable gateway now reports **`could not reach the DIDComm gateway at …`** instead of undici's bare `fetch failed`.

## Scope / follow-up
Backend + keymaster only (the chosen cut). **Wallet/CLI UI feature-gating off the manifest is a separate follow-up** (filed). A dedicated Drawbridge HTTP test was intentionally skipped — the app is built inside a non-exported `main()` with no test harness, and the endpoint is trivial config-boolean logic; factoring `main()` for app-level tests is out of scope here.

## Tests / validation
- keymaster gating (JS + Python): blocked-service and permissive-no-manifest paths.
- Lightning suite presets the memoized manifest (its stub `gatekeeper.url` is a black-hole host).
- Green: JS didcomm units + e2e, JS lightning (47), Python didcomm (19); drawbridge typecheck.

Closes #647.

🤖 Generated with [Claude Code](https://claude.com/claude-code)