### PR TITLE
chore: Init v0.11.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ These rules apply to coding agents working in this repository.
 - Keep `apps/gatekeeper-client/src/KeymasterUI.jsx` and `apps/keymaster-client/src/KeymasterUI.jsx` identical. When one changes, update the other to match rather than maintaining intentional drift.
 - For GitHub operations in this repo, use `gh` by default, especially for write actions and PR creation. Do not try the GitHub app first and then fall back to `gh` unless the user explicitly asks for the app or `gh` cannot perform the operation.
 - When generating or updating npm lockfiles, use the repo-pinned npm version from the root `package.json` so lockfiles stay compatible with CI.
+- For repo-wide version sweeps, search tracked files with `git ls-files` rather than raw filesystem traversal so local `node_modules`, `data`, and build outputs cannot pollute the bump.
 - Internal service-to-service admin auth should use `X-Archon-Admin-Key` consistently. Reserve `Authorization` for user/session/OAuth-style flows unless a file explicitly documents a different scheme.
 - Drawbridge's bundled Tor SOCKS host port should default to `127.0.0.1:9050`; internal services should keep using the Docker network address `tor:9050`.
 - Keymaster's Docker host port should default to localhost via `ARCHON_KEYMASTER_HOST_BIND=127.0.0.1`; internal services should keep using `keymaster:4226`.

--- a/apps/browser-extension/package-lock.json
+++ b/apps/browser-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "archon-browser-extension",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "archon-browser-extension",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "qrcode.react": "^4.2.0"

--- a/apps/browser-extension/package.json
+++ b/apps/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archon-browser-extension",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Archon Browser Extension",
   "main": "index.js",
   "scripts": {

--- a/apps/browser-extension/src/static/manifest.firefox.json
+++ b/apps/browser-extension/src/static/manifest.firefox.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Archon Wallet",
     "description": "Archon Wallet",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "icons": {
         "16": "icon.png",
         "48": "icon.png",

--- a/apps/browser-extension/src/static/manifest.json
+++ b/apps/browser-extension/src/static/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Archon Wallet",
     "description": "Archon Wallet",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "icons": {
         "16": "icon.png",
         "48": "icon.png",

--- a/apps/gatekeeper-client/package-lock.json
+++ b/apps/gatekeeper-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatekeeper-client",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatekeeper-client",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/apps/gatekeeper-client/package.json
+++ b/apps/gatekeeper-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatekeeper-client",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/herald-client/package-lock.json
+++ b/apps/herald-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-client",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-client",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.14.1",

--- a/apps/herald-client/package.json
+++ b/apps/herald-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-client",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/keymaster-client/package-lock.json
+++ b/apps/keymaster-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "keymaster-client",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "keymaster-client",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/apps/keymaster-client/package.json
+++ b/apps/keymaster-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymaster-client",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/react-wallet/package-lock.json
+++ b/apps/react-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@didcid/react-wallet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@didcid/react-wallet",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor-mlkit/barcode-scanning": "^7.3.0",

--- a/apps/react-wallet/package.json
+++ b/apps/react-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/react-wallet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Archon Android Demo",
   "scripts": {
     "dev": "vite",

--- a/docs/gatekeeper-api.json
+++ b/docs/gatekeeper-api.json
@@ -523,7 +523,7 @@
     "/did/{did}": {
       "get": {
         "summary": "Resolve a DID Document",
-        "description": "Resolves a DID Document from the local database. If local resolution fails, falls back to a configurable universal resolver (default: https://dev.uniresolver.io). Set `ARCHON_GATEKEEPER_FALLBACK_URL` to override the resolver URL (empty string disables fallback). Set `ARCHON_GATEKEEPER_FALLBACK_TIMEOUT` to override the timeout in milliseconds (default: 5000).\n",
+        "description": "Resolves a DID Document from the local database. If local resolution fails, falls back to a configurable universal resolver (default: https://dev.uniresolver.io). Set `ARCHON_GATEKEEPER_FALLBACK_URL` to override the resolver URL (empty string disables fallback). Set `ARCHON_GATEKEEPER_FALLBACK_TIMEOUT` to override the timeout in milliseconds (default: 5000). Set `ARCHON_GATEKEEPER_CONFIRM_FALLBACK_URL` to delegate unconfirmed `confirm=true` responses to another Gatekeeper node (empty string disables fallback).\n",
         "parameters": [
           {
             "in": "path",
@@ -697,12 +697,7 @@
                         },
                         "registry": {
                           "type": "string",
-                          "enum": [
-                            "local",
-                            "hyperswarm",
-                            "BTC:testnet4",
-                            "BTC:signet"
-                          ],
+                          "pattern": "^[A-Za-z0-9][A-Za-z0-9:_-]*$",
                           "description": "Registry in which this DID is maintained."
                         },
                         "version": {
@@ -1422,7 +1417,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The name of the registry whose queue is being retrieved. Valid values may include \"local\", \"hyperswarm\", \"BTC:testnet4\", \"BTC:signet\", etc.\n"
+            "description": "The name of the registry whose queue is being retrieved. Registry names must match `[A-Za-z0-9][A-Za-z0-9:_-]*`.\n"
           }
         ],
         "responses": {

--- a/docs/gatekeeper-api.json
+++ b/docs/gatekeeper-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Gatekeeper API",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "description": "Documentation for Keymaster API"
   },
   "paths": {

--- a/docs/keymaster-api.json
+++ b/docs/keymaster-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Keymaster API",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "description": "Documentation for Keymaster API"
   },
   "paths": {

--- a/docs/keymaster-api.json
+++ b/docs/keymaster-api.json
@@ -2309,6 +2309,437 @@
         }
       }
     },
+    "/didcomm/publish": {
+      "post": {
+        "summary": "Publish an X25519 key-agreement key (and optional DIDComm service) to the current identity DID document.",
+        "description": "Derives the identity's deterministic X25519 key-agreement key and writes it into the DID document as a `keyAgreement` verification method, enabling DIDComm v2 encrypted messaging. If an endpoint is supplied, also publishes a `DIDCommMessaging` DID service endpoint.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "endpoint": {
+                    "type": "string",
+                    "description": "Optional DIDComm service endpoint URI. When provided, a `DIDCommMessaging` service entry is published."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Optional identity name. Defaults to the current identity."
+                  },
+                  "routingKeys": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Optional mediator routing keys or DIDs. When present, the published `DIDCommMessaging` service advertises the object form (uri/accept/routingKeys) so senders wrap messages in a Forward to the mediator."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates whether the key agreement key was successfully published.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove the DIDComm key-agreement key and service from the current identity DID document.",
+        "description": "Removes the `keyAgreement` verification method and the `#didcomm` DID service endpoint from the selected identity.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Optional identity name. Defaults to the current identity."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates whether the DIDComm key was successfully unpublished.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/pack": {
+      "post": {
+        "summary": "Pack a DIDComm v2 message (encrypted, optionally signed) for one or more recipients.",
+        "description": "Resolves each recipient DID's X25519 key-agreement key and produces a DIDComm encrypted (JWE) envelope. Authenticated-sender (authcrypt) by default; pass `anoncrypt` for an anonymous sender, and `sign` to add an ES256K signature (non-repudiation).",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "object",
+                    "description": "The DIDComm plaintext message (type, body, and optional headers). `from`/`to` are set automatically."
+                  },
+                  "to": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "description": "Recipient DID or array of recipient DIDs."
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "sign": {
+                        "type": "boolean"
+                      },
+                      "anoncrypt": {
+                        "type": "boolean"
+                      },
+                      "encryption": {
+                        "type": "string",
+                        "enum": [
+                          "A256CBC-HS512",
+                          "XC20P",
+                          "A256GCM"
+                        ]
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The packed DIDComm message.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "packed": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/unpack": {
+      "post": {
+        "summary": "Unpack (decrypt and verify) a DIDComm v2 message addressed to the current identity.",
+        "description": "Decrypts the envelope with the identity's X25519 key-agreement key, verifies the authenticated sender (authcrypt) and any nested ES256K signature, and returns the plaintext message with metadata.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "packed": {
+                    "type": "string",
+                    "description": "The packed DIDComm message."
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Optional identity name. Defaults to the current identity."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The unpacked message and metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/didcomm/send": {
+      "post": {
+        "summary": "Pack a DIDComm message and deliver it to each recipient's DIDCommMessaging mailbox.",
+        "description": "Packs the message (authcrypt by default; `anoncrypt`/`sign` options) and POSTs it to each recipient's resolved `DIDCommMessaging` endpoint. Returns the stored message ids.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "object"
+                  },
+                  "to": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ]
+                  },
+                  "options": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Delivered. Returns stored message ids.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ids": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request."
+          }
+        }
+      }
+    },
+    "/didcomm/receive": {
+      "post": {
+        "summary": "Fetch and unpack queued DIDComm messages from the current identity's mailbox.",
+        "description": "Proves DID control with a signed challenge, fetches queued envelopes from the identity's `DIDCommMessaging` endpoint, unpacks them, and acknowledges (removes) the ones that unpacked.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The unpacked messages with metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request."
+          }
+        }
+      }
+    },
+    "/didcomm/mediate": {
+      "post": {
+        "summary": "Run the mediator relay — fetch Forward messages for this identity and relay each to its final recipient.",
+        "description": "For an identity acting as a DIDComm mediator. Fetches queued Forward envelopes from its mailbox, unpacks each, and relays the inner envelope to the recipient (`next`). Returns relayed/skipped counts.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "endpoint": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Relay result counts.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request."
+          }
+        }
+      }
+    },
     "/addresses/{address}": {
       "delete": {
         "summary": "Remove the stored address for the current identity and revoke it remotely.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "archon",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "archon",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "ISC",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archon",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Self-sovereign identity infrastructure for the decentralized web",
   "private": true,

--- a/python/keymaster_sdk/pyproject.toml
+++ b/python/keymaster_sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "keymaster-sdk"
-version = "0.10.0"
+version = "0.11.0"
 description = "Keymaster is a client library for Archon"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/python/keymaster_service/pyproject.toml
+++ b/python/keymaster_service/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "keymaster-service"
-version = "0.10.0"
+version = "0.11.0"
 description = "Native Python Keymaster service for Archon"
 readme = "README.md"
 dependencies = [

--- a/python/keymaster_service/src/keymaster_service/__init__.py
+++ b/python/keymaster_service/src/keymaster_service/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/python/keymaster_service/src/keymaster_service/config.py
+++ b/python/keymaster_service/src/keymaster_service/config.py
@@ -9,7 +9,7 @@ def _package_version() -> str:
     try:
         return metadata.version("keymaster-service")
     except metadata.PackageNotFoundError:
-        return "0.10.0"
+        return "0.11.0"
 
 
 @dataclass(slots=True)

--- a/rust/services/gatekeeper/Cargo.lock
+++ b/rust/services/gatekeeper/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "archon-rust-gatekeeper"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/rust/services/gatekeeper/Cargo.toml
+++ b/rust/services/gatekeeper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "archon-rust-gatekeeper"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 description = "Native Rust Gatekeeper service for Archon"

--- a/services/didcomm/server/package-lock.json
+++ b/services/didcomm/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "didcomm-server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "didcomm-server",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.6",

--- a/services/didcomm/server/package.json
+++ b/services/didcomm/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "didcomm-server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon DIDComm relay (mailbox) server",
   "main": "dist/index.js",

--- a/services/drawbridge/server/package-lock.json
+++ b/services/drawbridge/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drawbridge-server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drawbridge-server",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",

--- a/services/drawbridge/server/package.json
+++ b/services/drawbridge/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drawbridge-server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon Drawbridge L402 API Gateway",
   "main": "dist/drawbridge-api.js",

--- a/services/explorer/package-lock.json
+++ b/services/explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "archon-explorer",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "archon-explorer",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/services/explorer/package.json
+++ b/services/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archon-explorer",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "scripts": {
     "start": "npm run build && node server.js",

--- a/services/gatekeeper/server/package-lock.json
+++ b/services/gatekeeper/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatekeeper-server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatekeeper-server",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.6",

--- a/services/gatekeeper/server/package.json
+++ b/services/gatekeeper/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatekeeper-server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon Gatekeeper REST API server",
   "main": "src/index.js",

--- a/services/herald/package-lock.json
+++ b/services/herald/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "herald",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "herald",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "dependencies": {
         "jose": "^6.2.1"

--- a/services/herald/package.json
+++ b/services/herald/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herald",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "scripts": {
     "install": "npm install --prefix server",

--- a/services/herald/server/package-lock.json
+++ b/services/herald/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "herald-server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "herald-server",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@sendgrid/mail": "^8.1.6",

--- a/services/herald/server/package.json
+++ b/services/herald/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herald-server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon naming service",
   "main": "dist/index.js",

--- a/services/keymaster/server/package-lock.json
+++ b/services/keymaster/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "keymaster-server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "keymaster-server",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.6",

--- a/services/keymaster/server/package.json
+++ b/services/keymaster/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymaster-server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon Keymaster REST API server",
   "main": "src/index.js",

--- a/services/mediators/ethereum-wallet/package-lock.json
+++ b/services/mediators/ethereum-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ethereum-wallet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ethereum-wallet",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.16.0",

--- a/services/mediators/ethereum-wallet/package.json
+++ b/services/mediators/ethereum-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-wallet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon Ethereum Wallet Service",
   "main": "dist/wallet-api.js",

--- a/services/mediators/ethereum/package-lock.json
+++ b/services/mediators/ethereum/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ethereum-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ethereum-mediator",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.16.0",

--- a/services/mediators/ethereum/package.json
+++ b/services/mediators/ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon Ethereum blockchain mediator",
   "main": "dist/ethereum-mediator.js",

--- a/services/mediators/filecoin-wallet/package-lock.json
+++ b/services/mediators/filecoin-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filecoin-wallet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filecoin-wallet",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.2.0",

--- a/services/mediators/filecoin-wallet/package.json
+++ b/services/mediators/filecoin-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filecoin-wallet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon Filecoin Wallet Service",
   "main": "dist/wallet-api.js",

--- a/services/mediators/filecoin/package-lock.json
+++ b/services/mediators/filecoin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filecoin-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filecoin-mediator",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.16.0",

--- a/services/mediators/filecoin/package.json
+++ b/services/mediators/filecoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filecoin-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon Filecoin storage mediator",
   "main": "dist/filecoin-mediator.js",

--- a/services/mediators/hyperswarm/package-lock.json
+++ b/services/mediators/hyperswarm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hyperswarm-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hyperswarm-mediator",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.3.3",

--- a/services/mediators/hyperswarm/package.json
+++ b/services/mediators/hyperswarm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswarm-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon hyperswarm network mediator",
   "main": "src/index.js",

--- a/services/mediators/lightning/package-lock.json
+++ b/services/mediators/lightning/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-mediator",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.16.0",

--- a/services/mediators/lightning/package.json
+++ b/services/mediators/lightning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon Lightning mediator",
   "main": "dist/lightning-mediator.js",

--- a/services/mediators/pinning/package-lock.json
+++ b/services/mediators/pinning/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pinning-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pinning-mediator",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.16.0",

--- a/services/mediators/pinning/package.json
+++ b/services/mediators/pinning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinning-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon generic IPFS pinning mediator",
   "main": "dist/pinning-mediator.js",

--- a/services/mediators/satoshi-wallet/package-lock.json
+++ b/services/mediators/satoshi-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "satoshi-wallet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "satoshi-wallet",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/services/mediators/satoshi-wallet/package.json
+++ b/services/mediators/satoshi-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satoshi-wallet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon Satoshi Wallet Service",
   "main": "dist/wallet-api.js",

--- a/services/mediators/satoshi/package-lock.json
+++ b/services/mediators/satoshi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "satoshi-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "satoshi-mediator",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/services/mediators/satoshi/package.json
+++ b/services/mediators/satoshi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satoshi-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon satoshi blockchain mediator",
   "main": "src/index.js",

--- a/services/mediators/solana-wallet/package-lock.json
+++ b/services/mediators/solana-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solana-wallet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "solana-wallet",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@solana/web3.js": "^1.98.4",

--- a/services/mediators/solana-wallet/package.json
+++ b/services/mediators/solana-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solana-wallet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon Solana Wallet Service",
   "main": "dist/wallet-api.js",

--- a/services/mediators/solana/package-lock.json
+++ b/services/mediators/solana/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solana-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "solana-mediator",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@solana/web3.js": "^1.98.4",

--- a/services/mediators/solana/package.json
+++ b/services/mediators/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solana-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon Solana blockchain mediator",
   "main": "dist/solana-mediator.js",

--- a/services/mediators/zcash-wallet/package-lock.json
+++ b/services/mediators/zcash-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zcash-wallet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zcash-wallet",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@bitgo/utxo-lib": "^11.22.1",

--- a/services/mediators/zcash-wallet/package.json
+++ b/services/mediators/zcash-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcash-wallet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon Zcash Transparent Wallet Service",
   "main": "dist/wallet-api.js",

--- a/services/mediators/zcash/package-lock.json
+++ b/services/mediators/zcash/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zcash-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zcash-mediator",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/services/mediators/zcash/package.json
+++ b/services/mediators/zcash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcash-mediator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "Archon Zcash blockchain mediator",
   "main": "dist/zcash-mediator.js",


### PR DESCRIPTION
## Summary
- Bump Archon app and service package versions to 0.11.0
- Refresh corresponding npm package-lock metadata with npm 10.9.2
- Update Rust Gatekeeper, Python Keymaster service/SDK, browser extension manifests, API doc version metadata, and repo workflow guidance

## Validation
- npm install --package-lock-only --ignore-scripts across bumped app/service/root lockfiles
- release metadata verification script
- git diff --check

## Notes
- npm emitted existing audit advisory output during lockfile refresh.
- npm emitted EBADENGINE warnings for undici@8.5.0 in a few package contexts because this shell is Node v22.15.0 while that package declares >=22.19.0.
