### PR TITLE
fix(rust-gatekeeper): return 400 invalidDid for a malformed-CID DID

### DIFF
--- a/rust/services/gatekeeper/src/lib.rs
+++ b/rust/services/gatekeeper/src/lib.rs
@@ -19,7 +19,7 @@ pub(crate) use events::{
 pub(crate) use metrics::{normalize_path, record_metrics, Metrics};
 pub(crate) use proofs::{
     ensure_event_opid, generate_did_from_operation, generate_json_cid, infer_event_did,
-    verify_create_operation_impl, verify_event_shape, verify_operation_impl,
+    is_valid_did, verify_create_operation_impl, verify_event_shape, verify_operation_impl,
     verify_update_operation_impl,
 };
 pub(crate) use resolver::{
@@ -334,20 +334,39 @@ mod tests {
     }
 
     #[test]
+    fn is_valid_did_requires_a_parseable_cid_suffix() {
+        assert!(is_valid_did(
+            "did:cid:bafkreiawdmk6fmqc5p237vffyctazpzdgvgqfdj2i3hx2idtodxkwhyj5m"
+        ));
+        // Not a DID / too few segments.
+        assert!(!is_valid_did("notadid"));
+        assert!(!is_valid_did("did:cid"));
+        // did: prefix but a malformed CID suffix.
+        assert!(!is_valid_did("did:cid:xyz"));
+        assert!(!is_valid_did("did:cid:not-a-valid-cid"));
+    }
+
+    #[test]
     fn classify_conformant_error_distinguishes_did_failures_from_internal() {
         // Malformed DID syntax -> 400 invalidDid (regardless of the underlying error).
         assert_eq!(
             classify_conformant_error("notadid", &anyhow::anyhow!("boom")),
             (400, "invalidDid")
         );
+        // A `did:` DID whose CID suffix is malformed is invalidDid (400), not notFound — even
+        // though resolution would fail as notFound, the DID-syntax check takes precedence (#686).
+        assert_eq!(
+            classify_conformant_error("did:cid:xyz", &ResolveError::NotFound.into()),
+            (400, "invalidDid")
+        );
         // A tagged resolution failure -> 404 notFound.
         assert_eq!(
-            classify_conformant_error("did:cid:bagaaieratest", &ResolveError::NotFound.into()),
+            classify_conformant_error("did:cid:bafkreiawdmk6fmqc5p237vffyctazpzdgvgqfdj2i3hx2idtodxkwhyj5m", &ResolveError::NotFound.into()),
             (404, "notFound")
         );
         assert_eq!(
             classify_conformant_error(
-                "did:cid:bagaaieratest",
+                "did:cid:bafkreiawdmk6fmqc5p237vffyctazpzdgvgqfdj2i3hx2idtodxkwhyj5m",
                 &ResolveError::InvalidOperation.into()
             ),
             (404, "notFound")
@@ -355,21 +374,21 @@ mod tests {
         // A ResolveError anywhere in the cause chain is still recognized (e.g. wrapped by context).
         let wrapped = anyhow::Error::from(ResolveError::NotFound).context("while resolving");
         assert_eq!(
-            classify_conformant_error("did:cid:bagaaieratest", &wrapped),
+            classify_conformant_error("did:cid:bafkreiawdmk6fmqc5p237vffyctazpzdgvgqfdj2i3hx2idtodxkwhyj5m", &wrapped),
             (404, "notFound")
         );
         // A verify-layer validation error carrying the "Invalid operation" convention (no typed
         // ResolveError, e.g. a malformed proof value surfaced from proofs.rs) is still DID-level.
         assert_eq!(
             classify_conformant_error(
-                "did:cid:bagaaieratest",
+                "did:cid:bafkreiawdmk6fmqc5p237vffyctazpzdgvgqfdj2i3hx2idtodxkwhyj5m",
                 &anyhow::anyhow!("Invalid operation: proof")
             ),
             (404, "notFound")
         );
         // An untagged error (I/O, crypto, unexpected) -> 500 internalError.
         assert_eq!(
-            classify_conformant_error("did:cid:bagaaieratest", &anyhow::anyhow!("db unreachable")),
+            classify_conformant_error("did:cid:bafkreiawdmk6fmqc5p237vffyctazpzdgvgqfdj2i3hx2idtodxkwhyj5m", &anyhow::anyhow!("db unreachable")),
             (500, "internalError")
         );
     }

--- a/rust/services/gatekeeper/src/proofs.rs
+++ b/rust/services/gatekeeper/src/proofs.rs
@@ -16,13 +16,12 @@ pub(crate) fn is_valid_did(did: &str) -> bool {
     if !did.starts_with("did:") {
         return false;
     }
-    let parts: Vec<&str> = did.split(':').collect();
-    if parts.len() < 3 {
+    if did.split(':').count() < 3 {
         return false;
     }
-    parts
-        .last()
-        .map(|suffix| Cid::try_from(*suffix).is_ok())
+    did.rsplit(':')
+        .next()
+        .map(|suffix| Cid::try_from(suffix).is_ok())
         .unwrap_or(false)
 }
 

--- a/rust/services/gatekeeper/src/proofs.rs
+++ b/rust/services/gatekeeper/src/proofs.rs
@@ -8,6 +8,24 @@ use serde_json::Value;
 
 use crate::{is_valid_registry, resolve_local_doc_async, AppState, Config, ResolveOptions};
 
+/// Validate a `did:<method>:<cid>` DID, mirroring the TypeScript `isValidDID`: the string must
+/// start with `did:`, have at least three `:`-separated segments, and its final segment must parse
+/// as a valid CID. Lets the conformant surface return 400 `invalidDid` (rather than 404) for a
+/// syntactically-`did:` DID whose CID suffix is malformed.
+pub(crate) fn is_valid_did(did: &str) -> bool {
+    if !did.starts_with("did:") {
+        return false;
+    }
+    let parts: Vec<&str> = did.split(':').collect();
+    if parts.len() < 3 {
+        return false;
+    }
+    parts
+        .last()
+        .map(|suffix| Cid::try_from(*suffix).is_ok())
+        .unwrap_or(false)
+}
+
 pub(crate) fn infer_event_did(config: &Config, event: &Value) -> Result<String> {
     if let Some(did) = event.get("did").and_then(Value::as_str) {
         return Ok(did.to_string());

--- a/rust/services/gatekeeper/src/resolver.rs
+++ b/rust/services/gatekeeper/src/resolver.rs
@@ -8,8 +8,8 @@ use tracing::info;
 
 use crate::store::ResolvedDoc;
 use crate::{
-    chrono_like_now, generate_json_cid, verify_create_operation_impl, verify_update_operation_impl,
-    AppState, EventRecord, GatekeeperDb, ResolveOptions,
+    chrono_like_now, generate_json_cid, is_valid_did, verify_create_operation_impl,
+    verify_update_operation_impl, AppState, EventRecord, GatekeeperDb, ResolveOptions,
 };
 
 /// Typed classes for resolution failures that are the DID's own problem (a missing DID or an
@@ -59,7 +59,7 @@ pub(crate) fn classify_conformant_error(did: &str, error: &anyhow::Error) -> (u1
         cause.is::<ResolveError>() || cause.to_string().starts_with("Invalid operation")
     });
 
-    if !did.starts_with("did:") {
+    if !is_valid_did(did) {
         (400, "invalidDid")
     } else if is_did_level {
         (404, "notFound")

--- a/tests/gatekeeper/api-parity-fixtures.json
+++ b/tests/gatekeeper/api-parity-fixtures.json
@@ -168,5 +168,12 @@
     "path": "/1.0/identifiers/did:cid:bafkreiawdmk6fmqc5p237vffyctazpzdgvgqfdj2i3hx2idtodxkwhyj5m/bogus",
     "expectedStatus": 404,
     "compareMode": "json"
+  },
+  {
+    "name": "conformant-resolve-invalid-cid",
+    "method": "GET",
+    "path": "/1.0/identifiers/did:cid:xyz",
+    "expectedStatus": 400,
+    "compareMode": "json"
   }
 ]


### PR DESCRIPTION
## Summary

Closes #686. Brings the Rust gatekeeper's `/1.0/identifiers` surface to `invalidDid` parity with the TypeScript reference for malformed-CID DIDs.

**Before:** a syntactically-`did:` DID with a bad CID suffix (e.g. `did:cid:xyz`) returned **`404 notFound`** in Rust but **`400 invalidDid`** in TS — Rust's `classify_conformant_error` only checked the `did:` prefix, whereas TS validates the CID (`isValidDID` → `isValidCID`).

## Fix

- Add **`is_valid_did`** (`proofs.rs`) mirroring the TS rule: `did:` prefix, ≥3 `:`-separated segments, and the final segment parses as a CID (via the `cid` crate already used for DID generation).
- Use it in `classify_conformant_error` in place of the `did.starts_with("did:")` check. The DID-syntax check takes precedence, so a malformed-CID DID → `400 invalidDid` regardless of the underlying resolution error.

Behavior now matches TS: `notadid` → 400, `did:cid:<malformed>` → 400, valid-but-nonexistent CID → 404 notFound (unchanged).

## Testing

- New unit test `is_valid_did_requires_a_parseable_cid_suffix`.
- Classifier test updated: uses a real CID for the notFound/internal cases and adds a malformed-CID → 400 assertion.
- Parity fixture `conformant-resolve-invalid-cid` (`did:cid:xyz` → 400) — both implementations now agree.
- `cargo test --lib`: **26 passed, 0 failed**; `cargo clippy` clean.

Follow-up to #676 / #685; last of the did:cid conformance follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)