### PR TITLE
fix: did:cid universal resolver responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ These rules apply to coding agents working in this repository.
 - For GitHub operations in this repo, use `gh` by default, especially for write actions and PR creation. Do not try the GitHub app first and then fall back to `gh` unless the user explicitly asks for the app or `gh` cannot perform the operation.
 - When generating or updating npm lockfiles, use the repo-pinned npm version from the root `package.json` so lockfiles stay compatible with CI.
 - For repo-wide version sweeps, search tracked files with `git ls-files` rather than raw filesystem traversal so local `node_modules`, `data`, and build outputs cannot pollute the bump.
+- For focused Rust Gatekeeper fixes, avoid broad `cargo fmt` churn if the crate has pre-existing formatting drift; format only touched code or trim unrelated rustfmt changes before committing.
 - Internal service-to-service admin auth should use `X-Archon-Admin-Key` consistently. Reserve `Authorization` for user/session/OAuth-style flows unless a file explicitly documents a different scheme.
 - Drawbridge's bundled Tor SOCKS host port should default to `127.0.0.1:9050`; internal services should keep using the Docker network address `tor:9050`.
 - Keymaster's Docker host port should default to localhost via `ARCHON_KEYMASTER_HOST_BIND=127.0.0.1`; internal services should keep using `keymaster:4226`.

--- a/docs/gatekeeper-api.json
+++ b/docs/gatekeeper-api.json
@@ -2316,7 +2316,23 @@
           "200": {
             "description": "The DID Resolution result (standard triple).",
             "content": {
-              "application/json": {
+              "application/did+ld+json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "didDocument": {
+                      "type": "object"
+                    },
+                    "didResolutionMetadata": {
+                      "type": "object"
+                    },
+                    "didDocumentMetadata": {
+                      "type": "object"
+                    }
+                  }
+                }
+              },
+              "application/did+json": {
                 "schema": {
                   "type": "object",
                   "properties": {

--- a/docs/services/gatekeeper/README.md
+++ b/docs/services/gatekeeper/README.md
@@ -646,7 +646,7 @@ by the DID Resolution data model:
 ```jsonc
 {
   "didDocument": { /* ... */ },
-  "didResolutionMetadata": { "retrieved": "<RFC 3339>" },
+  "didResolutionMetadata": { "contentType": "application/did+ld+json" },
   "didDocumentMetadata": {
     "created": "<RFC 3339>",
     "versionId": "<CID>",
@@ -656,6 +656,13 @@ by the DID Resolution data model:
   }
 }
 ```
+
+`Accept: application/did+json` and `Accept: application/did+ld+json` are
+honored for successful resolution responses. The selected representation is
+returned as both the HTTP `Content-Type` and
+`didResolutionMetadata.contentType`. Volatile fields such as
+`didResolutionMetadata.retrieved` are omitted from this surface so generated
+W3C DID test-suite fixtures remain stable.
 
 `didDocumentData` and `didDocumentRegistration` (present inline in the
 internal [`DidCidDocument`](#37-didciddocument-resolution-result)) MUST be

--- a/rust/services/gatekeeper/src/api.rs
+++ b/rust/services/gatekeeper/src/api.rs
@@ -1336,23 +1336,28 @@ fn preferred_did_content_type(headers: &HeaderMap) -> &'static str {
 
 fn accept_quality(accept: &str, candidate: &str) -> Option<(f32, usize)> {
     let mut best = None;
+    let normalized_candidate = candidate.to_ascii_lowercase();
 
     for (order, part) in accept.split(',').enumerate() {
-        let mut media = "";
+        let mut media = String::new();
         let mut q = 1.0_f32;
 
         for (index, segment) in part.split(';').enumerate() {
             let segment = segment.trim();
             if index == 0 {
-                media = segment;
+                media = segment.to_ascii_lowercase();
                 continue;
             }
-            if let Some(raw_q) = segment.strip_prefix("q=") {
+            if let Some(raw_q) = segment
+                .strip_prefix("q=")
+                .or_else(|| segment.strip_prefix("Q="))
+            {
                 q = raw_q.parse::<f32>().unwrap_or(0.0);
             }
         }
 
-        let matches = media == candidate || media == "application/*" || media == "*/*";
+        let matches =
+            media == normalized_candidate || media == "application/*" || media == "*/*";
         if !matches || q <= 0.0 {
             continue;
         }
@@ -1377,6 +1382,7 @@ fn json_response_with_content_type(
         Ok(body) => Response::builder()
             .status(status)
             .header(header::CONTENT_TYPE, content_type)
+            .header(header::VARY, "Accept")
             .body(Body::from(body))
             .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()),
         Err(error) => {

--- a/rust/services/gatekeeper/src/api.rs
+++ b/rust/services/gatekeeper/src/api.rs
@@ -1247,17 +1247,29 @@ async fn resolve_conformant(
 pub(crate) async fn conformant_resolve_did(
     State(state): State<AppState>,
     Path(did): Path<String>,
+    headers: HeaderMap,
     Query(query): Query<HashMap<String, String>>,
 ) -> Response {
     let start = Instant::now();
     match resolve_conformant(&state, &did, &query).await {
         Ok(doc) => {
+            let content_type = preferred_did_content_type(&headers);
+            let mut did_resolution_metadata = doc
+                .get("didResolutionMetadata")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            if let Some(metadata) = did_resolution_metadata.as_object_mut() {
+                metadata.remove("retrieved");
+                metadata.insert(
+                    "contentType".to_string(),
+                    Value::String(content_type.to_string()),
+                );
+            } else {
+                did_resolution_metadata = json!({ "contentType": content_type });
+            }
             let triple = json!({
                 "didDocument": doc.get("didDocument").cloned().unwrap_or(Value::Null),
-                "didResolutionMetadata": doc
-                    .get("didResolutionMetadata")
-                    .cloned()
-                    .unwrap_or_else(|| json!({})),
+                "didResolutionMetadata": did_resolution_metadata,
                 "didDocumentMetadata": doc
                     .get("didDocumentMetadata")
                     .cloned()
@@ -1270,7 +1282,7 @@ pub(crate) async fn conformant_resolve_did(
                 200,
                 start.elapsed().as_secs_f64(),
             );
-            Json(triple).into_response()
+            json_response_with_content_type(StatusCode::OK, triple, content_type)
         }
         Err((status, error_kind)) => {
             record_metrics(
@@ -1290,6 +1302,86 @@ pub(crate) async fn conformant_resolve_did(
                 })),
             )
                 .into_response()
+        }
+    }
+}
+
+fn preferred_did_content_type(headers: &HeaderMap) -> &'static str {
+    const DID_LD_JSON: &str = "application/did+ld+json";
+    const DID_JSON: &str = "application/did+json";
+
+    let Some(accept) = headers
+        .get(header::ACCEPT)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return DID_LD_JSON;
+    };
+
+    let ld = accept_quality(accept, DID_LD_JSON);
+    let json = accept_quality(accept, DID_JSON);
+
+    match (ld, json) {
+        (Some((ld_q, ld_order)), Some((json_q, json_order))) => {
+            if json_q > ld_q || (json_q == ld_q && json_order < ld_order) {
+                DID_JSON
+            } else {
+                DID_LD_JSON
+            }
+        }
+        (Some(_), None) => DID_LD_JSON,
+        (None, Some(_)) => DID_JSON,
+        (None, None) => DID_LD_JSON,
+    }
+}
+
+fn accept_quality(accept: &str, candidate: &str) -> Option<(f32, usize)> {
+    let mut best = None;
+
+    for (order, part) in accept.split(',').enumerate() {
+        let mut media = "";
+        let mut q = 1.0_f32;
+
+        for (index, segment) in part.split(';').enumerate() {
+            let segment = segment.trim();
+            if index == 0 {
+                media = segment;
+                continue;
+            }
+            if let Some(raw_q) = segment.strip_prefix("q=") {
+                q = raw_q.parse::<f32>().unwrap_or(0.0);
+            }
+        }
+
+        let matches = media == candidate || media == "application/*" || media == "*/*";
+        if !matches || q <= 0.0 {
+            continue;
+        }
+
+        if best
+            .map(|(best_q, best_order)| q > best_q || (q == best_q && order < best_order))
+            .unwrap_or(true)
+        {
+            best = Some((q, order));
+        }
+    }
+
+    best
+}
+
+fn json_response_with_content_type(
+    status: StatusCode,
+    value: Value,
+    content_type: &'static str,
+) -> Response {
+    match serde_json::to_vec(&value) {
+        Ok(body) => Response::builder()
+            .status(status)
+            .header(header::CONTENT_TYPE, content_type)
+            .body(Body::from(body))
+            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()),
+        Err(error) => {
+            error!("failed to serialize JSON response: {error}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
     }
 }

--- a/rust/services/gatekeeper/tests/http_contract.rs
+++ b/rust/services/gatekeeper/tests/http_contract.rs
@@ -149,6 +149,13 @@ async fn universal_resolver_surface_returns_fixture_stable_did_resolution_result
             .and_then(|value| value.to_str().ok()),
         Some("application/did+ld+json")
     );
+    assert_eq!(
+        response
+            .headers()
+            .get("vary")
+            .and_then(|value| value.to_str().ok()),
+        Some("Accept")
+    );
     let doc = response.json::<Value>().await?;
     let object = doc.as_object().unwrap();
     assert_eq!(object.len(), 3);
@@ -165,7 +172,7 @@ async fn universal_resolver_surface_returns_fixture_stable_did_resolution_result
     let response = service
         .client
         .get(format!("{}/1.0/identifiers/{did}", service.root_url))
-        .header("accept", "application/did+json")
+        .header("accept", "Application/DID+JSON;Q=1, application/did+ld+json;q=0.5")
         .send()
         .await?;
     assert!(response.status().is_success());
@@ -175,6 +182,13 @@ async fn universal_resolver_surface_returns_fixture_stable_did_resolution_result
             .get("content-type")
             .and_then(|value| value.to_str().ok()),
         Some("application/did+json")
+    );
+    assert_eq!(
+        response
+            .headers()
+            .get("vary")
+            .and_then(|value| value.to_str().ok()),
+        Some("Accept")
     );
     let doc = response.json::<Value>().await?;
     assert_eq!(

--- a/rust/services/gatekeeper/tests/http_contract.rs
+++ b/rust/services/gatekeeper/tests/http_contract.rs
@@ -117,6 +117,75 @@ async fn http_contract_covers_ready_version_status_admin_and_metrics() -> Result
 }
 
 #[tokio::test]
+async fn universal_resolver_surface_returns_fixture_stable_did_resolution_result() -> Result<()> {
+    let service = spawn_json().await?;
+    let create = create_agent_operation(21, "2026-04-11T12:03:00Z", "local");
+
+    let response = service
+        .client
+        .post(format!("{}/did", service.base_url))
+        .json(&create)
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+    let did = response
+        .json::<Value>()
+        .await?
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let response = service
+        .client
+        .get(format!("{}/1.0/identifiers/{did}", service.root_url))
+        .header("accept", "application/did+ld+json")
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("application/did+ld+json")
+    );
+    let doc = response.json::<Value>().await?;
+    let object = doc.as_object().unwrap();
+    assert_eq!(object.len(), 3);
+    assert_eq!(doc["didDocument"]["id"], did);
+    assert_eq!(
+        doc["didResolutionMetadata"]["contentType"],
+        "application/did+ld+json"
+    );
+    assert!(doc["didResolutionMetadata"].get("retrieved").is_none());
+    assert_eq!(doc["didDocumentMetadata"]["confirmed"], true);
+    assert!(doc.get("didDocumentData").is_none());
+    assert!(doc.get("didDocumentRegistration").is_none());
+
+    let response = service
+        .client
+        .get(format!("{}/1.0/identifiers/{did}", service.root_url))
+        .header("accept", "application/did+json")
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("application/did+json")
+    );
+    let doc = response.json::<Value>().await?;
+    assert_eq!(
+        doc["didResolutionMetadata"]["contentType"],
+        "application/did+json"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn http_contract_matches_resolution_error_and_supported_registry_semantics() -> Result<()> {
     let service = spawn_json().await?;
 

--- a/services/gatekeeper/server/src/identifiers-router.ts
+++ b/services/gatekeeper/server/src/identifiers-router.ts
@@ -16,6 +16,66 @@ function classifyResolveError(error: unknown): { status: number; resolutionError
     return { status: 500, resolutionError: 'internalError' };
 }
 
+const DID_LD_JSON = 'application/did+ld+json';
+const DID_JSON = 'application/did+json';
+
+function preferredDidContentType(req: express.Request): typeof DID_LD_JSON | typeof DID_JSON {
+    const accept = req.get('accept');
+
+    if (!accept) {
+        return DID_LD_JSON;
+    }
+
+    const ld = acceptQuality(accept, DID_LD_JSON);
+    const json = acceptQuality(accept, DID_JSON);
+
+    if (ld && json) {
+        return json.quality > ld.quality || (json.quality === ld.quality && json.order < ld.order)
+            ? DID_JSON
+            : DID_LD_JSON;
+    }
+    if (json) {
+        return DID_JSON;
+    }
+    return DID_LD_JSON;
+}
+
+function acceptQuality(accept: string, candidate: string): { quality: number; order: number } | undefined {
+    let best: { quality: number; order: number } | undefined;
+
+    accept.split(',').forEach((part, order) => {
+        const [rawMedia, ...params] = part.split(';');
+        const media = rawMedia.trim();
+        let quality = 1;
+
+        for (const param of params) {
+            const trimmed = param.trim();
+            if (trimmed.startsWith('q=')) {
+                quality = Number.parseFloat(trimmed.slice(2));
+                if (Number.isNaN(quality)) {
+                    quality = 0;
+                }
+            }
+        }
+
+        const matches = media === candidate || media === 'application/*' || media === '*/*';
+        if (!matches || quality <= 0) {
+            return;
+        }
+
+        if (!best || quality > best.quality || (quality === best.quality && order < best.order)) {
+            best = { quality, order };
+        }
+    });
+
+    return best;
+}
+
+function sendDidResolutionJson(res: express.Response, contentType: string, body: unknown): void {
+    res.set('Content-Type', contentType);
+    res.end(JSON.stringify(body));
+}
+
 /**
  * Build the standards-conformant DID resolution / dereferencing router, mounted at
  * `/1.0/identifiers` following the Universal Resolver driver convention. Extracted into a
@@ -134,7 +194,16 @@ export function createIdentifiersRouter(
             // Conformant result: only the standard triple. The method-specific data and
             // registration objects are dereferenced via their own resource paths.
             const { didDocument, didResolutionMetadata, didDocumentMetadata } = result.doc;
-            res.json({ didDocument, didResolutionMetadata, didDocumentMetadata });
+            const contentType = preferredDidContentType(req);
+            const stableDidResolutionMetadata = { ...(didResolutionMetadata ?? {}) };
+            delete stableDidResolutionMetadata.retrieved;
+            stableDidResolutionMetadata.contentType = contentType;
+
+            sendDidResolutionJson(res, contentType, {
+                didDocument,
+                didResolutionMetadata: stableDidResolutionMetadata,
+                didDocumentMetadata,
+            });
         } catch (error: any) {
             const { status, resolutionError } = classifyResolveError(error);
             if (status >= 500) {

--- a/services/gatekeeper/server/src/identifiers-router.ts
+++ b/services/gatekeeper/server/src/identifiers-router.ts
@@ -42,15 +42,16 @@ function preferredDidContentType(req: express.Request): typeof DID_LD_JSON | typ
 
 function acceptQuality(accept: string, candidate: string): { quality: number; order: number } | undefined {
     let best: { quality: number; order: number } | undefined;
+    const normalizedCandidate = candidate.toLowerCase();
 
     accept.split(',').forEach((part, order) => {
         const [rawMedia, ...params] = part.split(';');
-        const media = rawMedia.trim();
+        const media = rawMedia.trim().toLowerCase();
         let quality = 1;
 
         for (const param of params) {
             const trimmed = param.trim();
-            if (trimmed.startsWith('q=')) {
+            if (trimmed.toLowerCase().startsWith('q=')) {
                 quality = Number.parseFloat(trimmed.slice(2));
                 if (Number.isNaN(quality)) {
                     quality = 0;
@@ -58,7 +59,7 @@ function acceptQuality(accept: string, candidate: string): { quality: number; or
             }
         }
 
-        const matches = media === candidate || media === 'application/*' || media === '*/*';
+        const matches = media === normalizedCandidate || media === 'application/*' || media === '*/*';
         if (!matches || quality <= 0) {
             return;
         }
@@ -73,6 +74,7 @@ function acceptQuality(accept: string, candidate: string): { quality: number; or
 
 function sendDidResolutionJson(res: express.Response, contentType: string, body: unknown): void {
     res.set('Content-Type', contentType);
+    res.vary('Accept');
     res.end(JSON.stringify(body));
 }
 
@@ -160,7 +162,17 @@ export function createIdentifiersRouter(
      *       200:
      *         description: The DID Resolution result (standard triple).
      *         content:
-     *           application/json:
+     *           application/did+ld+json:
+     *             schema:
+     *               type: object
+     *               properties:
+     *                 didDocument:
+     *                   type: object
+     *                 didResolutionMetadata:
+     *                   type: object
+     *                 didDocumentMetadata:
+     *                   type: object
+     *           application/did+json:
      *             schema:
      *               type: object
      *               properties:

--- a/swaggerConf.js
+++ b/swaggerConf.js
@@ -5,7 +5,7 @@ const baseDefinition = {
     openapi: '3.0.0',
     info: {
         title: 'Keymaster API',
-        version: '0.9.0',
+        version: '0.11.0',
         description: 'Documentation for Keymaster API'
     },
 };

--- a/tests/gatekeeper/api.test.ts
+++ b/tests/gatekeeper/api.test.ts
@@ -65,6 +65,7 @@ describe('GET /1.0/identifiers/:did (conformant resolution)', () => {
         expect(res.body.didDocumentMetadata.confirmed).toBe(true);
         expect(res.body.didResolutionMetadata.contentType).toBe('application/did+ld+json');
         expect(res.body.didResolutionMetadata.retrieved).toBeUndefined();
+        expect(res.headers.vary).toContain('Accept');
     });
 
     it('honors DID JSON and JSON-LD Accept headers in successful resolution metadata', async () => {
@@ -74,15 +75,17 @@ describe('GET /1.0/identifiers/:did (conformant resolution)', () => {
 
         expect(jsonLd.status).toBe(200);
         expect(jsonLd.headers['content-type']).toBe('application/did+ld+json');
+        expect(jsonLd.headers.vary).toContain('Accept');
         expect(jsonLd.body.didResolutionMetadata.contentType).toBe('application/did+ld+json');
         expect(jsonLd.body.didResolutionMetadata.retrieved).toBeUndefined();
 
         const didJson = await request(app)
             .get(`/1.0/identifiers/${agentDid}`)
-            .set('Accept', 'application/did+json');
+            .set('Accept', 'Application/DID+JSON;Q=1, application/did+ld+json;q=0.5');
 
         expect(didJson.status).toBe(200);
         expect(didJson.headers['content-type']).toBe('application/did+json');
+        expect(didJson.headers.vary).toContain('Accept');
         expect(didJson.body.didResolutionMetadata.contentType).toBe('application/did+json');
         expect(didJson.body.didResolutionMetadata.retrieved).toBeUndefined();
     });

--- a/tests/gatekeeper/api.test.ts
+++ b/tests/gatekeeper/api.test.ts
@@ -63,6 +63,28 @@ describe('GET /1.0/identifiers/:did (conformant resolution)', () => {
         expect(res.body.didDocumentRegistration).toBeUndefined();
         expect(res.body.didDocument.id).toBe(agentDid);
         expect(res.body.didDocumentMetadata.confirmed).toBe(true);
+        expect(res.body.didResolutionMetadata.contentType).toBe('application/did+ld+json');
+        expect(res.body.didResolutionMetadata.retrieved).toBeUndefined();
+    });
+
+    it('honors DID JSON and JSON-LD Accept headers in successful resolution metadata', async () => {
+        const jsonLd = await request(app)
+            .get(`/1.0/identifiers/${agentDid}`)
+            .set('Accept', 'application/did+ld+json');
+
+        expect(jsonLd.status).toBe(200);
+        expect(jsonLd.headers['content-type']).toBe('application/did+ld+json');
+        expect(jsonLd.body.didResolutionMetadata.contentType).toBe('application/did+ld+json');
+        expect(jsonLd.body.didResolutionMetadata.retrieved).toBeUndefined();
+
+        const didJson = await request(app)
+            .get(`/1.0/identifiers/${agentDid}`)
+            .set('Accept', 'application/did+json');
+
+        expect(didJson.status).toBe(200);
+        expect(didJson.headers['content-type']).toBe('application/did+json');
+        expect(didJson.body.didResolutionMetadata.contentType).toBe('application/did+json');
+        expect(didJson.body.didResolutionMetadata.retrieved).toBeUndefined();
     });
 
     it('resolves an asset to the triple only (no inline data/registration)', async () => {


### PR DESCRIPTION
## Summary

Fixes #699.

This tightens the Universal Resolver-style `/1.0/identifiers/{did}` response for `did:cid` in both Gatekeeper implementations.

- Rust Gatekeeper: adds DID media type negotiation, stable `didResolutionMetadata.contentType`, and fixture-stable metadata on successful conformant resolution responses
- TypeScript Gatekeeper: mirrors the Rust behavior in `identifiers-router`, including exact `Content-Type` responses for DID JSON and DID JSON-LD
- removes volatile `didResolutionMetadata.retrieved` from the conformant Universal Resolver-style success response while leaving the internal resolver metadata behavior intact
- keeps conformant responses limited to the DID Resolution triple: `didDocument`, `didResolutionMetadata`, and `didDocumentMetadata`
- updates Gatekeeper docs and records the Rust formatting lesson in `AGENTS.md`

## Validation

- `cargo test --manifest-path rust/services/gatekeeper/Cargo.toml --test http_contract -- --nocapture`
- `node --experimental-vm-modules node_modules/.bin/jest tests/gatekeeper/api.test.ts --runInBand --verbose`

Note: the Rust test run still reports the existing unused import warning for `queue_outbound_operation` in `rust/services/gatekeeper/src/lib.rs`.
