### PR TITLE
ci: Add Python keymaster PyPI publish workflow

### DIFF
--- a/.github/workflows/python-keymaster-publish.yml
+++ b/.github/workflows/python-keymaster-publish.yml
@@ -1,0 +1,195 @@
+name: Publish Python Keymaster to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Publish target"
+        required: true
+        default: check
+        type: choice
+        options:
+          - check
+          - testpypi
+          - pypi
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build archon-keymaster
+        working-directory: ./python/keymaster
+        run: |
+          python -m build
+
+      - name: Check distributions
+        working-directory: ./python/keymaster
+        run: |
+          python -m twine check dist/*
+
+      - name: Install package from wheel
+        working-directory: ./python/keymaster
+        run: |
+          python -m pip install dist/*.whl
+
+      - name: Smoke test keymaster CLI
+        run: |
+          keymaster --help > /dev/null
+          python - <<'PY'
+          import argparse
+          from keymaster.cli import build_parser
+
+          parser = build_parser()
+          subparsers = [
+              action
+              for action in parser._actions
+              if isinstance(action, argparse._SubParsersAction)
+          ]
+          assert subparsers, "CLI parser has no subcommands"
+
+          commands = subparsers[0].choices
+          required = {
+              "create-id",
+              "backup-wallet-file",
+              "create-asset",
+              "resolve-did",
+              "create-vault",
+              "add-vault-item",
+              "create-dmail",
+              "send-dmail",
+              "list-registries",
+          }
+          missing = sorted(required - commands.keys())
+          assert not missing, f"Missing expected commands: {', '.join(missing)}"
+          PY
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: archon-keymaster-dist
+          path: python/keymaster/dist/*
+          if-no-files-found: error
+
+  publish_testpypi:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event.inputs.target == 'testpypi' }}
+    environment: testpypi
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: archon-keymaster-dist
+          path: dist
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+      - name: Smoke test TestPyPI install
+        run: |
+          VERSION="$(python - <<'PY'
+          import tomllib
+          with open("python/keymaster/pyproject.toml", "rb") as f:
+              print(tomllib.load(f)["project"]["version"])
+          PY
+          )"
+
+          python -m venv /tmp/archon-keymaster-install-test
+          /tmp/archon-keymaster-install-test/bin/python -m pip install --upgrade pip
+
+          for attempt in {1..12}; do
+            if /tmp/archon-keymaster-install-test/bin/python -m pip install \
+              --index-url https://test.pypi.org/simple/ \
+              --extra-index-url https://pypi.org/simple/ \
+              "archon-keymaster==${VERSION}"; then
+              break
+            fi
+            if [ "$attempt" -eq 12 ]; then
+              echo "archon-keymaster ${VERSION} was not installable from TestPyPI" >&2
+              exit 1
+            fi
+            sleep 10
+          done
+
+          /tmp/archon-keymaster-install-test/bin/keymaster --help > /dev/null
+          /tmp/archon-keymaster-install-test/bin/python - <<'PY'
+          import argparse
+          from keymaster.cli import build_parser
+
+          parser = build_parser()
+          subparsers = [
+              action
+              for action in parser._actions
+              if isinstance(action, argparse._SubParsersAction)
+          ]
+          assert subparsers, "CLI parser has no subcommands"
+
+          commands = subparsers[0].choices
+          required = {
+              "create-id",
+              "backup-wallet-file",
+              "create-asset",
+              "resolve-did",
+              "create-vault",
+              "add-vault-item",
+              "create-dmail",
+              "send-dmail",
+              "list-registries",
+          }
+          missing = sorted(required - commands.keys())
+          assert not missing, f"Missing expected commands: {', '.join(missing)}"
+          PY
+
+  publish_pypi:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event.inputs.target == 'pypi' }}
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: archon-keymaster-dist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.github/workflows/python-keymaster-publish.yml
+++ b/.github/workflows/python-keymaster-publish.yml
@@ -112,11 +112,10 @@ jobs:
           path: dist
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           packages-dir: dist/
           repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
 
       - name: Smoke test TestPyPI install
         run: |
@@ -129,11 +128,14 @@ jobs:
 
           python -m venv /tmp/archon-keymaster-install-test
           /tmp/archon-keymaster-install-test/bin/python -m pip install --upgrade pip
+          rm -rf /tmp/archon-keymaster-testpypi-dist
+          mkdir -p /tmp/archon-keymaster-testpypi-dist
 
           for attempt in {1..12}; do
-            if /tmp/archon-keymaster-install-test/bin/python -m pip install \
+            if /tmp/archon-keymaster-install-test/bin/python -m pip download \
+              --no-deps \
+              --dest /tmp/archon-keymaster-testpypi-dist \
               --index-url https://test.pypi.org/simple/ \
-              --extra-index-url https://pypi.org/simple/ \
               "archon-keymaster==${VERSION}"; then
               break
             fi
@@ -144,6 +146,13 @@ jobs:
             sleep 10
           done
 
+          WHEEL="$(find /tmp/archon-keymaster-testpypi-dist -maxdepth 1 -name 'archon_keymaster-*.whl' -print -quit)"
+          if [ -z "$WHEEL" ]; then
+            echo "Downloaded TestPyPI package did not include a wheel" >&2
+            exit 1
+          fi
+
+          /tmp/archon-keymaster-install-test/bin/python -m pip install "$WHEEL"
           /tmp/archon-keymaster-install-test/bin/keymaster --help > /dev/null
           /tmp/archon-keymaster-install-test/bin/python - <<'PY'
           import argparse
@@ -190,6 +199,6 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           packages-dir: dist/

--- a/python/keymaster/PUBLISHING.md
+++ b/python/keymaster/PUBLISHING.md
@@ -6,7 +6,25 @@ the `archon-keymaster` distribution on PyPI.
 Do not upload to TestPyPI or PyPI unless the release owner explicitly asks for
 publication.
 
-## Preflight
+## GitHub Actions
+
+Use the manual `Publish Python Keymaster to PyPI` workflow for routine
+publishing. The workflow builds from `python/keymaster`, runs `twine check`,
+smoke tests the CLI parser, and then either stops after checks, publishes to
+TestPyPI, or publishes to PyPI.
+
+Production PyPI publishing uses PyPI trusted publishing and the GitHub
+`production` environment so release owners can require approval before upload.
+The TestPyPI path uses the `testpypi` environment and installs the just-published
+version back from TestPyPI before passing.
+
+Configure PyPI trusted publishers for:
+
+- workflow: `.github/workflows/python-keymaster-publish.yml`
+- environment: `production` for PyPI
+- environment: `testpypi` for TestPyPI
+
+## Manual Preflight
 
 ```bash
 python3 -m venv /tmp/archon-keymaster-publish

--- a/python/keymaster/tests/test_cli_smoke.py
+++ b/python/keymaster/tests/test_cli_smoke.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import argparse
+
+from keymaster.cli import build_parser
+
+
+def test_cli_parser_builds_with_stable_commands() -> None:
+    parser = build_parser()
+    subparsers = [
+        action
+        for action in parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    ]
+
+    assert subparsers, "CLI parser has no subcommands"
+
+    commands = subparsers[0].choices
+    required = {
+        "create-id",
+        "backup-wallet-file",
+        "create-asset",
+        "resolve-did",
+        "create-vault",
+        "add-vault-item",
+        "create-dmail",
+        "send-dmail",
+        "list-registries",
+    }
+
+    missing = sorted(required - commands.keys())
+    assert not missing, f"Missing expected commands: {', '.join(missing)}"


### PR DESCRIPTION
## Summary

- add a manual GitHub Actions workflow for publishing `archon-keymaster` to TestPyPI or PyPI
- build and `twine check` package artifacts before any publish job runs
- add CLI parser smoke coverage for stable Keymaster commands
- document trusted publishing environment setup in `python/keymaster/PUBLISHING.md`

Closes #586.

## Validation

- `.venv/bin/pytest -q python/keymaster/tests/test_cli_smoke.py`
- `../../.venv/bin/python -m build && ../../.venv/bin/python -m twine check dist/*` from `python/keymaster`
- clean wheel install smoke test with `keymaster --help` and parser command assertions
- `.venv/bin/pytest -q python/keymaster/tests`
- `git diff --check`
- parsed `.github/workflows/python-keymaster-publish.yml` with PyYAML

`actionlint` is not installed locally, so the workflow was not checked with actionlint.
