### PR TITLE
feat(gatekeeper): conformant DID resolution + dereferencing at /1.0/identifiers

### DIFF
--- a/docs/gatekeeper-api.json
+++ b/docs/gatekeeper-api.json
@@ -741,6 +741,106 @@
         }
       }
     },
+    "/1.0/identifiers/{did}/data": {
+      "get": {
+        "summary": "Dereference the data resource of a DID",
+        "description": "Dereferences the data resource associated with a DID, per the did:cid method-specific DID URL dereferencing rules (the DID URL `did:cid:<cid>/data`). Because the DID is content-addressed, the resource is retrieved by content rather than by an external location. This is distinct from DID resolution (`/1.0/identifiers/{did}`): it returns the associated data resource itself, not the DID Document + metadata triple. Agent DIDs return an empty object; asset DIDs return their attached data.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "did",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The DID whose data resource is dereferenced."
+          },
+          {
+            "in": "query",
+            "name": "versionTime",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Dereference the data as of this specific time."
+          },
+          {
+            "in": "query",
+            "name": "versionSequence",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Dereference the data at a specific version of the DID Document."
+          },
+          {
+            "in": "query",
+            "name": "confirm",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "If `true`, dereferences only if the DID is fully confirmed."
+          },
+          {
+            "in": "query",
+            "name": "verify",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "If `true`, verifies the signature(s) of the DID operation(s) first."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The dereferenced data resource.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Arbitrary data attached to the DID (empty object for agent DIDs)."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The DID is syntactically invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The DID does not exist or cannot be resolved.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error."
+          }
+        }
+      }
+    },
     "/dids/": {
       "post": {
         "summary": "Retrieve a list of DIDs or DID Documents.",

--- a/docs/gatekeeper-api.json
+++ b/docs/gatekeeper-api.json
@@ -773,24 +773,6 @@
               "type": "integer"
             },
             "description": "Dereference the data at a specific version of the DID Document."
-          },
-          {
-            "in": "query",
-            "name": "confirm",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            },
-            "description": "If `true`, dereferences only if the DID is fully confirmed."
-          },
-          {
-            "in": "query",
-            "name": "verify",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            },
-            "description": "If `true`, verifies the signature(s) of the DID operation(s) first."
           }
         ],
         "responses": {

--- a/docs/gatekeeper-api.json
+++ b/docs/gatekeeper-api.json
@@ -741,6 +741,74 @@
         }
       }
     },
+    "/1.0/identifiers/{did}": {
+      "get": {
+        "summary": "Resolve a DID (standards-conformant)",
+        "description": "Resolves a DID following the DID Resolution data model, returning only the standard result triple (`didDocument`, `didResolutionMetadata`, `didDocumentMetadata`). Follows the Universal Resolver driver convention. The method-specific `didDocumentData` and `didDocumentRegistration` objects are NOT part of this result — they are exposed as dereferenceable resources at `/1.0/identifiers/{did}/data` and `/1.0/identifiers/{did}/registration`. Always returns confirmed, cryptographically verified state; the internal `/api/v1/did/{did}` endpoint remains available for raw or unconfirmed state.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "did",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The DID to resolve."
+          },
+          {
+            "in": "query",
+            "name": "versionTime",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Resolve the state of the DID as of this specific time."
+          },
+          {
+            "in": "query",
+            "name": "versionSequence",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Resolve a specific version of the DID Document."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The DID Resolution result (standard triple).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "didDocument": {
+                      "type": "object"
+                    },
+                    "didResolutionMetadata": {
+                      "type": "object"
+                    },
+                    "didDocumentMetadata": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The DID is syntactically invalid (error in didResolutionMetadata)."
+          },
+          "404": {
+            "description": "The DID does not exist or cannot be resolved (error in didResolutionMetadata)."
+          },
+          "500": {
+            "description": "Internal Server Error."
+          }
+        }
+      }
+    },
     "/1.0/identifiers/{did}/data": {
       "get": {
         "summary": "Dereference the data resource of a DID",
@@ -783,6 +851,88 @@
                 "schema": {
                   "type": "object",
                   "description": "Arbitrary data attached to the DID (empty object for agent DIDs)."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The DID is syntactically invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The DID does not exist or cannot be resolved.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error."
+          }
+        }
+      }
+    },
+    "/1.0/identifiers/{did}/registration": {
+      "get": {
+        "summary": "Dereference the registration resource of a DID",
+        "description": "Dereferences the method-specific registration/anchoring resource associated with a DID (the DID URL `did:cid:<cid>/registration`). This is provenance about how and where the DID was registered and anchored — it is NOT DID Core metadata and NOT part of the DID resolution result. Standard document metadata (created, versionId, deactivated, etc.) remains in `didDocumentMetadata` on the resolution result.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "did",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The DID whose registration resource is dereferenced."
+          },
+          {
+            "in": "query",
+            "name": "versionTime",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Dereference the registration as of this specific time."
+          },
+          {
+            "in": "query",
+            "name": "versionSequence",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Dereference the registration at a specific version of the DID Document."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The dereferenced registration resource.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Method-specific anchoring/provenance data."
                 }
               }
             }

--- a/docs/nginx-proxy.conf.example
+++ b/docs/nginx-proxy.conf.example
@@ -82,6 +82,13 @@ server {
         proxy_pass http://gatekeeper;
     }
 
+    # Standards-conformant DID resolution / dereferencing (public, no auth):
+    # /1.0/identifiers/{did}, /{did}/data, /{did}/registration
+    location ~ ^/1\.0/identifiers/ {
+        limit_req zone=api_general burst=30 nodelay;
+        proxy_pass http://gatekeeper;
+    }
+
     # DID listing/query
     location = /api/v1/dids {
         limit_req zone=api_general burst=20 nodelay;

--- a/docs/scheme.md
+++ b/docs/scheme.md
@@ -228,7 +228,7 @@ For registries such as BTC with non-trivial transaction costs, it is expected th
 
 ## DID Revocation
 
-Revoking a DID is a special kind of Update that results in the termination of the DID. Revoked DIDs cannot be updated because they have no current controller, therefore they cannot be recovered once revoked. Revoked DIDs can be resolved without error, but resolvers will return a result with the `didDocumentMetadata.deactivated` property set to `true`. The `didDocument` is set to empty, and the DID's data resource (dereferenced at `/data`) is empty.
+Revoking a DID is a special kind of Update that results in the termination of the DID. Revoked DIDs cannot be updated because they have no current controller, therefore they cannot be recovered once revoked. Revoked DIDs can be resolved without error, but resolvers will return a result with the `didDocumentMetadata.deactivated` property set to `true`. The `didDocument` is reduced to just its `id`, and the DID's data resource (dereferenced at `/data`) is empty.
 
 To revoke a DID, the client must sign and submit a `delete` operation to a node.
 

--- a/docs/scheme.md
+++ b/docs/scheme.md
@@ -3,7 +3,7 @@
 
 ## Abstract
 
-The `did:cid` method specification conforms to the requirements specified in the [DID specification](https://www.w3.org/TR/did-core/) currently published by the W3C Credentials Community Group. For more information about DIDs and DID method specifications, please see the [DID Primer](https://w3c-ccg.github.io/did-primer/).
+The `did:cid` method specification conforms to the requirements specified in [DID Core 1.0](https://www.w3.org/TR/did-core/), a W3C Recommendation. For more information about DIDs and DID method specifications, please see the [DID Primer](https://w3c-ccg.github.io/did-primer/).
 
 ## Introduction
 
@@ -11,18 +11,32 @@ The `did:cid` method is designed to support a P2P identity layer with secure dec
 
 ## DID Format
 
-DIDs using this method have the following format:
+A `did:cid` DID has the following format:
 
 ```
-did-cid           = "did:cid:" cid-identifier
-                   [ ";" did-service ] [ "/" did-path ]
-                   [ "?" did-query ] [ "#" did-fragment ]
-cid-identifier    = CID v1 in standard base32 encoding
+did-cid        = "did:cid:" cid-identifier
+cid-identifier = CID v1 in standard base32 encoding
 ```
 
 ### Example
 
 `did:cid:bafkreiawdmk6fmqc5p237vffyctazpzdgvgqfdj2i3hx2idtodxkwhyj5m`
+
+### DID URL Syntax
+
+A `did:cid` DID URL extends the DID with the standard URI components defined by the W3C [DID Core 1.0](https://www.w3.org/TR/did-core/#did-url-syntax) DID URL grammar:
+
+```
+did-url = did-cid path-abempty [ "?" query ] [ "#" fragment ]
+```
+
+| Component | Purpose in `did:cid` |
+|-----------|----------------------|
+| `path` (`/…`) | Selects a method-specific dereferenceable resource of the DID. This method defines `/data` and `/registration` (see [DID URL Dereferencing](#did-url-dereferencing)). |
+| `query` (`?…`) | Selects a version to resolve or dereference. This method honors `versionTime` and `versionSequence`. |
+| `fragment` (`#…`) | Identifies a node within the DID document (e.g. `#key-1`), resolved client-side against the resolved document. |
+
+> **Note (DID Core 1.0):** Earlier drafts of the DID specification allowed a `;`-delimited service matrix parameter (`did:cid:<cid>;service=…`). DID Core 1.0 removed this form; service selection, where supported, uses the registered `service` and `relativeRef` **query** parameters. The `did:cid` method does not use the `;service` matrix-parameter form.
 
 ## DID Lifecycle
 
@@ -214,7 +228,7 @@ For registries such as BTC with non-trivial transaction costs, it is expected th
 
 ## DID Revocation
 
-Revoking a DID is a special kind of Update that results in the termination of the DID. Revoked DIDs cannot be updated because they have no current controller, therefore they cannot be recovered once revoked. Revoked DIDs can be resolved without error, but resolvers will return a document set with the `didDocumentMetadata.deactivated` property set to `true`. The `didDocument` and `didDocumentData` properties will be set to empty.
+Revoking a DID is a special kind of Update that results in the termination of the DID. Revoked DIDs cannot be updated because they have no current controller, therefore they cannot be recovered once revoked. Revoked DIDs can be resolved without error, but resolvers will return a result with the `didDocumentMetadata.deactivated` property set to `true`. The `didDocument` is set to empty, and the DID's data resource (dereferenced at `/data`) is empty.
 
 To revoke a DID, the client must sign and submit a `delete` operation to a node.
 
@@ -248,11 +262,14 @@ Upon receiving the operation the node must:
 1. Verify the previd is identical to the latest version's operation CID.
 1. Record the operation on the DID specified registry (or forward the request to a trusted node that supports the specified registry).
 
-After revocation is confirmed on the DID's registry, resolving the DID will result in response like this:
+After revocation is confirmed on the DID's registry, resolving the DID returns a result like this:
 ```json
 {
     "didDocument": {
         "id": "did:cid:bagaaiera7vfnrxrmcvo7prrbmdhpvusroii4y2gir252nzk4jv5nxgkzldha"
+    },
+    "didResolutionMetadata": {
+        "retrieved": "2026-01-14T19:36:09.115Z"
     },
     "didDocumentMetadata": {
         "deactivated": true,
@@ -260,26 +277,16 @@ After revocation is confirmed on the DID's registry, resolving the DID will resu
         "deleted": "2026-01-14T19:34:33Z",
         "versionId": "bagaaierats6ttxvpx2l3tat25ota7z7335akfd2iup5loajsdlqcwismkgpq",
         "versionSequence": "2",
-        "confirmed": true,
-        "isOwned": false
-    },
-    "didDocumentData": {},
-    "didDocumentRegistration": {
-        "version": 1,
-        "type": "asset",
-        "registry": "hyperswarm"
-    },
-    "didResolutionMetadata": {
-        "retrieved": "2026-01-14T19:36:09.115Z"
+        "confirmed": true
     }
 }
 ```
 
-The metadata has a deactivated field set to true to conform to the [W3C specification](https://www.w3.org/TR/did-core/#did-document-metadata).
+The metadata has a `deactivated` field set to `true` to conform to the [W3C specification](https://www.w3.org/TR/did-core/#did-document-metadata).
 
 ## DID Resolution
 
-Resolution is the operation of responding to a DID with a DID Document. If you think of the DID as a secure reference or pointer, then resolution is equivalent to dereferencing.
+Resolution is the operation of returning a DID Document and its metadata for a given DID. It is distinct from *dereferencing*, which returns a resource identified by a DID URL (see [DID URL Dereferencing](#did-url-dereferencing)).
 
 Given a DID and an optional resolution time, the resolver retrieves the associated document seed from IPFS using the DID suffix as the CID, parsing it as plaintext JSON.
 If the data cannot be retrieved, then the resolver should delegate the resolution request to a fallback node.
@@ -320,6 +327,49 @@ function resolveDid(did, versionTime=now):
             apply update to DID document
     return DID document
 ```
+
+### Resolution Result
+
+A conformant resolution returns only the three members defined by the W3C [DID Resolution](https://www.w3.org/TR/did-core/#did-resolution) data model:
+
+- `didDocument`
+- `didResolutionMetadata`
+- `didDocumentMetadata`
+
+The method-specific data and registration objects are **not** part of the resolution result; they are exposed as dereferenceable resources (see [DID URL Dereferencing](#did-url-dereferencing)). Standard document metadata — `created`, `updated`, `versionId`, `versionSequence`, `deactivated`, `canonicalId`, `confirmed` — is carried in `didDocumentMetadata`.
+
+### Endpoints
+
+The conformant resolution and dereferencing surface follows the [Universal Resolver](https://github.com/decentralized-identity/universal-resolver) driver convention:
+
+| DID URL | HTTP | Returns |
+|---------|------|---------|
+| `did:cid:<cid>` | `GET /1.0/identifiers/<did>` | DID Resolution result (the triple) |
+| `did:cid:<cid>/data` | `GET /1.0/identifiers/<did>/data` | The data resource |
+| `did:cid:<cid>/registration` | `GET /1.0/identifiers/<did>/registration` | The registration resource |
+
+This surface always returns confirmed, cryptographically verified state. The legacy `/api/v1/did/<did>` endpoint remains available for backwards compatibility; it returns the richer internal document set (with `didDocumentData` and `didDocumentRegistration` inline) and can return unconfirmed or unverified state.
+
+## DID URL Dereferencing
+
+Dereferencing a `did:cid` DID URL returns a *resource* associated with the DID, as distinct from resolution (which returns the DID document and its metadata). Because `did:cid` is content-addressed, these resources are retrieved by content rather than from an external location.
+
+### Path resources
+
+This method defines two dereferenceable resources, selected by the DID URL path:
+
+- **`/data`** — `did:cid:<cid>/data` dereferences to the DID's data resource (`didDocumentData` in the internal document set). Agent DIDs have an empty data resource; asset DIDs return their attached data.
+- **`/registration`** — `did:cid:<cid>/registration` dereferences to the DID's registration/anchoring provenance (registry, type, validity, version). This is method-specific provenance, not W3C DID document metadata, which is why it is dereferenced rather than embedded in `didDocumentMetadata`.
+
+Neither resource is part of the DID resolution result. Both honor the `versionTime` and `versionSequence` version selectors.
+
+### Fragments
+
+A fragment identifies a node within the DID document — for example `did:cid:<cid>#key-1` dereferences to the verification method whose `id` matches. Per the DID Core processing model, the fragment is applied **client-side** to the resolved DID document (it is not transmitted to the resolver over HTTP); the node whose fully-qualified `id` matches the DID URL is returned.
+
+### Service dereferencing (future)
+
+The registered `service` and `relativeRef` query parameters — used to construct external service-endpoint URLs — are not currently implemented. If added they would be additive, and would change neither the resolution result nor the path resources above.
 
 ## Proof Verification
 

--- a/docs/services/drawbridge/README.md
+++ b/docs/services/drawbridge/README.md
@@ -88,6 +88,7 @@ Binds to `${ARCHON_BIND_ADDRESS}:${ARCHON_DRAWBRIDGE_PORT}` (default
 | `*` | `/didcomm/**` | Forwarded to the local DIDComm relay (path prefix `/didcomm` stripped). Carries the relay's own routes (mailbox `messages/*`, signed-`challenge`, egress `deliver`). Not paywalled — DIDComm authenticates with its own signed challenge. **501** if DIDComm is disabled. `application/didcomm-encrypted+json` bodies are captured as text and forwarded verbatim. |
 | `GET` | `/.well-known/*` | Forwarded to Herald (e.g. `lnurlp/<name>`, `webfinger`, `names`). |
 | `GET\|POST\|PUT\|DELETE` | `/names/*` | Forwarded to Herald (`/api/*`). **501** if name resolution is disabled. |
+| `*` | `/1.0/identifiers/**` | Forwarded verbatim to the Gatekeeper's standards-conformant DID resolution / dereferencing surface (`/1.0/identifiers/:did`, `/:did/data`, `/:did/registration`; see [Gatekeeper spec §2.6](../gatekeeper/README.md)). **Not paywalled** — public DID resolution for interop with universal resolvers, which do not speak L402. Proxied unchanged (no prefix stripped), so the Gatekeeper's resolution triple, raw dereferenced resources, and status/error shapes pass through intact. |
 | `GET` | `/metrics` | Prometheus exposition. |
 
 ### 2.2 L402 admin routes

--- a/docs/services/gatekeeper/README.md
+++ b/docs/services/gatekeeper/README.md
@@ -636,9 +636,15 @@ by the DID Resolution data model:
 
 ```jsonc
 {
-  "didDocument": { ... },
+  "didDocument": { /* ... */ },
   "didResolutionMetadata": { "retrieved": "<RFC 3339>" },
-  "didDocumentMetadata": { "created", "versionId", "versionSequence", "confirmed", ... }
+  "didDocumentMetadata": {
+    "created": "<RFC 3339>",
+    "versionId": "<CID>",
+    "versionSequence": "1",
+    "confirmed": true
+    // ...plus updated / deleted / deactivated / canonicalId when applicable
+  }
 }
 ```
 

--- a/docs/services/gatekeeper/README.md
+++ b/docs/services/gatekeeper/README.md
@@ -55,6 +55,7 @@ It is responsible for:
 - generating deterministic DIDs from create operations
 - verifying cryptographic proofs (secp256k1 ECDSA over SHA-256 of canonical JSON)
 - resolving DIDs into `didDocument` + `didDocumentMetadata` per the DID Core spec
+- exposing a standards-conformant DID resolution and dereferencing surface (`/1.0/identifiers`) per the DID Resolution data model
 - managing the import queue for events received from other nodes
 - exposing IPFS read/write through HTTP for clients without their own Kubo
 - serving Prometheus metrics and a small set of admin/operational endpoints
@@ -70,9 +71,11 @@ It is **not** responsible for:
 ## 2. HTTP API contract
 
 The service binds to `${ARCHON_BIND_ADDRESS}:${ARCHON_GATEKEEPER_PORT}`
-(default `0.0.0.0:4224`). All API routes live under `/api/v1`. Two
-non-versioned routes exist: `/metrics` for Prometheus and an `/api/*`
-catch-all for unhandled paths.
+(default `0.0.0.0:4224`). Most API routes live under `/api/v1`. A
+standards-conformant DID resolution surface lives under `/1.0/identifiers`
+(see [§2.6](#26-conformant-did-resolution-surface)). Two other non-versioned
+routes exist: `/metrics` for Prometheus and an `/api/*` catch-all for
+unhandled paths.
 
 ### 2.1 Routes
 
@@ -84,7 +87,7 @@ catch-all for unhandled paths.
 | `GET` | `/api/v1/registries` | no | JSON array of supported registry names. |
 | `POST` | `/api/v1/did` | no | Submit a `create`, `update`, or `delete` operation. Create returns the new DID string; update/delete return `true`. See [§7](#7-did-create--update--delete-validation). |
 | `POST` | `/api/v1/did/generate` | no | Deterministic DID generation without persistence. Body: `Operation`. Returns: DID string. |
-| `GET` | `/api/v1/did/:did` | no | Resolve a DID. Query params: `versionTime` (ISO 8601), `versionSequence` (int), `confirm` (`"true"`/`"false"`), `verify` (`"true"`/`"false"`). See [§6](#6-did-resolution-algorithm). |
+| `GET` | `/api/v1/did/:did` | no | Resolve a DID (internal resolver; returns the full document set incl. `didDocumentData`/`didDocumentRegistration`, see [§3.7](#37-didciddocument-resolution-result)). Query params: `versionTime` (ISO 8601), `versionSequence` (int), `confirm` (`"true"`/`"false"`), `verify` (`"true"`/`"false"`). See [§6](#6-did-resolution-algorithm). For the standards-conformant surface see [§2.6](#26-conformant-did-resolution-surface). |
 | `POST` | `/api/v1/dids/` | no | List DIDs. Body: `GetDIDOptions`. Only `/dids/` is registered explicitly; Express matches both `/dids` and `/dids/`. |
 | `POST` | `/api/v1/dids/remove` | yes | Body: array of DIDs. Returns boolean. |
 | `POST` | `/api/v1/dids/export` | no | Body: `{ "dids": string[] | undefined }`. Returns `GatekeeperEvent[][]` (one inner array per DID). |
@@ -153,6 +156,48 @@ Limit strings parse case-insensitively as `<digits>(b|kb|mb)?`.
     listed in [§2.1](#21-routes).
 - The unhandled-route fallback returns `{"message":"Endpoint not found"}`.
 - Any uncaught panic / exception SHOULD return HTTP 500 and SHOULD be logged.
+
+### 2.6 Conformant DID resolution surface
+
+In addition to the internal `/api/v1/did/:did` resolver, the service MUST
+expose a standards-conformant DID resolution and dereferencing surface under
+the [Universal Resolver](https://github.com/decentralized-identity/universal-resolver)
+driver convention `/1.0/identifiers`. This surface satisfies the W3C
+[DID Resolution](https://www.w3.org/TR/did-core/#did-resolution) data model,
+which permits only three top-level members in a resolution result.
+
+| Method | Path | Returns |
+| --- | --- | --- |
+| `GET` | `/1.0/identifiers/:did` | The DID Resolution result: exactly `didDocument`, `didResolutionMetadata`, `didDocumentMetadata`. See [§6.5](#65-conformant-resolution-result). |
+| `GET` | `/1.0/identifiers/:did/data` | The DID's data resource (`didDocumentData`), returned as the raw resource (empty object for agents). |
+| `GET` | `/1.0/identifiers/:did/registration` | The DID's registration/anchoring provenance (`didDocumentRegistration`), returned as the raw resource. |
+
+Shared behavior:
+
+- **Query params:** `versionTime` (ISO 8601) and `versionSequence` (int) only.
+  Unlike `/api/v1/did/:did`, the non-standard `confirm`/`verify` params are
+  NOT accepted; this surface always resolves with `confirm: true, verify:
+  true` (confirmed, cryptographically verified state). Clients needing raw or
+  unconfirmed state use `/api/v1/did/:did`.
+- **Routing:** `:did` is a bare DID (a single path segment); the
+  dereference resources are selected by the `/data` and `/registration`
+  sub-paths, so DID-URL path parsing is handled by routing rather than the
+  DID validator.
+- **Dereferenceable resources:** `/data` and `/registration` are method-specific
+  dereferenceable resources of the DID (the DID URLs `did:cid:<cid>/data` and
+  `did:cid:<cid>/registration`), retrieved by content address. They are NOT
+  part of the resolution result and are returned as the raw resource value
+  (not wrapped in a named envelope).
+- **Errors:**
+  - `invalidDid` -> HTTP 400; `notFound` -> HTTP 404.
+  - For `/:did`, errors are reported in `didResolutionMetadata.error` and the
+    body remains triple-shaped (`didDocument: null`, `didDocumentMetadata:
+    {}`).
+  - For the dereference resources, the body is `{"error":"<value>"}`.
+  - A validation failure in the DID's own operation chain (surfaced by the
+    forced `verify`) MUST be treated as `notFound` (HTTP 404), not an internal
+    error. Unexpected failures MUST return HTTP 500 with error value
+    `internalError` (triple-shaped for `/:did`) and SHOULD be logged.
 
 ---
 
@@ -241,6 +286,14 @@ omitted from the JSON object; required fields MUST be present unless noted.
 ```
 
 ### 3.7 `DidCidDocument` (resolution result)
+
+This is the **full internal document set** returned by `/api/v1/did/:did` and
+used throughout the protocol (including update operation payloads). The
+standards-conformant `/1.0/identifiers/:did` surface returns only the
+`didDocument` / `didResolutionMetadata` / `didDocumentMetadata` subset;
+`didDocumentData` and `didDocumentRegistration` are dereferenced separately
+(see [§2.6](#26-conformant-did-resolution-surface) and
+[§6.5](#65-conformant-resolution-result)).
 
 ```jsonc
 {
@@ -569,6 +622,29 @@ Before returning, implementations MUST:
 - omit `didDocumentMetadata.canonicalId` unless set
 - always emit `didDocumentMetadata.versionId`, `versionSequence` (string),
   `confirmed`, `created`
+
+### 6.5 Conformant resolution result
+
+The `/1.0/identifiers` surface ([§2.6](#26-conformant-did-resolution-surface))
+reshapes the resolver output at the HTTP boundary; the resolution algorithm
+itself is unchanged (it always runs with `confirm: true, verify: true` for
+this surface). The conformant result contains only the three members defined
+by the DID Resolution data model:
+
+```jsonc
+{
+  "didDocument": { ... },
+  "didResolutionMetadata": { "retrieved": "<RFC 3339>" },
+  "didDocumentMetadata": { "created", "versionId", "versionSequence", "confirmed", ... }
+}
+```
+
+`didDocumentData` and `didDocumentRegistration` (present inline in the
+internal [`DidCidDocument`](#37-didciddocument-resolution-result)) MUST be
+omitted here and instead exposed via the `/data` and `/registration`
+dereference resources. Standard document metadata (`created`, `updated`,
+`versionId`, `versionSequence`, `deactivated`, `canonicalId`, `confirmed`)
+remains in `didDocumentMetadata`.
 
 ---
 
@@ -962,16 +1038,19 @@ The `route` label MUST collapse dynamic path segments to placeholder names
 so cardinality stays bounded. Required normalizations:
 
 ```
-/api/v1/did/did:...        -> /api/v1/did/:did
-/api/v1/block/<r>/latest   -> /api/v1/block/:registry/latest
-/api/v1/block/<r>/<id>     -> /api/v1/block/:registry/<id>
-/api/v1/queue/<r>/clear    -> /api/v1/queue/:registry/clear
-/api/v1/queue/<r>          -> /api/v1/queue/:registry
-/api/v1/events/<x>         -> /api/v1/events/:registry
-/api/v1/dids/<x>           -> /api/v1/dids/:prefix
+/api/v1/did/did:...          -> /api/v1/did/:did
+/api/v1/block/<r>/latest     -> /api/v1/block/:registry/latest
+/api/v1/block/<r>/<id>       -> /api/v1/block/:registry/<id>
+/api/v1/queue/<r>/clear      -> /api/v1/queue/:registry/clear
+/api/v1/queue/<r>            -> /api/v1/queue/:registry
+/api/v1/events/<x>           -> /api/v1/events/:registry
+/api/v1/dids/<x>             -> /api/v1/dids/:prefix
+/1.0/identifiers/did:...     -> /1.0/identifiers/:did   (the /data and /registration suffixes are preserved)
 ```
 
-The label MUST include the `/api/v1` prefix.
+The label MUST retain each route's own prefix (`/api/v1` for the versioned
+API, `/1.0/identifiers` for the conformant surface); only the dynamic DID /
+registry segments are collapsed.
 
 ### 13.2 Counter semantics
 

--- a/docs/services/gatekeeper/README.md
+++ b/docs/services/gatekeeper/README.md
@@ -188,6 +188,14 @@ Shared behavior:
   `did:cid:<cid>/registration`), retrieved by content address. They are NOT
   part of the resolution result and are returned as the raw resource value
   (not wrapped in a named envelope).
+- **Local-only (no fallback delegation):** unlike `/api/v1/did/:did`, this
+  surface resolves solely from local state — it MUST NOT delegate to the
+  universal-resolver `fallbackURL` or the confirmed-Gatekeeper peer on a local
+  miss, and returns `notFound` instead. This is deliberate: `/1.0/identifiers`
+  is the node's own Universal Resolver *driver* surface, so delegating to the
+  configured `fallbackURL` (itself a Universal Resolver by default) could form
+  a resolution loop and would return an external resolver's representation.
+  Clients that want fallback/import-propagation behavior use `/api/v1/did/:did`.
 - **Errors:**
   - `invalidDid` -> HTTP 400; `notFound` -> HTTP 404.
   - For `/:did`, errors are reported in `didResolutionMetadata.error` and the

--- a/docs/services/gatekeeper/README.md
+++ b/docs/services/gatekeeper/README.md
@@ -196,8 +196,11 @@ Shared behavior:
   - For the dereference resources, the body is `{"error":"<value>"}`.
   - A validation failure in the DID's own operation chain (surfaced by the
     forced `verify`) MUST be treated as `notFound` (HTTP 404), not an internal
-    error. Unexpected failures MUST return HTTP 500 with error value
+    error. Unexpected failures SHOULD return HTTP 500 with error value
     `internalError` (triple-shaped for `/:did`) and SHOULD be logged.
+    (The TypeScript reference does this; implementations whose resolver returns
+    type-erased errors, like the Rust port, MAY instead report them as
+    `notFound`.)
 
 ---
 

--- a/docs/services/gatekeeper/README.md
+++ b/docs/services/gatekeeper/README.md
@@ -202,6 +202,10 @@ Shared behavior:
     body remains triple-shaped (`didDocument: null`, `didDocumentMetadata:
     {}`).
   - For the dereference resources, the body is `{"error":"<value>"}`.
+  - Any other path under `/1.0/identifiers` (an unsupported DID URL resource,
+    e.g. `/1.0/identifiers/<did>/bogus`) MUST return HTTP 404
+    `{"error":"notFound"}` — a structured JSON body, not a framework-default
+    HTML 404.
   - A validation failure in the DID's own operation chain (surfaced by the
     forced `verify`) MUST be treated as `notFound` (HTTP 404), not an internal
     error. Unexpected failures SHOULD return HTTP 500 with error value

--- a/rust/services/gatekeeper/src/api.rs
+++ b/rust/services/gatekeeper/src/api.rs
@@ -1190,6 +1190,180 @@ pub(crate) async fn resolve_did(
     Json(local_doc).into_response()
 }
 
+// Shared resolution for the conformant /1.0/identifiers surface. confirm/verify are not DID
+// Core parameters, so they are not accepted here; the surface always resolves confirmed,
+// cryptographically verified state (only the standard version selectors are honored).
+// Returns the resolved document, or an (HTTP status, DID Resolution error value) pair.
+async fn resolve_conformant(
+    state: &AppState,
+    did: &str,
+    query: &HashMap<String, String>,
+) -> std::result::Result<Value, (StatusCode, String)> {
+    let options = ResolveOptions {
+        version_time: query.get("versionTime").cloned(),
+        version_sequence: query
+            .get("versionSequence")
+            .and_then(|value| value.parse::<usize>().ok()),
+        confirm: true,
+        verify: true,
+    };
+
+    let classify = |error_kind: &str| -> (StatusCode, String) {
+        let status = if error_kind == "invalidDid" {
+            StatusCode::BAD_REQUEST
+        } else {
+            StatusCode::NOT_FOUND
+        };
+        (status, error_kind.to_string())
+    };
+
+    match resolve_local_doc_async(state, did, options).await {
+        Ok(doc) => {
+            if let Some(error_kind) = doc
+                .get("didResolutionMetadata")
+                .and_then(|value| value.get("error"))
+                .and_then(Value::as_str)
+            {
+                return Err(classify(error_kind));
+            }
+            Ok(doc)
+        }
+        Err(_) => {
+            let error_kind = if did.starts_with("did:") {
+                "notFound"
+            } else {
+                "invalidDid"
+            };
+            Err(classify(error_kind))
+        }
+    }
+}
+
+// GET /1.0/identifiers/:did — standards-conformant DID resolution. Returns only the DID
+// Resolution triple (didDocument, didResolutionMetadata, didDocumentMetadata); the
+// method-specific data/registration objects are dereferenced separately.
+pub(crate) async fn conformant_resolve_did(
+    State(state): State<AppState>,
+    Path(did): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Response {
+    let start = Instant::now();
+    match resolve_conformant(&state, &did, &query).await {
+        Ok(doc) => {
+            let triple = json!({
+                "didDocument": doc.get("didDocument").cloned().unwrap_or(Value::Null),
+                "didResolutionMetadata": doc
+                    .get("didResolutionMetadata")
+                    .cloned()
+                    .unwrap_or_else(|| json!({})),
+                "didDocumentMetadata": doc
+                    .get("didDocumentMetadata")
+                    .cloned()
+                    .unwrap_or_else(|| json!({}))
+            });
+            record_metrics(
+                &state,
+                "GET",
+                "/1.0/identifiers/:did",
+                200,
+                start.elapsed().as_secs_f64(),
+            );
+            Json(triple).into_response()
+        }
+        Err((status, error_kind)) => {
+            record_metrics(
+                &state,
+                "GET",
+                "/1.0/identifiers/:did",
+                status.as_u16(),
+                start.elapsed().as_secs_f64(),
+            );
+            // Errors are reported in didResolutionMetadata, keeping the result triple-shaped.
+            (
+                status,
+                Json(json!({
+                    "didDocument": Value::Null,
+                    "didResolutionMetadata": { "error": error_kind },
+                    "didDocumentMetadata": {}
+                })),
+            )
+                .into_response()
+        }
+    }
+}
+
+// GET /1.0/identifiers/:did/data — dereferences the method-specific data resource
+// (did:cid:<cid>/data), returned as the raw resource (empty object for agent DIDs).
+pub(crate) async fn conformant_dereference_data(
+    State(state): State<AppState>,
+    Path(did): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Response {
+    let start = Instant::now();
+    match resolve_conformant(&state, &did, &query).await {
+        Ok(doc) => {
+            let data = doc
+                .get("didDocumentData")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            record_metrics(
+                &state,
+                "GET",
+                "/1.0/identifiers/:did/data",
+                200,
+                start.elapsed().as_secs_f64(),
+            );
+            Json(data).into_response()
+        }
+        Err((status, error_kind)) => {
+            record_metrics(
+                &state,
+                "GET",
+                "/1.0/identifiers/:did/data",
+                status.as_u16(),
+                start.elapsed().as_secs_f64(),
+            );
+            (status, error_json(&error_kind)).into_response()
+        }
+    }
+}
+
+// GET /1.0/identifiers/:did/registration — dereferences the method-specific
+// registration/anchoring provenance resource (did:cid:<cid>/registration).
+pub(crate) async fn conformant_dereference_registration(
+    State(state): State<AppState>,
+    Path(did): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Response {
+    let start = Instant::now();
+    match resolve_conformant(&state, &did, &query).await {
+        Ok(doc) => {
+            let registration = doc
+                .get("didDocumentRegistration")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            record_metrics(
+                &state,
+                "GET",
+                "/1.0/identifiers/:did/registration",
+                200,
+                start.elapsed().as_secs_f64(),
+            );
+            Json(registration).into_response()
+        }
+        Err((status, error_kind)) => {
+            record_metrics(
+                &state,
+                "GET",
+                "/1.0/identifiers/:did/registration",
+                status.as_u16(),
+                start.elapsed().as_secs_f64(),
+            );
+            (status, error_json(&error_kind)).into_response()
+        }
+    }
+}
+
 pub(crate) async fn ipfs_add_json(
     State(state): State<AppState>,
     Json(payload): Json<Value>,

--- a/rust/services/gatekeeper/src/api.rs
+++ b/rust/services/gatekeeper/src/api.rs
@@ -1364,6 +1364,19 @@ pub(crate) async fn conformant_dereference_registration(
     }
 }
 
+// Any other path under /1.0/identifiers is not a supported DID URL resource for this method.
+// Return a structured JSON 404 so the conformant surface stays consistent (matches the TS
+// implementation) instead of the generic top-level "Endpoint not found" fallback.
+pub(crate) async fn conformant_not_found(
+    State(state): State<AppState>,
+    request: Request,
+) -> Response {
+    let method = request.method().clone();
+    let route = normalize_path(request.uri().path());
+    record_metrics(&state, method.as_str(), &route, 404, 0.0);
+    (StatusCode::NOT_FOUND, error_json("notFound")).into_response()
+}
+
 pub(crate) async fn ipfs_add_json(
     State(state): State<AppState>,
     Json(payload): Json<Value>,

--- a/rust/services/gatekeeper/src/app.rs
+++ b/rust/services/gatekeeper/src/app.rs
@@ -23,12 +23,13 @@ use tracing::{info, warn};
 
 use crate::{
     api::{
-        add_block, api_not_found, clear_queue, create_did, db_reset, db_verify, export_batch,
-        export_dids, generate_did, get_block_by_id, get_latest_block, get_metrics, get_queue,
-        import_batch, import_batch_by_cids, import_dids, ipfs_add_data, ipfs_add_json,
-        ipfs_add_stream, ipfs_add_text, ipfs_get_data, ipfs_get_json, ipfs_get_stream,
-        ipfs_get_text, list_dids, not_found, process_events_route, query_docs, ready, registries,
-        remove_dids, resolve_did, search_docs, status, version,
+        add_block, api_not_found, clear_queue, conformant_dereference_data,
+        conformant_dereference_registration, conformant_resolve_did, create_did, db_reset,
+        db_verify, export_batch, export_dids, generate_did, get_block_by_id, get_latest_block,
+        get_metrics, get_queue, import_batch, import_batch_by_cids, import_dids, ipfs_add_data,
+        ipfs_add_json, ipfs_add_stream, ipfs_add_text, ipfs_get_data, ipfs_get_json,
+        ipfs_get_stream, ipfs_get_text, list_dids, not_found, process_events_route, query_docs,
+        ready, registries, remove_dids, resolve_did, search_docs, status, version,
     },
     build_search_index, log_status_snapshot, refresh_metrics_snapshot, start_background_tasks,
     CheckDidsResult, Config, EventRecord, JsonDb, Metrics, SearchIndex,
@@ -225,9 +226,18 @@ fn build_router(state: AppState) -> Router {
         .route("/query", post(query_docs))
         .layer(DefaultBodyLimit::max(json_limit));
 
+    // Standards-conformant DID resolution / dereferencing surface, following the Universal
+    // Resolver driver convention (/1.0/identifiers). Distinct from the internal /api/v1/did
+    // family, which is preserved for backwards compatibility.
+    let identifiers = Router::new()
+        .route("/:did", get(conformant_resolve_did))
+        .route("/:did/data", get(conformant_dereference_data))
+        .route("/:did/registration", get(conformant_dereference_registration));
+
     Router::new()
         .route("/metrics", get(get_metrics))
         .nest("/api/v1", streaming.merge(upload).merge(json))
+        .nest("/1.0/identifiers", identifiers)
         .nest("/api", Router::new().fallback(api_not_found))
         .fallback(not_found)
         .layer(middleware::from_fn(log_http))

--- a/rust/services/gatekeeper/src/app.rs
+++ b/rust/services/gatekeeper/src/app.rs
@@ -24,7 +24,8 @@ use tracing::{info, warn};
 use crate::{
     api::{
         add_block, api_not_found, clear_queue, conformant_dereference_data,
-        conformant_dereference_registration, conformant_resolve_did, create_did, db_reset,
+        conformant_dereference_registration, conformant_not_found, conformant_resolve_did,
+        create_did, db_reset,
         db_verify, export_batch, export_dids, generate_did, get_block_by_id, get_latest_block,
         get_metrics, get_queue, import_batch, import_batch_by_cids, import_dids, ipfs_add_data,
         ipfs_add_json, ipfs_add_stream, ipfs_add_text, ipfs_get_data, ipfs_get_json,
@@ -232,7 +233,8 @@ fn build_router(state: AppState) -> Router {
     let identifiers = Router::new()
         .route("/:did", get(conformant_resolve_did))
         .route("/:did/data", get(conformant_dereference_data))
-        .route("/:did/registration", get(conformant_dereference_registration));
+        .route("/:did/registration", get(conformant_dereference_registration))
+        .fallback(conformant_not_found);
 
     Router::new()
         .route("/metrics", get(get_metrics))

--- a/rust/services/gatekeeper/src/lib.rs
+++ b/rust/services/gatekeeper/src/lib.rs
@@ -320,6 +320,15 @@ mod tests {
             normalize_path("/1.0/identifiers/did:cid:bagaaieratest/registration?versionSequence=2"),
             "/1.0/identifiers/:did/registration"
         );
+        // Percent-encoded colon must still collapse (parity with the TS normalizer).
+        assert_eq!(
+            normalize_path("/1.0/identifiers/did%3Acid%3Abagaaieratest/data"),
+            "/1.0/identifiers/:did/data"
+        );
+        assert_eq!(
+            normalize_path("/api/v1/did/did%3Acid%3Abagaaieratest"),
+            "/api/v1/did/:did"
+        );
     }
 
     #[test]

--- a/rust/services/gatekeeper/src/lib.rs
+++ b/rust/services/gatekeeper/src/lib.rs
@@ -308,6 +308,18 @@ mod tests {
             normalize_path("/api/v1/block/BTC:signet/latest"),
             "/api/v1/block/:registry/latest"
         );
+        assert_eq!(
+            normalize_path("/1.0/identifiers/did:cid:bagaaieratest"),
+            "/1.0/identifiers/:did"
+        );
+        assert_eq!(
+            normalize_path("/1.0/identifiers/did:cid:bagaaieratest/data"),
+            "/1.0/identifiers/:did/data"
+        );
+        assert_eq!(
+            normalize_path("/1.0/identifiers/did:cid:bagaaieratest/registration?versionSequence=2"),
+            "/1.0/identifiers/:did/registration"
+        );
     }
 
     #[test]

--- a/rust/services/gatekeeper/src/metrics.rs
+++ b/rust/services/gatekeeper/src/metrics.rs
@@ -53,9 +53,15 @@ pub(crate) fn normalize_path(path: &str) -> String {
         .filter(|segment| !segment.is_empty())
         .collect::<Vec<_>>();
 
+    // A DID path segment, either literal ("did:...") or with the colon
+    // percent-encoded ("did%3A..."), matching the TypeScript normalizer.
+    let is_did_segment = |value: &str| {
+        value.starts_with("did:") || value.to_ascii_lowercase().starts_with("did%3a")
+    };
+
     if let Some(index) = segments.iter().position(|segment| *segment == "did") {
         if let Some(value) = segments.get(index + 1) {
-            if value.starts_with("did:") {
+            if is_did_segment(value) {
                 let mut normalized = segments.clone();
                 normalized[index + 1] = ":did";
                 return format!("/{}", normalized.join("/"));
@@ -67,7 +73,7 @@ pub(crate) fn normalize_path(path: &str) -> String {
     // segment; any /data or /registration suffix is preserved.
     if let Some(index) = segments.iter().position(|segment| *segment == "identifiers") {
         if let Some(value) = segments.get(index + 1) {
-            if value.starts_with("did:") {
+            if is_did_segment(value) {
                 let mut normalized = segments.clone();
                 normalized[index + 1] = ":did";
                 return format!("/{}", normalized.join("/"));

--- a/rust/services/gatekeeper/src/metrics.rs
+++ b/rust/services/gatekeeper/src/metrics.rs
@@ -37,7 +37,7 @@ pub(crate) fn record_metrics(
 }
 
 fn qualify_route(route: &str) -> String {
-    if route.starts_with("/api/") || route == "/metrics" {
+    if route.starts_with("/api/") || route == "/metrics" || route.starts_with("/1.0/") {
         return route.to_string();
     }
     if route.starts_with('/') {
@@ -54,6 +54,18 @@ pub(crate) fn normalize_path(path: &str) -> String {
         .collect::<Vec<_>>();
 
     if let Some(index) = segments.iter().position(|segment| *segment == "did") {
+        if let Some(value) = segments.get(index + 1) {
+            if value.starts_with("did:") {
+                let mut normalized = segments.clone();
+                normalized[index + 1] = ":did";
+                return format!("/{}", normalized.join("/"));
+            }
+        }
+    }
+
+    // Conformant surface: /1.0/identifiers/<did>[/data|/registration]. Collapse the DID
+    // segment; any /data or /registration suffix is preserved.
+    if let Some(index) = segments.iter().position(|segment| *segment == "identifiers") {
         if let Some(value) = segments.get(index + 1) {
             if value.starts_with("did:") {
                 let mut normalized = segments.clone();

--- a/services/drawbridge/server/src/drawbridge-api.ts
+++ b/services/drawbridge/server/src/drawbridge-api.ts
@@ -94,6 +94,7 @@ async function resolveDidCommEndpoint(): Promise<string | null> {
 function normalizePath(path: string): string {
     return path
         .replace(/\/did\/(?:did:[^/]+|did%3[aA][^/]+)/, '/did/:did')
+        .replace(/\/identifiers\/(?:did:[^/]+|did%3[aA][^/]+)/, '/identifiers/:did')
         .replace(/\/invoice\/(?:did:[^/]+|did%3[aA][^/]+)/, '/invoice/:did')
         .replace(/\/ipfs\/json\/[^/]+/, '/ipfs/json/:cid')
         .replace(/\/ipfs\/text\/[^/]+/, '/ipfs/text/:cid')
@@ -756,6 +757,20 @@ async function main() {
         } catch (error: any) {
             logger.error({ err: error, path: req.originalUrl }, 'DIDComm proxy error');
             res.status(502).json({ error: 'Upstream didcomm error' });
+        }
+    });
+
+    // Standards-conformant DID resolution / dereferencing surface (Universal Resolver
+    // driver convention). Proxied verbatim to the gatekeeper so its conformant output —
+    // the resolution triple, raw dereferenced resources, and status/error shapes — is
+    // preserved unchanged. Intentionally open (no L402): public DID resolution for interop
+    // with universal resolvers, which do not speak L402.
+    app.use('/1.0/identifiers', async (req, res) => {
+        try {
+            await proxyRequest(req, res, config.gatekeeperURL, '');
+        } catch (error: any) {
+            logger.error({ err: error, path: req.originalUrl }, 'Gatekeeper conformant proxy error');
+            res.status(502).json({ error: 'Upstream gatekeeper error' });
         }
     });
 

--- a/services/gatekeeper/server/src/gatekeeper-api.ts
+++ b/services/gatekeeper/server/src/gatekeeper-api.ts
@@ -900,18 +900,6 @@ v1router.get('/did/:did', async (req, res) => {
  *         schema:
  *           type: integer
  *         description: Dereference the data at a specific version of the DID Document.
- *       - in: query
- *         name: confirm
- *         required: false
- *         schema:
- *           type: boolean
- *         description: If `true`, dereferences only if the DID is fully confirmed.
- *       - in: query
- *         name: verify
- *         required: false
- *         schema:
- *           type: boolean
- *         description: If `true`, verifies the signature(s) of the DID operation(s) first.
  *     responses:
  *       200:
  *         description: The dereferenced data resource.
@@ -943,8 +931,11 @@ v1router.get('/did/:did', async (req, res) => {
  */
 identifiersRouter.get('/:did/data', async (req, res) => {
     try {
-        const options: ResolveDIDOptions = {};
-        const { versionTime, versionSequence, confirm, verify } = req.query;
+        // confirm/verify are not DID Core parameters. The conformant surface always
+        // returns confirmed, cryptographically verified state; callers needing raw or
+        // unconfirmed state use the internal /api/v1/did/:did endpoint.
+        const options: ResolveDIDOptions = { confirm: true, verify: true };
+        const { versionTime, versionSequence } = req.query;
 
         if (typeof versionTime === 'string') {
             options.versionTime = versionTime;
@@ -955,14 +946,6 @@ identifiersRouter.get('/:did/data', async (req, res) => {
             if (!isNaN(parsed)) {
                 options.versionSequence = parsed;
             }
-        }
-
-        if (confirm) {
-            options.confirm = confirm === 'true';
-        }
-
-        if (verify) {
-            options.verify = verify === 'true';
         }
 
         const doc = await gatekeeper.resolveDID(req.params.did, options);

--- a/services/gatekeeper/server/src/gatekeeper-api.ts
+++ b/services/gatekeeper/server/src/gatekeeper-api.ts
@@ -85,6 +85,7 @@ function normalizePath(path: string): string {
     // Normalize known dynamic segments
     return basePath
         .replace(/\/did\/(?:did:[^/]+|did%3[aA][^/]+)/g, '/did/:did')
+        .replace(/\/identifiers\/(?:did:[^/]+|did%3[aA][^/]+)/g, '/identifiers/:did')
         .replace(/\/block\/[^/]+\/latest/g, '/block/:registry/latest')
         .replace(/\/block\/[^/]+/g, '/block/:registry')
         .replace(/\/queue\/[^/]+\/clear/g, '/queue/:registry/clear')
@@ -136,6 +137,10 @@ const startTime = new Date();
 const app = express();
 const v1router = express.Router();
 const adminRouter = express.Router();
+// Standards-conformant DID resolution / dereferencing surface, following the
+// Universal Resolver driver convention (/1.0/identifiers/:did). Distinct from the
+// internal /api/v1/did/:did family, which is preserved for backwards compatibility.
+const identifiersRouter = express.Router();
 const ARCHON_ADMIN_HEADER = 'x-archon-admin-key';
 
 // Admin API key middleware — when ARCHON_ADMIN_API_KEY is set, admin
@@ -858,6 +863,120 @@ v1router.get('/did/:did', async (req, res) => {
         }
 
         res.json(doc);
+    } catch (error: any) {
+        res.status(404).send({ error: 'DID not found' });
+    }
+});
+
+/**
+ * @swagger
+ * /1.0/identifiers/{did}/data:
+ *   get:
+ *     summary: Dereference the data resource of a DID
+ *     description: >
+ *       Dereferences the data resource associated with a DID, per the did:cid method-specific
+ *       DID URL dereferencing rules (the DID URL `did:cid:<cid>/data`). Because the DID is
+ *       content-addressed, the resource is retrieved by content rather than by an external
+ *       location. This is distinct from DID resolution (`/1.0/identifiers/{did}`): it returns
+ *       the associated data resource itself, not the DID Document + metadata triple. Agent DIDs
+ *       return an empty object; asset DIDs return their attached data.
+ *     parameters:
+ *       - in: path
+ *         name: did
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The DID whose data resource is dereferenced.
+ *       - in: query
+ *         name: versionTime
+ *         required: false
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: Dereference the data as of this specific time.
+ *       - in: query
+ *         name: versionSequence
+ *         required: false
+ *         schema:
+ *           type: integer
+ *         description: Dereference the data at a specific version of the DID Document.
+ *       - in: query
+ *         name: confirm
+ *         required: false
+ *         schema:
+ *           type: boolean
+ *         description: If `true`, dereferences only if the DID is fully confirmed.
+ *       - in: query
+ *         name: verify
+ *         required: false
+ *         schema:
+ *           type: boolean
+ *         description: If `true`, verifies the signature(s) of the DID operation(s) first.
+ *     responses:
+ *       200:
+ *         description: The dereferenced data resource.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               description: Arbitrary data attached to the DID (empty object for agent DIDs).
+ *       400:
+ *         description: The DID is syntactically invalid.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *       404:
+ *         description: The DID does not exist or cannot be resolved.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *       500:
+ *         description: Internal Server Error.
+ */
+identifiersRouter.get('/:did/data', async (req, res) => {
+    try {
+        const options: ResolveDIDOptions = {};
+        const { versionTime, versionSequence, confirm, verify } = req.query;
+
+        if (typeof versionTime === 'string') {
+            options.versionTime = versionTime;
+        }
+
+        if (typeof versionSequence === 'string') {
+            const parsed = parseInt(versionSequence, 10);
+            if (!isNaN(parsed)) {
+                options.versionSequence = parsed;
+            }
+        }
+
+        if (confirm) {
+            options.confirm = confirm === 'true';
+        }
+
+        if (verify) {
+            options.verify = verify === 'true';
+        }
+
+        const doc = await gatekeeper.resolveDID(req.params.did, options);
+
+        if (doc.didResolutionMetadata?.error) {
+            const error = doc.didResolutionMetadata.error;
+            const status = error === 'invalidDid' ? 400 : 404;
+            res.status(status).json({ error });
+            return;
+        }
+
+        // Dereference the method-specific data resource (did:cid:<cid>/data).
+        // Not part of the DID resolution result — returned as the resource itself.
+        res.json(doc.didDocumentData ?? {});
     } catch (error: any) {
         res.status(404).send({ error: 'DID not found' });
     }
@@ -2238,6 +2357,7 @@ v1router.post('/query', async (req, res) => {
 });
 
 app.use('/api/v1', v1router);
+app.use('/1.0/identifiers', identifiersRouter);
 
 app.use('/api', (req, res) => {
     console.warn(`Warning: Unhandled API endpoint - ${req.method} ${req.originalUrl}`);

--- a/services/gatekeeper/server/src/gatekeeper-api.ts
+++ b/services/gatekeeper/server/src/gatekeeper-api.ts
@@ -9,6 +9,7 @@ import DbRedis from '@didcid/gatekeeper/db/redis';
 import DbSqlite from '@didcid/gatekeeper/db/sqlite';
 import DbMongo from '@didcid/gatekeeper/db/mongo';
 import { CheckDIDsResult, ResolveDIDOptions, Operation, DidCidDocument } from '@didcid/gatekeeper/types';
+import { InvalidOperationError } from '@didcid/common/errors';
 import KuboClient from '@didcid/ipfs/kubo';
 import config from './config.js';
 import {
@@ -902,6 +903,18 @@ async function resolveConformant(
     return { ok: true, doc };
 }
 
+// Classify an error thrown during conformant resolution/dereferencing. A validation failure
+// in the DID's own operation chain (e.g. a bad proof surfaced by verify) is a property of the
+// DID, not a server fault, so it resolves to a 4xx "notFound"; anything else is an internal
+// error. resolveConformant() already handles the expected invalidDid/notFound cases, so this
+// only ever sees thrown exceptions.
+function classifyResolveError(error: unknown): { status: number; resolutionError: string } {
+    if (error instanceof InvalidOperationError) {
+        return { status: 404, resolutionError: 'notFound' };
+    }
+    return { status: 500, resolutionError: 'internalError' };
+}
+
 /**
  * @swagger
  * /1.0/identifiers/{did}:
@@ -976,7 +989,16 @@ identifiersRouter.get('/:did', async (req, res) => {
         const { didDocument, didResolutionMetadata, didDocumentMetadata } = result.doc;
         res.json({ didDocument, didResolutionMetadata, didDocumentMetadata });
     } catch (error: any) {
-        res.status(404).send({ error: 'DID not found' });
+        const { status, resolutionError } = classifyResolveError(error);
+        if (status >= 500) {
+            logger.error({ did: req.params.did, error }, 'DID resolution failed');
+        }
+        // Errors are reported in didResolutionMetadata, keeping the result triple-shaped.
+        res.status(status).json({
+            didDocument: null,
+            didResolutionMetadata: { error: resolutionError },
+            didDocumentMetadata: {},
+        });
     }
 });
 
@@ -1054,7 +1076,11 @@ identifiersRouter.get('/:did/data', async (req, res) => {
         // Not part of the DID resolution result — returned as the resource itself.
         res.json(result.doc.didDocumentData ?? {});
     } catch (error: any) {
-        res.status(404).send({ error: 'DID not found' });
+        const { status, resolutionError } = classifyResolveError(error);
+        if (status >= 500) {
+            logger.error({ did: req.params.did, error }, 'DID dereferencing failed');
+        }
+        res.status(status).json({ error: resolutionError });
     }
 });
 
@@ -1131,7 +1157,11 @@ identifiersRouter.get('/:did/registration', async (req, res) => {
         // Not part of the DID resolution result — returned as the resource itself.
         res.json(result.doc.didDocumentRegistration ?? {});
     } catch (error: any) {
-        res.status(404).send({ error: 'DID not found' });
+        const { status, resolutionError } = classifyResolveError(error);
+        if (status >= 500) {
+            logger.error({ did: req.params.did, error }, 'DID dereferencing failed');
+        }
+        res.status(status).json({ error: resolutionError });
     }
 });
 

--- a/services/gatekeeper/server/src/gatekeeper-api.ts
+++ b/services/gatekeeper/server/src/gatekeeper-api.ts
@@ -8,7 +8,7 @@ import DbJsonCache from '@didcid/gatekeeper/db/json-cache';
 import DbRedis from '@didcid/gatekeeper/db/redis';
 import DbSqlite from '@didcid/gatekeeper/db/sqlite';
 import DbMongo from '@didcid/gatekeeper/db/mongo';
-import { CheckDIDsResult, ResolveDIDOptions, Operation } from '@didcid/gatekeeper/types';
+import { CheckDIDsResult, ResolveDIDOptions, Operation, DidCidDocument } from '@didcid/gatekeeper/types';
 import KuboClient from '@didcid/ipfs/kubo';
 import config from './config.js';
 import {
@@ -868,6 +868,118 @@ v1router.get('/did/:did', async (req, res) => {
     }
 });
 
+// Shared resolution for the conformant /1.0/identifiers surface.
+//
+// confirm/verify are not DID Core parameters, so they are not exposed here; the surface
+// always returns confirmed, cryptographically verified state (callers needing raw or
+// unconfirmed state use the internal /api/v1/did/:did endpoint). Only the standard version
+// selectors are honored. Returns the resolved document, or an HTTP status + resolution
+// metadata carrying the error.
+async function resolveConformant(
+    req: express.Request
+): Promise<{ ok: true; doc: DidCidDocument } | { ok: false; status: number; didResolutionMetadata: any }> {
+    const options: ResolveDIDOptions = { confirm: true, verify: true };
+    const { versionTime, versionSequence } = req.query;
+
+    if (typeof versionTime === 'string') {
+        options.versionTime = versionTime;
+    }
+
+    if (typeof versionSequence === 'string') {
+        const parsed = parseInt(versionSequence, 10);
+        if (!isNaN(parsed)) {
+            options.versionSequence = parsed;
+        }
+    }
+
+    const doc = await gatekeeper.resolveDID(req.params.did, options);
+
+    if (doc.didResolutionMetadata?.error) {
+        const status = doc.didResolutionMetadata.error === 'invalidDid' ? 400 : 404;
+        return { ok: false, status, didResolutionMetadata: doc.didResolutionMetadata };
+    }
+
+    return { ok: true, doc };
+}
+
+/**
+ * @swagger
+ * /1.0/identifiers/{did}:
+ *   get:
+ *     summary: Resolve a DID (standards-conformant)
+ *     description: >
+ *       Resolves a DID following the DID Resolution data model, returning only the standard
+ *       result triple (`didDocument`, `didResolutionMetadata`, `didDocumentMetadata`). Follows
+ *       the Universal Resolver driver convention. The method-specific `didDocumentData` and
+ *       `didDocumentRegistration` objects are NOT part of this result — they are exposed as
+ *       dereferenceable resources at `/1.0/identifiers/{did}/data` and
+ *       `/1.0/identifiers/{did}/registration`. Always returns confirmed, cryptographically
+ *       verified state; the internal `/api/v1/did/{did}` endpoint remains available for raw or
+ *       unconfirmed state.
+ *     parameters:
+ *       - in: path
+ *         name: did
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The DID to resolve.
+ *       - in: query
+ *         name: versionTime
+ *         required: false
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: Resolve the state of the DID as of this specific time.
+ *       - in: query
+ *         name: versionSequence
+ *         required: false
+ *         schema:
+ *           type: integer
+ *         description: Resolve a specific version of the DID Document.
+ *     responses:
+ *       200:
+ *         description: The DID Resolution result (standard triple).
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 didDocument:
+ *                   type: object
+ *                 didResolutionMetadata:
+ *                   type: object
+ *                 didDocumentMetadata:
+ *                   type: object
+ *       400:
+ *         description: The DID is syntactically invalid (error in didResolutionMetadata).
+ *       404:
+ *         description: The DID does not exist or cannot be resolved (error in didResolutionMetadata).
+ *       500:
+ *         description: Internal Server Error.
+ */
+identifiersRouter.get('/:did', async (req, res) => {
+    try {
+        const result = await resolveConformant(req);
+
+        if (!result.ok) {
+            // DID Resolution: errors are reported in didResolutionMetadata.
+            res.status(result.status).json({
+                didDocument: null,
+                didResolutionMetadata: result.didResolutionMetadata,
+                didDocumentMetadata: {},
+            });
+            return;
+        }
+
+        // Conformant result: only the standard triple. The method-specific data and
+        // registration objects are dereferenced via their own resource paths.
+        const { didDocument, didResolutionMetadata, didDocumentMetadata } = result.doc;
+        res.json({ didDocument, didResolutionMetadata, didDocumentMetadata });
+    } catch (error: any) {
+        res.status(404).send({ error: 'DID not found' });
+    }
+});
+
 /**
  * @swagger
  * /1.0/identifiers/{did}/data:
@@ -931,35 +1043,93 @@ v1router.get('/did/:did', async (req, res) => {
  */
 identifiersRouter.get('/:did/data', async (req, res) => {
     try {
-        // confirm/verify are not DID Core parameters. The conformant surface always
-        // returns confirmed, cryptographically verified state; callers needing raw or
-        // unconfirmed state use the internal /api/v1/did/:did endpoint.
-        const options: ResolveDIDOptions = { confirm: true, verify: true };
-        const { versionTime, versionSequence } = req.query;
+        const result = await resolveConformant(req);
 
-        if (typeof versionTime === 'string') {
-            options.versionTime = versionTime;
-        }
-
-        if (typeof versionSequence === 'string') {
-            const parsed = parseInt(versionSequence, 10);
-            if (!isNaN(parsed)) {
-                options.versionSequence = parsed;
-            }
-        }
-
-        const doc = await gatekeeper.resolveDID(req.params.did, options);
-
-        if (doc.didResolutionMetadata?.error) {
-            const error = doc.didResolutionMetadata.error;
-            const status = error === 'invalidDid' ? 400 : 404;
-            res.status(status).json({ error });
+        if (!result.ok) {
+            res.status(result.status).json({ error: result.didResolutionMetadata.error });
             return;
         }
 
         // Dereference the method-specific data resource (did:cid:<cid>/data).
         // Not part of the DID resolution result — returned as the resource itself.
-        res.json(doc.didDocumentData ?? {});
+        res.json(result.doc.didDocumentData ?? {});
+    } catch (error: any) {
+        res.status(404).send({ error: 'DID not found' });
+    }
+});
+
+/**
+ * @swagger
+ * /1.0/identifiers/{did}/registration:
+ *   get:
+ *     summary: Dereference the registration resource of a DID
+ *     description: >
+ *       Dereferences the method-specific registration/anchoring resource associated with a DID
+ *       (the DID URL `did:cid:<cid>/registration`). This is provenance about how and where the
+ *       DID was registered and anchored — it is NOT DID Core metadata and NOT part of the DID
+ *       resolution result. Standard document metadata (created, versionId, deactivated, etc.)
+ *       remains in `didDocumentMetadata` on the resolution result.
+ *     parameters:
+ *       - in: path
+ *         name: did
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The DID whose registration resource is dereferenced.
+ *       - in: query
+ *         name: versionTime
+ *         required: false
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: Dereference the registration as of this specific time.
+ *       - in: query
+ *         name: versionSequence
+ *         required: false
+ *         schema:
+ *           type: integer
+ *         description: Dereference the registration at a specific version of the DID Document.
+ *     responses:
+ *       200:
+ *         description: The dereferenced registration resource.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               description: Method-specific anchoring/provenance data.
+ *       400:
+ *         description: The DID is syntactically invalid.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *       404:
+ *         description: The DID does not exist or cannot be resolved.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *       500:
+ *         description: Internal Server Error.
+ */
+identifiersRouter.get('/:did/registration', async (req, res) => {
+    try {
+        const result = await resolveConformant(req);
+
+        if (!result.ok) {
+            res.status(result.status).json({ error: result.didResolutionMetadata.error });
+            return;
+        }
+
+        // Dereference the method-specific registration resource (did:cid:<cid>/registration).
+        // Not part of the DID resolution result — returned as the resource itself.
+        res.json(result.doc.didDocumentRegistration ?? {});
     } catch (error: any) {
         res.status(404).send({ error: 'DID not found' });
     }

--- a/services/gatekeeper/server/src/gatekeeper-api.ts
+++ b/services/gatekeeper/server/src/gatekeeper-api.ts
@@ -1165,6 +1165,13 @@ identifiersRouter.get('/:did/registration', async (req, res) => {
     }
 });
 
+// Any other path under /1.0/identifiers is not a supported DID URL resource for this method.
+// Return a structured JSON 404 (not Express's default HTML) so the conformant surface stays
+// consistent and matches the Rust implementation.
+identifiersRouter.use((req, res) => {
+    res.status(404).json({ error: 'notFound' });
+});
+
 /**
  * @swagger
  * /dids/:

--- a/tests/gatekeeper/api-parity-fixtures.json
+++ b/tests/gatekeeper/api-parity-fixtures.json
@@ -161,5 +161,12 @@
     "path": "/1.0/identifiers/did:cid:bafkreiawdmk6fmqc5p237vffyctazpzdgvgqfdj2i3hx2idtodxkwhyj5m/registration",
     "expectedStatus": 404,
     "compareMode": "json"
+  },
+  {
+    "name": "conformant-unsupported-path",
+    "method": "GET",
+    "path": "/1.0/identifiers/did:cid:bafkreiawdmk6fmqc5p237vffyctazpzdgvgqfdj2i3hx2idtodxkwhyj5m/bogus",
+    "expectedStatus": 404,
+    "compareMode": "json"
   }
 ]

--- a/tests/gatekeeper/api-parity-fixtures.json
+++ b/tests/gatekeeper/api-parity-fixtures.json
@@ -140,5 +140,26 @@
         "bafyreicidplaceholder"
       ]
     }
+  },
+  {
+    "name": "conformant-resolve-not-found",
+    "method": "GET",
+    "path": "/1.0/identifiers/did:cid:bafkreiawdmk6fmqc5p237vffyctazpzdgvgqfdj2i3hx2idtodxkwhyj5m",
+    "expectedStatus": 404,
+    "compareMode": "json"
+  },
+  {
+    "name": "conformant-dereference-data-not-found",
+    "method": "GET",
+    "path": "/1.0/identifiers/did:cid:bafkreiawdmk6fmqc5p237vffyctazpzdgvgqfdj2i3hx2idtodxkwhyj5m/data",
+    "expectedStatus": 404,
+    "compareMode": "json"
+  },
+  {
+    "name": "conformant-dereference-registration-not-found",
+    "method": "GET",
+    "path": "/1.0/identifiers/did:cid:bafkreiawdmk6fmqc5p237vffyctazpzdgvgqfdj2i3hx2idtodxkwhyj5m/registration",
+    "expectedStatus": 404,
+    "compareMode": "json"
   }
 ]

--- a/tests/gatekeeper/metrics-parity.json
+++ b/tests/gatekeeper/metrics-parity.json
@@ -16,6 +16,9 @@
     "/queue/:registry/clear",
     "/queue/:registry",
     "/events/:registry",
-    "/dids/"
+    "/dids/",
+    "/1.0/identifiers/:did",
+    "/1.0/identifiers/:did/data",
+    "/1.0/identifiers/:did/registration"
   ]
 }


### PR DESCRIPTION
## Summary

Adds the complete **standards-conformant DID resolution / dereferencing surface** for the `did:cid` method, exposed under the Universal Resolver driver convention `/1.0/identifiers`, across **both gatekeeper implementations (TypeScript + Rust)** and the public **Drawbridge** gateway, with the method spec and service specs updated to match. The internal `/api/v1/did/:did` family is **left untouched** for backwards compatibility.

**Why:** a DIF method-recommendation review flagged our resolution result as non-conformant — it carried two non-standard top-level members (`didDocumentData`, `didDocumentRegistration`) alongside the [DID Resolution](https://www.w3.org/TR/did-core/#did-resolution) triple. This surface returns the clean triple and exposes those two objects as **dereferenceable resources** instead.

## Endpoints (`/1.0/identifiers`)

| Route | Returns |
|---|---|
| `GET /1.0/identifiers/:did` | DID Resolution triple only: `didDocument`, `didResolutionMetadata`, `didDocumentMetadata` |
| `GET /1.0/identifiers/:did/data` | `didDocumentData` resource, raw (empty object for agent DIDs) |
| `GET /1.0/identifiers/:did/registration` | method-specific anchoring/provenance resource, raw |
| any other path under `/1.0/identifiers` | `404 {"error":"notFound"}` (structured, consistent across TS/Rust) |

## Design

- **Content-addressed dereferencing.** `did:cid` is content-addressed (the DID is the CID of the create op), so `data`/`registration` are retrieved by content — not via a `service` endpoint / external location.
- **Thin reshapers over the existing resolver** — no change to core resolution logic (`gatekeeper.ts` / `resolver.rs` untouched); reshaping happens at the HTTP boundary.
- **`confirm`/`verify` are not DID Core params**, so they are not exposed; the surface hard-codes `{ confirm: true, verify: true }` (always confirmed, cryptographically verified state). The create event is always confirmed, so freshly created DIDs still resolve — only pending updates are withheld. Raw/unconfirmed state stays on `/api/v1/did/:did`.
- **Local-only.** The conformant surface does NOT delegate to the universal-resolver `fallbackURL` or the confirmed-Gatekeeper peer on a local miss (unlike `/api/v1/did/:did`) — it is the node's own UR *driver* surface, and delegating to the default `fallbackURL` (itself a Universal Resolver) could form a resolution loop. Documented in service spec §2.6.
- **Standard version selectors** (`versionTime`, `versionSequence`) honored. Errors reported in `didResolutionMetadata` for `/:did` (`invalidDid`→400, `notFound`→404) per the DID Resolution data model.

## Surfaces changed

- **TS gatekeeper** (`services/gatekeeper/server/src/gatekeeper-api.ts`) — new `identifiersRouter`, shared `resolveConformant()` helper, `classifyResolveError()` (validation failure → 404 `notFound`; unexpected → 500 `internalError`, logged), structured-404 catch-all, `normalizePath` collapse for `/identifiers/:did` (incl. percent-encoded `did%3A`). OpenAPI regenerated.
- **Rust gatekeeper** (`rust/services/gatekeeper/`) — mirror implementation: three handlers + `resolve_conformant()` + `conformant_not_found` fallback, nested `/1.0/identifiers` router, `normalize_path` parity. Note: Rust uses type-erased errors and maps unexpected failures to `notFound` rather than 500 `internalError` (spec §2.6 SHOULD; follow-up #679).
- **Drawbridge** (`services/drawbridge/server/src/drawbridge-api.ts`) — Drawbridge (the public L402+Tor gateway) whitelists gatekeeper routes under `/api/v1`, so the conformant surface was publicly unreachable. Added a top-level `/1.0/identifiers` mount that **raw-proxies** verbatim to the gatekeeper (preserving its conformant output; the typed client would return the full internal doc). **Open / no L402** — public DID resolution for universal resolvers, which don't speak L402. `normalizePath` updated.
- **Method spec** (`docs/scheme.md`) — DID Core 1.0: dropped the pre-1.0 `;service` matrix param; added DID URL Syntax + DID URL Dereferencing sections (path/query/fragment; fragments client-side); resolution documented as the triple + endpoints table; revocation example fixed.
- **Service spec** (`docs/services/gatekeeper/README.md`) — new §2.6 (conformant surface) + §6.5 (result shape), local-only note, error semantics.
- **Drawbridge spec** (`docs/services/drawbridge/README.md`) + **nginx example** — document the public proxied route.
- **Parity fixtures** (`tests/gatekeeper/`) — notFound + unsupported-path fixtures and the three normalized metric routes for the manual `gatekeeper-parity` harness.

## Live verification

Confirmed end-to-end through Drawbridge (`curl → :4222 → gatekeeper`):
- base resolve → clean triple, no leaked members;
- `/data` (agent) → `{}`;
- `/registration` → `{ "version": 1, "type": "agent", "registry": "BTC:mainnet" }`.

## Closes

Closes #671. Closes #672. Closes #673.

## Follow-ups (tracked, out of scope)

- #677 — supertest HTTP harness for gatekeeper-api (no HTTP-level unit tests exist today; handlers are thin reshapers over the tested resolver).
- #678 — pre-existing Rust `verify_event_shape` lib-test failure (fails on `main`; unrelated).
- #679 — Rust typed-error refactor to reach 500 `internalError` parity with TS.

## Testing

- TS: `tsc --noEmit` + `eslint` clean; OpenAPI regenerates additively.
- Rust: `cargo build` clean; `normalize_path` unit test extended (incl. percent-encoded + `/1.0/identifiers` cases) and passing.
- Parity fixtures added but **not** auto-run (the parity harness is manual, not per-PR CI) — validate with a live TS-vs-Rust diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)