### PR TITLE
test: Restore test coverage above 95%

### DIFF
--- a/tests/cipher/cipher.test.ts
+++ b/tests/cipher/cipher.test.ts
@@ -9,6 +9,16 @@ const mockObject = {
     age: 42
 };
 
+describe('HD key helpers', () => {
+    it('restores an HD key from its JSON form', () => {
+        const mnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+        const hdkey = cipher.generateHDKey(mnemonic);
+
+        expect(cipher.generateHDKeyJSON(hdkey.toJSON()).publicExtendedKey)
+            .toBe(hdkey.publicExtendedKey);
+    });
+});
+
 describe('addProofOfWork', () => {
     it('should add valid PoW to an object', async () => {
         const difficulty = 8;
@@ -81,4 +91,3 @@ describe('checkProofOfWork', () => {
         expect(result).toBe(false);
     });
 });
-

--- a/tests/cipher/passphrase.test.ts
+++ b/tests/cipher/passphrase.test.ts
@@ -1,0 +1,40 @@
+import { decryptWithPassphrase, encryptWithPassphrase } from '../../packages/cipher/src/passphrase.ts';
+
+describe('passphrase encryption helpers', () => {
+    const originalIterations = process.env.PBKDF2_ITERATIONS;
+
+    beforeEach(() => {
+        process.env.PBKDF2_ITERATIONS = '1';
+    });
+
+    afterEach(() => {
+        if (originalIterations === undefined) {
+            delete process.env.PBKDF2_ITERATIONS;
+        }
+        else {
+            process.env.PBKDF2_ITERATIONS = originalIterations;
+        }
+    });
+
+    it('encrypts and decrypts text with a passphrase', async () => {
+        const encrypted = await encryptWithPassphrase('wallet secret', 'pass');
+
+        expect(encrypted.salt).toBeTruthy();
+        expect(encrypted.iv).toBeTruthy();
+        expect(encrypted.data).toBeTruthy();
+        await expect(decryptWithPassphrase(encrypted, 'pass')).resolves.toBe('wallet secret');
+    });
+
+    it('rejects decryption with the wrong passphrase', async () => {
+        const encrypted = await encryptWithPassphrase('wallet secret', 'pass');
+
+        await expect(decryptWithPassphrase(encrypted, 'wrong')).rejects.toThrow();
+    });
+
+    it('falls back to default iterations when the env override is invalid', async () => {
+        process.env.PBKDF2_ITERATIONS = 'invalid';
+        const encrypted = await encryptWithPassphrase('fallback secret', 'pass');
+
+        await expect(decryptWithPassphrase(encrypted, 'pass')).resolves.toBe('fallback secret');
+    });
+});

--- a/tests/didcomm/mailbox.test.ts
+++ b/tests/didcomm/mailbox.test.ts
@@ -112,6 +112,130 @@ describe('RedisMailboxStore connection guards', () => {
     });
 });
 
+describe('RedisMailboxStore command mapping', () => {
+    class FakeRedis {
+        values = new Map<string, string>();
+        sets = new Map<string, Set<string>>();
+        calls: any[][] = [];
+
+        multi() {
+            const ops: (() => void)[] = [];
+            const chain = {
+                set: (key: string, value: string, mode: string, ttl: number) => {
+                    this.calls.push(['set', key, value, mode, ttl]);
+                    ops.push(() => this.values.set(key, value));
+                    return chain;
+                },
+                sadd: (key: string, id: string) => {
+                    this.calls.push(['sadd', key, id]);
+                    ops.push(() => {
+                        const set = this.sets.get(key) || new Set<string>();
+                        set.add(id);
+                        this.sets.set(key, set);
+                    });
+                    return chain;
+                },
+                expire: (key: string, ttl: number) => {
+                    this.calls.push(['expire', key, ttl]);
+                    return chain;
+                },
+                exec: async () => {
+                    ops.forEach(op => op());
+                    return [];
+                },
+            };
+            return chain;
+        }
+
+        async smembers(key: string) {
+            return [...(this.sets.get(key) || [])];
+        }
+
+        async mget(keys: string[]) {
+            return keys.map(key => this.values.get(key) ?? null);
+        }
+
+        async srem(key: string, ...ids: string[]) {
+            this.calls.push(['srem', key, ...ids]);
+            const set = this.sets.get(key);
+            ids.forEach(id => set?.delete(id));
+            return ids.length;
+        }
+
+        async del(...keys: string[]) {
+            this.calls.push(['del', ...keys]);
+            let removed = 0;
+            keys.forEach(key => {
+                if (this.values.delete(key)) {
+                    removed += 1;
+                }
+            });
+            return removed;
+        }
+
+        async set(key: string, value: string, mode: string, ttl: number) {
+            this.calls.push(['set', key, value, mode, ttl]);
+            this.values.set(key, value);
+        }
+
+        async getdel(key: string) {
+            const value = this.values.get(key) ?? null;
+            this.values.delete(key);
+            return value;
+        }
+
+        async quit() {
+            this.calls.push(['quit']);
+        }
+    }
+
+    function redisStore(prefix = 'unit') {
+        const store = new RedisMailboxStore('redis://unused', prefix, 2000, 3000);
+        const redis = new FakeRedis();
+        (store as any).redis = redis;
+        return { store, redis };
+    }
+
+    it('stores messages with TTLs, prunes expired ids while listing, and removes by id', async () => {
+        const { store, redis } = redisStore();
+
+        const message = await store.add('did:cid:bob', 'env-1', 'id-1');
+        expect(message).toMatchObject({ id: 'id-1', recipient: 'did:cid:bob', envelope: 'env-1' });
+        expect(redis.calls).toContainEqual(['set', 'unit:msg:did:cid:bob:id-1', expect.any(String), 'EX', 2]);
+        expect(redis.calls).toContainEqual(['sadd', 'unit:inbox:did:cid:bob', 'id-1']);
+        expect(redis.calls).toContainEqual(['expire', 'unit:inbox:did:cid:bob', 2]);
+
+        redis.sets.get('unit:inbox:did:cid:bob')!.add('expired');
+        const listed = await store.list('did:cid:bob');
+        expect(listed).toHaveLength(1);
+        expect(listed[0].id).toBe('id-1');
+        expect(redis.calls).toContainEqual(['srem', 'unit:inbox:did:cid:bob', 'expired']);
+
+        expect(await store.remove('did:cid:bob', ['id-1', 'missing'])).toBe(1);
+        expect(redis.calls).toContainEqual([
+            'del',
+            'unit:msg:did:cid:bob:id-1',
+            'unit:msg:did:cid:bob:missing',
+        ]);
+        expect(redis.calls).toContainEqual(['srem', 'unit:inbox:did:cid:bob', 'id-1', 'missing']);
+    });
+
+    it('returns an empty inbox without mget, consumes challenges once, and disconnects cleanly', async () => {
+        const { store, redis } = redisStore('challenge');
+
+        expect(await store.list('did:cid:empty')).toEqual([]);
+
+        await store.issueChallenge('c1');
+        expect(redis.calls).toContainEqual(['set', 'challenge:challenge:c1', '1', 'PX', 3000]);
+        expect(await store.consumeChallenge('c1')).toBe(true);
+        expect(await store.consumeChallenge('c1')).toBe(false);
+
+        await store.disconnect();
+        expect(redis.calls).toContainEqual(['quit']);
+        await expect(store.list('did:cid:empty')).rejects.toThrow('Redis is not connected');
+    });
+});
+
 describe('recipientDidsFromEnvelope', () => {
     it('extracts the recipient DIDs from the JWE recipient kids', () => {
         const cipher = new CipherNode();
@@ -179,5 +303,35 @@ describe('verifyChallengeSignature', () => {
 
         const ok = await verifyChallengeSignature({ resolver: gatekeeper, cipher }, { did: aliceDid, challenge, signature: mallorySig });
         expect(ok).toBe(false);
+    });
+
+    it('rejects unresolved DIDs, non-signing keys, and verifier errors', async () => {
+        await expect(verifyChallengeSignature(
+            { resolver: { resolveDID: async () => { throw new Error('not found'); } }, cipher },
+            { did: 'did:cid:missing', challenge: 'challenge', signature: 'sig' }
+        )).resolves.toBe(false);
+
+        await expect(verifyChallengeSignature(
+            {
+                resolver: {
+                    resolveDID: async () => ({
+                        didDocument: {
+                            id: 'did:cid:x25519',
+                            verificationMethod: [{ id: '#key-1', type: 'JsonWebKey2020', publicKeyJwk: { kty: 'OKP', crv: 'X25519', x: 'x' } }],
+                        },
+                    }),
+                },
+                cipher,
+            },
+            { did: 'did:cid:x25519', challenge: 'challenge', signature: 'sig' }
+        )).resolves.toBe(false);
+
+        await expect(verifyChallengeSignature(
+            {
+                resolver: gatekeeper,
+                cipher: { ...cipher, verifySig: () => { throw new Error('bad signature'); } },
+            },
+            { did: await keymaster.createId('VerifierError'), challenge: 'challenge', signature: 'sig' }
+        )).resolves.toBe(false);
     });
 });

--- a/tests/didcomm/mailbox.test.ts
+++ b/tests/didcomm/mailbox.test.ts
@@ -24,6 +24,15 @@ describe('MemoryMailboxStore', () => {
         expect((await store.list('did:cid:bob')).map(m => m.id)).toEqual(['id-2']);
     });
 
+    it('removes the recipient inbox after the last message is deleted', async () => {
+        const store = new MemoryMailboxStore();
+        await store.add('did:cid:bob', 'env-1', 'id-1');
+
+        expect(await store.remove('did:cid:bob', ['id-1'])).toBe(1);
+        expect(await store.list('did:cid:bob')).toStrictEqual([]);
+        expect(await store.remove('did:cid:bob', ['missing'])).toBe(0);
+    });
+
     it('prunes messages past the TTL', async () => {
         let now = 1_000_000;
         const store = new MemoryMailboxStore(1000, 1000, () => now);
@@ -83,6 +92,23 @@ describeRedis('RedisMailboxStore (live redis)', () => {
         expect(await store.consumeChallenge('rc1')).toBe(true);
         expect(await store.consumeChallenge('rc1')).toBe(false);
         expect(await store.consumeChallenge('never-issued')).toBe(false);
+    });
+});
+
+describe('RedisMailboxStore connection guards', () => {
+    it('throws a clear error when used before connecting', async () => {
+        const store = new RedisMailboxStore('redis://localhost:6379');
+
+        await expect(store.add('did:cid:bob', 'env', 'id-1')).rejects.toThrow('Redis is not connected');
+        await expect(store.list('did:cid:bob')).rejects.toThrow('Redis is not connected');
+        await expect(store.issueChallenge('challenge')).rejects.toThrow('Redis is not connected');
+        await expect(store.consumeChallenge('challenge')).rejects.toThrow('Redis is not connected');
+    });
+
+    it('does not require a Redis connection to remove an empty id list', async () => {
+        const store = new RedisMailboxStore('redis://localhost:6379');
+
+        await expect(store.remove('did:cid:bob', [])).resolves.toBe(0);
     });
 });
 

--- a/tests/gatekeeper/drawbridge-client.test.ts
+++ b/tests/gatekeeper/drawbridge-client.test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import nock from 'nock';
 import DrawbridgeClient from '@didcid/gatekeeper/drawbridge';
 import { ExpectedExceptionError } from '@didcid/common/errors';
@@ -133,6 +134,19 @@ describe('DrawbridgeClient', () => {
         }
         catch (error: any) {
             expect(error.message).toBe(ServerError.message);
+        }
+    });
+
+    it('throws non-HTTP error messages unchanged', async () => {
+        const client = await DrawbridgeClient.create({ url: DrawbridgeURL });
+        (client as any).axios.post = jest.fn().mockRejectedValue(new Error('socket down'));
+
+        try {
+            await client.getLightningBalance('invoice');
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error).toBe('socket down');
         }
     });
 });

--- a/tests/gatekeeper/drawbridge-client.test.ts
+++ b/tests/gatekeeper/drawbridge-client.test.ts
@@ -1,0 +1,138 @@
+import nock from 'nock';
+import DrawbridgeClient from '@didcid/gatekeeper/drawbridge';
+import { ExpectedExceptionError } from '@didcid/common/errors';
+
+const DrawbridgeURL = 'http://drawbridge.org';
+const ServerError = { message: 'Server error' };
+const Endpoints = {
+    lightning: {
+        supported: '/api/v1/lightning/supported',
+        wallet: '/api/v1/lightning/wallet',
+        balance: '/api/v1/lightning/balance',
+        invoice: '/api/v1/lightning/invoice',
+        pay: '/api/v1/lightning/pay',
+        payment: '/api/v1/lightning/payment',
+        publish: '/api/v1/lightning/publish',
+        payments: '/api/v1/lightning/payments',
+        zap: '/api/v1/lightning/zap',
+    },
+    didcommEndpoint: '/api/v1/didcomm-endpoint',
+};
+
+describe('DrawbridgeClient', () => {
+    it('creates a connected client', async () => {
+        const client = await DrawbridgeClient.create({ url: DrawbridgeURL });
+
+        expect(client).toBeInstanceOf(DrawbridgeClient);
+        expect(client.url).toBe(DrawbridgeURL);
+    });
+
+    it('returns lightning support status and treats failures as unsupported', async () => {
+        nock(DrawbridgeURL)
+            .get(Endpoints.lightning.supported)
+            .reply(200, { supported: true })
+            .get(Endpoints.lightning.supported)
+            .reply(200, { supported: false })
+            .get(Endpoints.lightning.supported)
+            .reply(500, ServerError);
+
+        const client = await DrawbridgeClient.create({ url: DrawbridgeURL });
+
+        expect(await client.isLightningSupported()).toBe(true);
+        expect(await client.isLightningSupported()).toBe(false);
+        expect(await client.isLightningSupported()).toBe(false);
+    });
+
+    it('creates a lightning wallet', async () => {
+        nock(DrawbridgeURL)
+            .post(Endpoints.lightning.wallet, { name: 'Alice' })
+            .reply(200, { walletId: 'wallet', adminKey: 'admin', invoiceKey: 'invoice' });
+
+        const client = await DrawbridgeClient.create({ url: DrawbridgeURL });
+
+        expect(await client.createLightningWallet('Alice')).toStrictEqual({
+            walletId: 'wallet',
+            adminKey: 'admin',
+            invoiceKey: 'invoice',
+        });
+    });
+
+    it('fetches lightning balance, invoice, payment status, and payment history', async () => {
+        nock(DrawbridgeURL)
+            .post(Endpoints.lightning.balance, { invoiceKey: 'invoice' })
+            .reply(200, { balance: 123 })
+            .post(Endpoints.lightning.invoice, { invoiceKey: 'invoice', amount: 21, memo: 'coffee' })
+            .reply(200, { paymentRequest: 'lnbc...', paymentHash: 'hash' })
+            .post(Endpoints.lightning.payment, { invoiceKey: 'invoice', paymentHash: 'hash' })
+            .reply(200, { paid: true, paymentHash: 'hash', status: 'success' })
+            .post(Endpoints.lightning.payments, { adminKey: 'admin' })
+            .reply(200, { payments: [{ paymentHash: 'hash', amount: 21, fee: 0, memo: 'coffee', time: '2026-01-01T00:00:00.000Z', pending: false, status: 'success' }] });
+
+        const client = await DrawbridgeClient.create({ url: DrawbridgeURL });
+
+        expect(await client.getLightningBalance('invoice')).toStrictEqual({ balance: 123 });
+        expect(await client.createLightningInvoice('invoice', 21, 'coffee')).toStrictEqual({ paymentRequest: 'lnbc...', paymentHash: 'hash' });
+        expect(await client.checkLightningPayment('invoice', 'hash')).toStrictEqual({ paid: true, paymentHash: 'hash', status: 'success' });
+        expect(await client.getLightningPayments('admin')).toStrictEqual([
+            { paymentHash: 'hash', amount: 21, fee: 0, memo: 'coffee', time: '2026-01-01T00:00:00.000Z', pending: false, status: 'success' },
+        ]);
+    });
+
+    it('pays invoices and zaps DIDs', async () => {
+        nock(DrawbridgeURL)
+            .post(Endpoints.lightning.pay, { adminKey: 'admin', bolt11: 'lnbc...' })
+            .reply(200, { paymentHash: 'paid-hash' })
+            .post(Endpoints.lightning.zap, { adminKey: 'admin', did: 'did:cid:alice', amount: 21, memo: 'zap' })
+            .reply(200, { paymentHash: 'zap-hash' });
+
+        const client = await DrawbridgeClient.create({ url: DrawbridgeURL });
+
+        expect(await client.payLightningInvoice('admin', 'lnbc...')).toStrictEqual({ paymentHash: 'paid-hash' });
+        expect(await client.zapLightning('admin', 'did:cid:alice', 21, 'zap')).toStrictEqual({ paymentHash: 'zap-hash' });
+    });
+
+    it('publishes and unpublishes lightning service endpoints', async () => {
+        nock(DrawbridgeURL)
+            .post(Endpoints.lightning.publish, { did: 'did:cid:alice', invoiceKey: 'invoice' })
+            .reply(200, { ok: true, publicHost: 'https://example.com' })
+            .delete(`${Endpoints.lightning.publish}/did%3Acid%3Aalice`)
+            .reply(200, { ok: true });
+
+        const client = await DrawbridgeClient.create({ url: DrawbridgeURL });
+
+        expect(await client.publishLightning('did:cid:alice', 'invoice')).toStrictEqual({ ok: true, publicHost: 'https://example.com' });
+        expect(await client.unpublishLightning('did:cid:alice')).toBe(true);
+    });
+
+    it('returns the DIDComm endpoint when available and undefined otherwise', async () => {
+        nock(DrawbridgeURL)
+            .get(Endpoints.didcommEndpoint)
+            .reply(200, { endpoint: 'https://example.com/didcomm' })
+            .get(Endpoints.didcommEndpoint)
+            .reply(200, {})
+            .get(Endpoints.didcommEndpoint)
+            .reply(500, ServerError);
+
+        const client = await DrawbridgeClient.create({ url: DrawbridgeURL });
+
+        expect(await client.getDidCommEndpoint()).toBe('https://example.com/didcomm');
+        expect(await client.getDidCommEndpoint()).toBeUndefined();
+        expect(await client.getDidCommEndpoint()).toBeUndefined();
+    });
+
+    it('throws response data for lightning API errors', async () => {
+        nock(DrawbridgeURL)
+            .post(Endpoints.lightning.wallet, { name: 'Alice' })
+            .reply(500, ServerError);
+
+        const client = await DrawbridgeClient.create({ url: DrawbridgeURL });
+
+        try {
+            await client.createLightningWallet('Alice');
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});

--- a/tests/keymaster/didcomm.test.ts
+++ b/tests/keymaster/didcomm.test.ts
@@ -1,4 +1,5 @@
 import Gatekeeper from '@didcid/gatekeeper';
+import { jest } from '@jest/globals';
 import Keymaster from '@didcid/keymaster';
 import CipherNode from '@didcid/cipher/node';
 import DbJsonMemory from '@didcid/gatekeeper/db/json-memory';
@@ -35,6 +36,22 @@ beforeEach(() => {
     cipher = new CipherNode();
     keymaster = new Keymaster({ gatekeeper, wallet, cipher, passphrase: 'passphrase' });
 });
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+function useDidCommGateway(base = 'https://gateway.example/didcomm'): string {
+    keymaster = new Keymaster({ gatekeeper, wallet, cipher, passphrase: 'passphrase', didcommServiceURL: base });
+    return base;
+}
 
 describe('fetchDidCommKeyPair', () => {
     it('derives a deterministic X25519 keypair for an identity', async () => {
@@ -284,6 +301,146 @@ describe('packDidComm / unpackDidComm (cross-method: Archon did:cid <-> did:key)
         expect(out.body).toEqual(body);
         expect(metadata.authenticated).toBe(true);
         expect(metadata.sender).toBe(bob.kid);
+    });
+});
+
+describe('DIDComm gateway transport helpers', () => {
+    it('delivers routed messages as Forward envelopes and mediates the valid ones', async () => {
+        const base = useDidCommGateway();
+        await keymaster.createId('Alice');
+        const mediatorDid = await keymaster.createId('Mediator');
+        const bobDid = await keymaster.createId('Bob');
+
+        await keymaster.publishDidComm('https://alice.example/didcomm', 'Alice');
+        await keymaster.publishDidComm('https://mediator.example/didcomm', 'Mediator');
+        await keymaster.publishDidComm('https://bob.example/didcomm', 'Bob', [mediatorDid]);
+
+        const deliveries: any[] = [];
+        let challengeCount = 0;
+        const fetchMock = jest.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+            const url = String(input);
+            if (url === `${base}/api/v1/challenge`) {
+                challengeCount += 1;
+                return jsonResponse({ challenge: `challenge-${challengeCount}` });
+            }
+            if (url === `${base}/api/v1/deliver`) {
+                deliveries.push(JSON.parse(String(init?.body)));
+                return jsonResponse({ ids: ['queued-forward'] });
+            }
+            throw new Error(`unexpected fetch ${url}`);
+        });
+
+        const ids = await keymaster.sendDidComm(
+            { type: 'https://x/1/msg', body: { text: 'routed' } },
+            bobDid,
+            { name: 'Alice' }
+        );
+
+        expect(ids).toEqual(['queued-forward']);
+        expect(deliveries).toHaveLength(1);
+        expect(deliveries[0].endpoint).toBe('https://bob.example/didcomm');
+        expect(deliveries[0].did).toMatch(/^did:/);
+        expect(deliveries[0].message).toContain('protected');
+
+        const removeBodies: any[] = [];
+        fetchMock.mockImplementation(async (input, init) => {
+            const url = String(input);
+            if (url === `${base}/api/v1/challenge`) {
+                challengeCount += 1;
+                return jsonResponse({ challenge: `challenge-${challengeCount}` });
+            }
+            if (url === `${base}/api/v1/messages/fetch`) {
+                return jsonResponse({
+                    messages: [
+                        { id: 'forward-1', message: deliveries[0].message },
+                        { id: 'not-forward', message: 'not json' },
+                    ],
+                });
+            }
+            if (url === `${base}/api/v1/messages`) {
+                expect(init?.headers).toEqual({ 'Content-Type': 'application/didcomm-encrypted+json' });
+                expect(String(init?.body)).toContain('protected');
+                return jsonResponse({ id: 'relayed' });
+            }
+            if (url === `${base}/api/v1/messages/remove`) {
+                removeBodies.push(JSON.parse(String(init?.body)));
+                return jsonResponse({ ok: true });
+            }
+            throw new Error(`unexpected fetch ${url}`);
+        });
+
+        const result = await keymaster.mediateDidComm({ name: 'Mediator' });
+
+        expect(result).toEqual({ relayed: 1, skipped: 1 });
+        expect(removeBodies).toHaveLength(1);
+        expect(removeBodies[0].ids).toEqual(['forward-1']);
+    });
+
+    it('receives only decryptable mailbox messages and acknowledges handled ids', async () => {
+        const base = useDidCommGateway();
+        const aliceDid = await keymaster.createId('Alice');
+        await keymaster.createId('Bob');
+        await keymaster.publishDidComm('https://alice.example/didcomm', 'Alice');
+        await keymaster.publishDidComm('https://bob.example/didcomm', 'Bob');
+
+        const packed = await keymaster.packDidComm(
+            { type: 'https://x/1/msg', body: { text: 'hello alice' } },
+            aliceDid,
+            { name: 'Bob' }
+        );
+
+        const requests: any[] = [];
+        let challengeCount = 0;
+        jest.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+            const url = String(input);
+            requests.push({ url, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+            if (url === `${base}/api/v1/challenge`) {
+                challengeCount += 1;
+                return jsonResponse({ challenge: `mailbox-${challengeCount}` });
+            }
+            if (url === `${base}/api/v1/messages/fetch`) {
+                return jsonResponse({
+                    messages: [
+                        { id: 'msg-ok', message: packed },
+                        { id: 'msg-bad', message: 'not an encrypted envelope' },
+                    ],
+                });
+            }
+            if (url === `${base}/api/v1/messages/remove`) {
+                return jsonResponse({ ok: true });
+            }
+            throw new Error(`unexpected fetch ${url}`);
+        });
+
+        const received = await keymaster.receiveDidComm({ name: 'Alice' });
+
+        expect(received).toHaveLength(1);
+        expect(received[0].message.body).toEqual({ text: 'hello alice' });
+        expect(received[0].metadata.authenticated).toBe(true);
+
+        const fetchBody = requests.find(r => r.url.endsWith('/messages/fetch'))?.body;
+        const removeBody = requests.find(r => r.url.endsWith('/messages/remove'))?.body;
+        expect(fetchBody.did).toBe(aliceDid);
+        expect(removeBody.ids).toEqual(['msg-ok']);
+    });
+
+    it('surfaces DIDComm gateway challenge failures clearly', async () => {
+        const base = useDidCommGateway();
+        await keymaster.createId('Alice');
+        const bobDid = await keymaster.createId('Bob');
+        await keymaster.publishDidComm('https://alice.example/didcomm', 'Alice');
+        await keymaster.publishDidComm('https://bob.example/didcomm', 'Bob');
+
+        jest.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+            if (String(input) === `${base}/api/v1/challenge`) {
+                throw new TypeError('fetch failed');
+            }
+            throw new Error(`unexpected fetch ${String(input)}`);
+        });
+
+        await expect(
+            keymaster.sendDidComm({ type: 'https://x/1/msg', body: {} }, bobDid, { name: 'Alice' })
+        ).rejects.toThrow(/could not reach the DIDComm gateway/);
     });
 });
 

--- a/tests/keymaster/wallet-db.test.ts
+++ b/tests/keymaster/wallet-db.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, rm } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import WalletJson from '../../packages/keymaster/src/db/json.ts';
+import WalletSQLite from '../../packages/keymaster/src/db/sqlite.ts';
+import type { StoredWallet } from '../../packages/keymaster/src/types.ts';
+
+const walletOne = {
+    version: 2,
+    seed: {},
+    counter: 1,
+    current: 'Alice',
+    ids: {
+        Alice: {
+            did: 'did:cid:alice',
+            account: 0,
+            index: 0,
+        },
+    },
+} as StoredWallet;
+
+const walletTwo = {
+    version: 2,
+    seed: {},
+    counter: 2,
+    current: 'Bob',
+    ids: {
+        Bob: {
+            did: 'did:cid:bob',
+            account: 0,
+            index: 1,
+        },
+    },
+} as StoredWallet;
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+    const dir = await mkdtemp(join(tmpdir(), 'archon-wallet-db-test-'));
+    try {
+        await fn(dir);
+    } finally {
+        await rm(dir, { recursive: true, force: true });
+    }
+}
+
+describe('WalletJson', () => {
+    it('loads null when the wallet file is missing', async () => {
+        await withTempDir(async dir => {
+            const wallet = new WalletJson('wallet.json', dir);
+
+            await expect(wallet.loadWallet()).resolves.toBeNull();
+        });
+    });
+
+    it('creates the data folder and preserves existing wallets unless overwrite is set', async () => {
+        await withTempDir(async dir => {
+            const dataFolder = join(dir, 'nested', 'wallets');
+            const wallet = new WalletJson('wallet.json', dataFolder);
+
+            expect(existsSync(dataFolder)).toBe(false);
+            await expect(wallet.saveWallet(walletOne)).resolves.toBe(true);
+            expect(existsSync(dataFolder)).toBe(true);
+            await expect(wallet.loadWallet()).resolves.toStrictEqual(walletOne);
+
+            await expect(wallet.saveWallet(walletTwo)).resolves.toBe(false);
+            await expect(wallet.loadWallet()).resolves.toStrictEqual(walletOne);
+
+            await expect(wallet.saveWallet(walletTwo, true)).resolves.toBe(true);
+            await expect(wallet.loadWallet()).resolves.toStrictEqual(walletTwo);
+        });
+    });
+});
+
+describe('WalletSQLite', () => {
+    it('loads null when the wallet table is empty', async () => {
+        await withTempDir(async dir => {
+            const wallet = await WalletSQLite.create('wallet.db', dir);
+            try {
+                await expect(wallet.loadWallet()).resolves.toBeNull();
+            } finally {
+                await wallet.disconnect();
+            }
+        });
+    });
+
+    it('preserves existing wallets unless overwrite is set', async () => {
+        await withTempDir(async dir => {
+            const wallet = new WalletSQLite('wallet.db', dir);
+            try {
+                await expect(wallet.saveWallet(walletOne)).resolves.toBe(true);
+                await expect(wallet.loadWallet()).resolves.toStrictEqual(walletOne);
+
+                await expect(wallet.saveWallet(walletTwo)).resolves.toBe(false);
+                await expect(wallet.loadWallet()).resolves.toStrictEqual(walletOne);
+
+                await expect(wallet.saveWallet(walletTwo, true)).resolves.toBe(true);
+                await expect(wallet.loadWallet()).resolves.toStrictEqual(walletTwo);
+            } finally {
+                await wallet.disconnect();
+            }
+        });
+    });
+
+    it('allows repeated connect and disconnect calls', async () => {
+        await withTempDir(async dir => {
+            const wallet = new WalletSQLite('wallet.db', dir);
+
+            await expect(wallet.connect()).resolves.toBeUndefined();
+            await expect(wallet.connect()).resolves.toBeUndefined();
+            await expect(wallet.disconnect()).resolves.toBeUndefined();
+            await expect(wallet.disconnect()).resolves.toBeUndefined();
+        });
+    });
+});

--- a/tests/mcp-server/config.test.ts
+++ b/tests/mcp-server/config.test.ts
@@ -87,6 +87,24 @@ describe('mcp server config', () => {
         fs.rmSync(directory, { recursive: true, force: true });
     });
 
+    it('creates json wallets from ARCHON_WALLET_PATH', async () => {
+        const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'archon-mcp-json-wallet-'));
+        const walletPath = path.join(directory, 'wallet.json');
+        const wallet = await createWallet({
+            nodeUrl: 'http://localhost:4224',
+            walletType: 'json',
+            walletPath,
+            passphrase: 'secret',
+            defaultRegistry: undefined,
+            readOnly: false,
+        });
+
+        await wallet.saveWallet({ version: 2, seed: {}, counter: 0, ids: {} });
+
+        expect(fs.existsSync(walletPath)).toBe(true);
+        fs.rmSync(directory, { recursive: true, force: true });
+    });
+
     it('creates runtime without blocking startup or writing to stdout', async () => {
         const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
         const runtime = await createArchonRuntime({
@@ -103,5 +121,21 @@ describe('mcp server config', () => {
         expect(logSpy).not.toHaveBeenCalled();
 
         logSpy.mockRestore();
+    });
+
+    it('creates runtime with a Keymaster when a passphrase is configured', async () => {
+        const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'archon-mcp-runtime-wallet-'));
+        const runtime = await createArchonRuntime({
+            nodeUrl: 'http://127.0.0.1:1',
+            walletType: 'json',
+            walletPath: path.join(directory, 'wallet.json'),
+            passphrase: 'secret',
+            defaultRegistry: 'hyperswarm',
+            readOnly: false,
+        });
+
+        expect(runtime.node.url).toBe('http://127.0.0.1:1');
+        expect(runtime.keymaster).toBeDefined();
+        fs.rmSync(directory, { recursive: true, force: true });
     });
 });

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -22,9 +22,90 @@ const baseConfig: McpServerConfig = {
 
 const mutatingTools = ARCHON_MCP_TOOL_DEFINITIONS.filter(definition => definition.mutates).map(definition => definition.name);
 const readTools = ARCHON_MCP_TOOL_DEFINITIONS.filter(definition => !definition.mutates).map(definition => definition.name);
+const inlineFile = {
+    name: 'hello.txt',
+    mimeType: 'text/plain',
+    data: Buffer.from('hello').toString('base64'),
+};
+
+const defaultToolArgs = {
+    address: 'alice@example.com',
+    alias: 'alice-alias',
+    amount: 21,
+    anoncrypt: true,
+    attachment: inlineFile,
+    ballot: 'did:cid:ballot',
+    bolt11: 'lnbc...',
+    challenge: { prompt: 'prove it' },
+    claims: { name: 'Alice' },
+    config: { title: 'Poll', options: ['yes', 'no'] },
+    confirm: true,
+    confirmPayment: true,
+    controller: 'did:cid:bob',
+    credential: { type: ['VerifiableCredential'] },
+    data: { hello: 'world' },
+    did: 'did:cid:alice',
+    domain: 'example.com',
+    encryption: 'XC20P',
+    endpoint: 'https://example.com/didcomm',
+    file: inlineFile,
+    group: 'did:cid:group',
+    groupName: 'Friends',
+    id: 'did:cid:asset',
+    includeIds: true,
+    issuer: 'did:cid:issuer',
+    item: inlineFile,
+    key: 'hello',
+    member: 'did:cid:member',
+    memo: 'coffee',
+    message: { body: 'hello' },
+    name: 'Alice',
+    newName: 'Alicia',
+    newPassphrase: 'new secret',
+    nsec: 'nsec1example',
+    object: { hello: 'world' },
+    oldName: 'Alice',
+    owner: 'did:cid:alice',
+    packed: 'packed-message',
+    paymentHash: 'hash',
+    poll: 'did:cid:poll',
+    recoveryPhrase: 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    registry: 'hyperswarm',
+    recipient: 'did:cid:bob',
+    response: 'did:cid:response',
+    reveal: true,
+    routingKeys: ['did:cid:mediator#key-agreement-1'],
+    schema: { type: 'object' },
+    sign: true,
+    subject: 'did:cid:subject',
+    tags: ['inbox'],
+    to: 'did:cid:bob',
+    validFrom: '2026-01-01T00:00:00.000Z',
+    validUntil: '2026-12-31T00:00:00.000Z',
+    value: 'world',
+    version: 1,
+    vote: 1,
+    wallet: { version: 2, ids: {} },
+};
+
+const toolArgOverrides: Record<string, Record<string, unknown>> = {
+    archon_bind_credential: { schema: 'did:cid:schema' },
+    archon_create_response: { challenge: 'did:cid:challenge' },
+    archon_create_schema_template: { schema: 'did:cid:schema' },
+    archon_encrypt_message: { message: 'hello' },
+    archon_remove_vault_item: { item: 'hello.txt' },
+    archon_get_vault_item: { item: 'hello.txt' },
+};
 
 function parseToolResult(response: any) {
     return JSON.parse(response.content[0].text);
+}
+
+function argsForTool(name: string) {
+    return {
+        ...defaultToolArgs,
+        ...(toolArgOverrides[name] || {}),
+    };
 }
 
 function mockRuntime(overrides: Record<string, unknown> = {}) {
@@ -151,6 +232,13 @@ function mockRuntime(overrides: Record<string, unknown> = {}) {
         removeDmailAttachment: jest.fn().mockResolvedValue(true),
         getDmailAttachment: jest.fn().mockResolvedValue(Buffer.from('attachment')),
         listDmailAttachments: jest.fn().mockResolvedValue({}),
+        publishDidComm: jest.fn().mockResolvedValue(true),
+        unpublishDidComm: jest.fn().mockResolvedValue(true),
+        packDidComm: jest.fn().mockResolvedValue('packed'),
+        unpackDidComm: jest.fn().mockResolvedValue({ body: 'hello' }),
+        sendDidComm: jest.fn().mockResolvedValue(['msg-1']),
+        receiveDidComm: jest.fn().mockResolvedValue([{ body: 'hello' }]),
+        mediateDidComm: jest.fn().mockResolvedValue({ forwarded: 1 }),
         ...overrides,
     };
 
@@ -181,6 +269,21 @@ describe('mcp server tools', () => {
 
         expect(parseToolResult(response)).toStrictEqual({ ok: true, result: ['hyperswarm'] });
         expect(runtime.node.listRegistries).toHaveBeenCalledTimes(1);
+    });
+
+    it('executes every registered tool with representative valid inputs', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        for (const definition of ARCHON_MCP_TOOL_DEFINITIONS) {
+            const response = await server.tools.get(definition.name)!.handler(argsForTool(definition.name));
+            const result = parseToolResult(response);
+            if (!result.ok) {
+                throw new Error(`${definition.name}: ${result.error}`);
+            }
+            expect(result.ok).toBe(true);
+        }
     });
 
     it('does not advertise mutating tools in read-only mode', () => {

--- a/tests/pinning/mediator.test.ts
+++ b/tests/pinning/mediator.test.ts
@@ -2,12 +2,14 @@ import { mkdtemp, rm } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
+import nock from 'nock';
 import CipherNode from '@didcid/cipher/node';
 import type { Operation } from '@didcid/gatekeeper/types';
 import { JsonPinStore } from '../../services/mediators/pinning/src/state.ts';
 import { fingerprintOperation, processPinningQueue, type PinningGatekeeper } from '../../services/mediators/pinning/src/sync.ts';
-import { pinPayload } from '../../services/mediators/pinning/src/provider.ts';
+import { normalizeStatus, pinPayload, providerError } from '../../services/mediators/pinning/src/provider.ts';
 import type { PinningServiceProvider, ProviderPinRequest } from '../../services/mediators/pinning/src/provider.ts';
+import { PinningServiceProvider as PinningServiceProviderClass } from '../../services/mediators/pinning/src/provider.ts';
 
 function op(id: string, registry = 'BTC:mainnet'): Operation {
     return {
@@ -287,5 +289,68 @@ describe('pinning mediator queue processing', () => {
             name: 'archon-test',
             meta: {},
         });
+    });
+});
+
+describe('pinning service provider helpers', () => {
+    it('requires an API token', () => {
+        expect(() => new PinningServiceProviderClass('pinata', 'https://pinning.example', undefined))
+            .toThrow('ARCHON_PIN_API_TOKEN is required');
+    });
+
+    it('submits pins and checks status through the Pinning Service API', async () => {
+        nock('https://pinning.example')
+            .post('/pins', {
+                cid: 'bagaaieraexample',
+                name: 'archon-test',
+                meta: { archonFingerprint: 'fingerprint' },
+                origins: ['https://gateway.example/ipfs/bagaaieraexample'],
+            })
+            .matchHeader('authorization', 'Bearer secret-token')
+            .reply(202, { requestid: 'request-1', status: 'queued' })
+            .get('/pins/request-1')
+            .matchHeader('authorization', 'Bearer secret-token')
+            .reply(200, { requestid: 'request-1', status: 'pinned' });
+
+        const provider = new PinningServiceProviderClass('pinata', 'https://pinning.example/', 'secret-token');
+
+        expect(provider.name).toBe('pinata');
+        expect(await provider.pin({
+            cid: 'bagaaieraexample',
+            name: 'archon-test',
+            meta: { archonFingerprint: 'fingerprint' },
+            origins: ['https://gateway.example/ipfs/bagaaieraexample'],
+        })).toStrictEqual({
+            requestid: 'request-1',
+            status: 'queued',
+            response: { requestid: 'request-1', status: 'queued' },
+        });
+        expect(await provider.getStatus('request-1')).toStrictEqual({
+            requestid: 'request-1',
+            status: 'pinned',
+            response: { requestid: 'request-1', status: 'pinned' },
+        });
+    });
+
+    it('normalizes unknown or malformed provider status responses', () => {
+        expect(normalizeStatus({ requestid: 123, status: 'surprising' })).toStrictEqual({
+            requestid: undefined,
+            status: 'pinning',
+            response: { requestid: 123, status: 'surprising' },
+        });
+        expect(normalizeStatus(null)).toStrictEqual({
+            requestid: undefined,
+            status: 'pinning',
+            response: null,
+        });
+    });
+
+    it('extracts useful provider error messages', () => {
+        expect(providerError({ response: { data: { error: { details: 'bad cid' } } } })).toBe('bad cid');
+        expect(providerError({ response: { data: { error: { reason: 'quota exceeded' } } } })).toBe('quota exceeded');
+        expect(providerError({ response: { data: { error: 'plain error' } } })).toBe('plain error');
+        expect(providerError({ response: { data: { message: 'message error' } } })).toBe('message error');
+        expect(providerError(new Error('network down'))).toBe('network down');
+        expect(providerError('string failure')).toBe('string failure');
     });
 });

--- a/tests/wallet/alchemy-wallet.test.ts
+++ b/tests/wallet/alchemy-wallet.test.ts
@@ -30,6 +30,44 @@ describe('Alchemy wallet backend', () => {
         ]);
     });
 
+    it('normalizes alternate hosted API wrapper shapes', () => {
+        expect(normalizeHostedUtxos({
+            data: [
+                { hash: 'data-tx', n: 3, valueSats: 4000, confirmations: 2.9 },
+            ],
+        })).toEqual([
+            { txid: 'data-tx', vout: 3, valueSats: 4000, confirmations: 2 },
+        ]);
+
+        expect(normalizeHostedUtxos({
+            result: {
+                utxos: [
+                    { txId: 'result-utxos-tx', outputIndex: 4, value_sat: 5000n, confirmations: -1 },
+                ],
+            },
+        })).toEqual([
+            { txid: 'result-utxos-tx', vout: 4, valueSats: 5000, confirmations: 0 },
+        ]);
+
+        expect(normalizeHostedUtxos({
+            outputs: [
+                { txid: 'outputs-tx', vout: 5, amount: 0.00006 },
+            ],
+        })).toEqual([
+            { txid: 'outputs-tx', vout: 5, valueSats: 6000, confirmations: 0 },
+        ]);
+    });
+
+    it('normalizes a bare result array', () => {
+        expect(normalizeHostedUtxos({
+            result: [
+                { transactionHash: 'result-array-tx', index: 6, value: '7000', confirmations: 1 },
+            ],
+        })).toEqual([
+            { txid: 'result-array-tx', vout: 6, valueSats: 7000, confirmations: 1 },
+        ]);
+    });
+
     it('ignores incomplete or zero-value UTXOs', () => {
         expect(normalizeHostedUtxos([
             { txid: 'missing-vout', value: 1000 },

--- a/tests/wallet/zcash-wallet.test.ts
+++ b/tests/wallet/zcash-wallet.test.ts
@@ -1,12 +1,19 @@
 import { jest } from '@jest/globals';
 import {
     anchorData,
+    bumpTransactionFee,
     estimateZip317TransparentFeeZats,
     estimateFee,
     getBalance,
     getReceiveAddress,
+    getTransaction,
+    getTransactions,
     getUtxos,
+    getWalletStatus,
+    sendZec,
     setupTransparentWallet,
+    validateOpReturnData,
+    zecToZats,
 } from '../../services/mediators/zcash-wallet/src/zcash-wallet';
 import { deriveTransparentAddress } from '../../services/mediators/zcash-wallet/src/derivation';
 import type { RpcClient } from '../../services/mediators/zcash-wallet/src/zcash-rpc';
@@ -77,6 +84,16 @@ describe('zcash-wallet RPC-backed behavior', () => {
         await expect(getReceiveAddress(rpc, TEST_MNEMONIC, 'mainnet')).resolves.toBe(FIRST_ADDRESS);
     });
 
+    it('falls back to the last receive address when the gap range is used', async () => {
+        const rpc = createRpcMock({
+            getaddresstxids: ['used-txid'],
+        });
+
+        await expect(getReceiveAddress(rpc, TEST_MNEMONIC, 'mainnet')).resolves.toBe(
+            deriveTransparentAddress(TEST_MNEMONIC, 'mainnet', 0, 19)
+        );
+    });
+
     it('reports balance in ZEC from address-index zats', async () => {
         const rpc = createRpcMock({
             getaddressbalance: { balance: 123_456_789, received: 123_466_789 },
@@ -97,6 +114,65 @@ describe('zcash-wallet RPC-backed behavior', () => {
             feerate: 0.0001,
             blocks: 3,
         });
+    });
+
+    it('reports wallet status from required Zebra address-index RPCs', async () => {
+        const readyRpc = createRpcMock();
+        const missingRpc = createRpcMock({ getaddressbalance: new Error('Method not found') });
+
+        await expect(getWalletStatus(readyRpc, TEST_MNEMONIC, 'mainnet')).resolves.toMatchObject({
+            network: 'mainnet',
+            ready: true,
+            descriptorCount: 2,
+            addressCount: 40,
+        });
+        await expect(getWalletStatus(missingRpc, TEST_MNEMONIC, 'mainnet')).resolves.toMatchObject({
+            network: 'mainnet',
+            ready: false,
+            descriptorCount: 0,
+            addressCount: 0,
+        });
+    });
+
+    it('maps raw transactions and filters failed transaction lookups', async () => {
+        const rpc = createRpcMock({
+            getaddresstxids: ['tx-a', 'tx-b', 'tx-a'],
+            getrawtransaction: (params?: any[]) => {
+                const txid = params?.[0];
+                if (txid === 'tx-b') {
+                    throw new Error('missing transaction');
+                }
+                return {
+                    txid,
+                    confirmations: 2,
+                    blockhash: 'block-hash',
+                    blocktime: 1_700_000_000,
+                    time: 1_700_000_001,
+                    fee: -0.00001,
+                    vout: [{
+                        n: 0,
+                        value: 0.25,
+                        scriptPubKey: { addresses: [FIRST_ADDRESS] },
+                    }],
+                };
+            },
+        });
+
+        await expect(getTransaction(rpc, 'tx-a')).resolves.toStrictEqual({
+            txid: 'tx-a',
+            confirmations: 2,
+            blockhash: 'block-hash',
+            blocktime: 1_700_000_000,
+            time: 1_700_000_001,
+            fee: -0.00001,
+            details: [{
+                address: FIRST_ADDRESS,
+                category: 'receive',
+                amount: 0.25,
+                vout: 0,
+            }],
+        });
+        await expect(getTransactions(rpc, TEST_MNEMONIC, 'mainnet', 2, 0)).resolves.toHaveLength(1);
     });
 
     it('normalizes UTXOs and confirmations', async () => {
@@ -142,5 +218,15 @@ describe('zcash-wallet RPC-backed behavior', () => {
             txid: 'broadcast-txid',
             fee: 0.0002,
         });
+    });
+
+    it('validates send and anchor request inputs before broadcasting', async () => {
+        const rpc = createRpcMock();
+
+        expect(validateOpReturnData('hello')).toStrictEqual(Buffer.from('hello'));
+        await expect(anchorData(rpc, TEST_MNEMONIC, 'mainnet', 'x'.repeat(81))).rejects.toThrow('OP_RETURN data exceeds 80 byte limit');
+        await expect(sendZec(rpc, TEST_MNEMONIC, 'mainnet', 'not-an-address', 1)).rejects.toThrow('Invalid address for mainnet');
+        expect(() => zecToZats(Number.POSITIVE_INFINITY)).toThrow('Amount must be a finite number');
+        await expect(bumpTransactionFee()).rejects.toThrow('not supported');
     });
 });


### PR DESCRIPTION
## Summary
- restore local statement coverage from `88.18%` to `95.01%`
- add focused coverage for Keymaster DIDComm gateway send, receive, and mediation paths
- expand DIDComm relay mailbox coverage, including Redis command mapping, pruning, challenges, and connection guards
- cover Drawbridge client HTTP contracts for Lightning and DIDComm endpoints
- add representative MCP tool execution coverage across the registered tool surface
- cover pinning provider helpers, hosted UTXO normalization, wallet persistence adapters, Zcash wallet behavior, and cipher passphrase/HD-key helpers

## Coverage
- Statements: `95.01%` (`5926/6237`)
- Lines: `95.22%`
- Branches: `82.64%`
- Functions: `97.99%`
- `packages/keymaster/src/keymaster.ts`: `94.52%` statement coverage

## Validation
- `npm test -- --silent`
- Full run passed: 58 suites passed, 1 skipped; 1525 tests passed, 3 skipped

Focused suites were also run while building the coverage back up:
- `tests/keymaster/didcomm.test.ts`
- `tests/didcomm/mailbox.test.ts`
- `tests/cipher/cipher.test.ts`
- `tests/cipher/passphrase.test.ts`
- `tests/gatekeeper/drawbridge-client.test.ts`
- `tests/mcp-server/tools.test.ts`
- `tests/pinning/mediator.test.ts`
- `tests/wallet/alchemy-wallet.test.ts`
- `tests/keymaster/wallet-db.test.ts`
- `tests/wallet/zcash-wallet.test.ts`
- `tests/mcp-server/config.test.ts`
