### PR TITLE
fix(compose): CLN rune-init containers must use the same image as the node

### DIFF
--- a/docker/compose/lightning.yml
+++ b/docker/compose/lightning.yml
@@ -1,7 +1,12 @@
+# Shared CLN image. The node and its one-shot rune-init containers (drawbridge-init,
+# rtl-init, lnbits-init) MUST run the same image so the init `lightning-cli` always
+# matches the running lightningd. Bump ARCHON_CLN_VERSION to move all of them together.
+x-cln-image: &cln-image ghcr.io/lightning-goats/cl-hive-node:${ARCHON_CLN_VERSION:-3.4.0}
+
 services:
   cln-mainnet-node:
     profiles: ["lightning", "drawbridge"]
-    image: ghcr.io/lightning-goats/cl-hive-node:${ARCHON_CLN_VERSION:-3.4.0}
+    image: *cln-image
     environment:
       - NETWORK=bitcoin
       - ALIAS=${ARCHON_CLN_ALIAS:-archon}
@@ -32,7 +37,7 @@ services:
 
   drawbridge-init:
     profiles: ["lightning", "drawbridge"]
-    image: ghcr.io/archetech/cl-hive-node:${ARCHON_CLN_VERSION:-2.13.2}
+    image: *cln-image
     entrypoint: ["/bin/bash", "-c"]
     command:
       - |
@@ -76,7 +81,7 @@ services:
 
   rtl-init:
     profiles: ["lightning", "drawbridge"]
-    image: ghcr.io/archetech/cl-hive-node:${ARCHON_CLN_VERSION:-2.13.2}
+    image: *cln-image
     entrypoint: ["/bin/bash", "-c"]
     command:
       - |
@@ -140,7 +145,7 @@ services:
 
   lnbits-init:
     profiles: ["lightning", "drawbridge"]
-    image: ghcr.io/archetech/cl-hive-node:${ARCHON_CLN_VERSION:-2.13.2}
+    image: *cln-image
     entrypoint: ["/bin/bash", "-c"]
     command:
       - |


### PR DESCRIPTION
## Summary

In `docker/compose/lightning.yml`, the CLN node and its one-shot rune-init containers ran **different images**:

| Service | Image | Default tag |
|---|---|---|
| `cln-mainnet-node` | `ghcr.io/lightning-goats/cl-hive-node` | `3.4.0` |
| `drawbridge-init` / `rtl-init` / `lnbits-init` | `ghcr.io/archetech/cl-hive-node` | `2.13.2` |

Both interpolate the **same** `${ARCHON_CLN_VERSION}` but with different defaults, from different registries (upstream vs. an archetech fork) on **different versioning schemes** (3.x vs 2.x).

Consequences:
- The init containers' `lightning-cli` comes from a *different fork/version* than the running `lightningd` it drives (`getinfo`/`createrune`) — latent version skew.
- Setting `ARCHON_CLN_VERSION` to a node tag (e.g. `3.4.0`) would make the init containers try to pull `archetech/cl-hive-node:3.4.0`, which doesn't exist.
- `ghcr.io/archetech/cl-hive-node:2.13.2` isn't publicly resolvable (private/removed), while the node's `lightning-goats/cl-hive-node:3.4.0` is public.

## Fix

Add a shared `x-cln-image` YAML anchor pointing at the node's image and reference it from the node **and** all three init containers, so:
- the init `lightning-cli` always matches the running `lightningd` (same image), and
- `ARCHON_CLN_VERSION` moves all four together (single source of truth).

The unrelated `rtl` (`shahanafarooqui/rtl`) and `lnbits` (`archetech/lnbits`) images are unchanged.

## Verification

- Pulled `ghcr.io/lightning-goats/cl-hive-node:3.4.0` and confirmed it ships `bash`, `python3`, and `lightning-cli` — everything the init scripts use.
- `docker compose -f docker/compose/lightning.yml --profile drawbridge config` resolves all four CLN services to `ghcr.io/lightning-goats/cl-hive-node:3.4.0`; no `archetech/cl-hive-node` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)