### PR TITLE
fix(satoshi-mediator): re-point registered[] at live txid on RBF bump

### DIFF
--- a/services/mediators/satoshi/src/satoshi-mediator.ts
+++ b/services/mediators/satoshi/src/satoshi-mediator.ts
@@ -988,6 +988,12 @@ async function replaceByFee(): Promise<boolean> {
             if (db.pending?.txids) {
                 db.pending.txids.push(newTxid);
             }
+            // RBF just superseded `txid`. Re-point the registered anchor at the live txid so
+            // registered[] stays ground truth and doesn't retain orphaned RBF-dropped txids.
+            const registeredEntry = db.registered?.find((r) => r.txid === txid);
+            if (registeredEntry) {
+                registeredEntry.txid = newTxid;
+            }
         });
     }
 


### PR DESCRIPTION
## Summary

Closes #689. `satoshi-mediator`'s `registered[]` retained orphaned, RBF-superseded txids indefinitely.

## Root cause

`RegisteredItem` (`{ did, txid }`) is written once at anchor time with the initial broadcast txid:
```js
(db.registered ??= []).push({ did, txid });
db.pending = { txids: [txid], blockCount };
```
When RBF bumps the fee, the new txid is appended to `pending.txids` but `registered[]` is **never updated** — so once the old txid is dropped from mempool (RBF-superseded) and the new one confirms, the entry keeps pointing at the dead txid. Those orphans accumulate.

## Fix (issue's "cleaner" approach)

The RBF path already has both the superseded txid (`txid`, from `getEntryFromMempool`) and its replacement (`newTxid`), so re-point the registered entry in the same `updateDb` block:
```js
const registeredEntry = db.registered?.find((r) => r.txid === txid);
if (registeredEntry) registeredEntry.txid = newTxid;
```
This chains correctly across multiple bumps (`orig → bump1 → bump2 …`), because each cycle bumps the current live txid — which is exactly what the entry now holds. `registered[]` stays ground truth for landed anchors. No schema change, no new network calls.

## Scope / caveats

- **Prevents future RBF orphans.** It does not retroactively remove rows orphaned before this fix; those are a one-time, cosmetic (per the issue's own "Impact") data cleanup the operator does by hand (the 4 known txids are enumerated in #689). We deliberately did **not** add a permanent GC/sweep pass, since post-fix it would have nothing ongoing to do and carries false-eviction risk.
- **Testing:** the satoshi mediator has no existing test harness (the module has import-time side effects; only the pinning/filecoin mediators are unit-tested). The change is minimal, sits beside the adjacent `pending.txids` update, and is `tsc` + `eslint` verified. Happy to add a mediator test harness as a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)