### PR TITLE
test(rust-gatekeeper): fix verify_event_shape registry-format test expectation

### DIFF
--- a/rust/services/gatekeeper/src/lib.rs
+++ b/rust/services/gatekeeper/src/lib.rs
@@ -560,8 +560,11 @@ mod tests {
         assert!(verify_event_shape(&valid_update));
         assert!(verify_event_shape(&valid_delete));
 
+        // Registry-name validation is a *format* check (spec §8.5: `[A-Za-z0-9][A-Za-z0-9:_-]*`),
+        // not a supported-registry lookup. "not-a-registry" is format-valid (hyphens are allowed),
+        // so use a name that actually violates the format — here, one containing a space.
         let mut invalid_registry = valid_create.clone();
-        invalid_registry["registry"] = Value::String("not-a-registry".to_string());
+        invalid_registry["registry"] = Value::String("not a registry".to_string());
         assert!(!verify_event_shape(&invalid_registry));
 
         let mut missing_time = valid_create.clone();


### PR DESCRIPTION
## Summary

Closes #678. Fixes the pre-existing `cargo test --lib` failure in the Rust gatekeeper:

```
assertion failed: !verify_event_shape(&invalid_registry)   (src/lib.rs)
```

## Root cause

The test set `registry = "not-a-registry"` and expected `verify_event_shape` to reject it. But event-shape validation checks the registry **name format** — per [service spec §8.5](../blob/main/docs/services/gatekeeper/README.md), `[A-Za-z0-9][A-Za-z0-9:_-]*` (max 128 chars), where **hyphens are allowed**. `is_valid_registry` implements exactly that regex, so `"not-a-registry"` is a *format-valid* name and is correctly accepted — making the assertion fail.

Shape validation is a pure format check; whether a registry is *supported* is enforced separately (during `importEvent` / operation verification), not here.

## Fix

The implementation is correct — the **test expectation was wrong**. Changed the case to a genuinely format-invalid name (one containing a space, `"not a registry"`), so it tests what it intended (registry name-format rejection). Added a comment so it isn't "corrected" back to a valid-looking name.

## Testing

- `cargo test --lib`: **24 passed, 0 failed** (was 23 passed / 1 failed on `main`).

Surfaced during the did:cid `/1.0/identifiers` work (#676); this failure was pre-existing and unrelated to that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)