### PR TITLE
fix: Normalize DID resolver metadata datetimes

### DIFF
--- a/rust/services/gatekeeper/src/api.rs
+++ b/rust/services/gatekeeper/src/api.rs
@@ -1270,10 +1270,11 @@ pub(crate) async fn conformant_resolve_did(
             let triple = json!({
                 "didDocument": doc.get("didDocument").cloned().unwrap_or(Value::Null),
                 "didResolutionMetadata": did_resolution_metadata,
-                "didDocumentMetadata": doc
-                    .get("didDocumentMetadata")
-                    .cloned()
-                    .unwrap_or_else(|| json!({}))
+                "didDocumentMetadata": normalize_did_document_metadata(
+                    doc.get("didDocumentMetadata")
+                        .cloned()
+                        .unwrap_or_else(|| json!({}))
+                )
             });
             record_metrics(
                 &state,
@@ -1304,6 +1305,30 @@ pub(crate) async fn conformant_resolve_did(
                 .into_response()
         }
     }
+}
+
+fn normalize_did_core_datetime(value: &str) -> Option<String> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|datetime| {
+            datetime
+                .with_timezone(&chrono::Utc)
+                .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+        })
+}
+
+fn normalize_did_document_metadata(mut metadata: Value) -> Value {
+    for field in ["created", "updated", "deleted"] {
+        if let Some(normalized) = metadata
+            .get(field)
+            .and_then(Value::as_str)
+            .and_then(normalize_did_core_datetime)
+        {
+            metadata[field] = Value::String(normalized);
+        }
+    }
+
+    metadata
 }
 
 fn preferred_did_content_type(headers: &HeaderMap) -> &'static str {

--- a/rust/services/gatekeeper/tests/http_contract.rs
+++ b/rust/services/gatekeeper/tests/http_contract.rs
@@ -119,7 +119,7 @@ async fn http_contract_covers_ready_version_status_admin_and_metrics() -> Result
 #[tokio::test]
 async fn universal_resolver_surface_returns_fixture_stable_did_resolution_result() -> Result<()> {
     let service = spawn_json().await?;
-    let create = create_agent_operation(21, "2026-04-11T12:03:00Z", "local");
+    let create = create_agent_operation(21, "2026-04-11T12:03:00.495Z", "local");
 
     let response = service
         .client
@@ -134,6 +134,33 @@ async fn universal_resolver_surface_returns_fixture_stable_did_resolution_result
         .as_str()
         .unwrap()
         .to_string();
+
+    let response = service
+        .client
+        .get(format!("{}/did/{did}", service.base_url))
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+    let mut latest_doc = response.json::<Value>().await?;
+    let version_id = latest_doc["didDocumentMetadata"]["versionId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    latest_doc["didDocumentData"] = json!({ "hello": "world" });
+    let update = create_update_operation(
+        21,
+        &did,
+        Some(&version_id),
+        "2026-05-28T16:47:27.000Z",
+        latest_doc,
+    );
+    let response = service
+        .client
+        .post(format!("{}/did", service.base_url))
+        .json(&update)
+        .send()
+        .await?;
+    assert!(response.status().is_success());
 
     let response = service
         .client
@@ -166,8 +193,26 @@ async fn universal_resolver_surface_returns_fixture_stable_did_resolution_result
     );
     assert!(doc["didResolutionMetadata"].get("retrieved").is_none());
     assert_eq!(doc["didDocumentMetadata"]["confirmed"], true);
+    assert_eq!(doc["didDocumentMetadata"]["created"], "2026-04-11T12:03:00Z");
+    assert_eq!(doc["didDocumentMetadata"]["updated"], "2026-05-28T16:47:27Z");
     assert!(doc.get("didDocumentData").is_none());
     assert!(doc.get("didDocumentRegistration").is_none());
+
+    let response = service
+        .client
+        .get(format!(
+            "{}/1.0/identifiers/{did}?versionSequence=1",
+            service.root_url
+        ))
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+    let historical = response.json::<Value>().await?;
+    assert_eq!(
+        historical["didDocumentMetadata"]["created"],
+        "2026-04-11T12:03:00Z"
+    );
+    assert!(historical["didDocumentMetadata"].get("updated").is_none());
 
     let response = service
         .client

--- a/services/gatekeeper/server/src/identifiers-router.ts
+++ b/services/gatekeeper/server/src/identifiers-router.ts
@@ -78,9 +78,9 @@ function sendDidResolutionJson(res: express.Response, contentType: string, body:
     res.end(JSON.stringify(body));
 }
 
-function normalizeDidCoreDatetime(value: unknown): unknown {
-    if (typeof value !== 'string') {
-        return value;
+function normalizeDidCoreDatetime(value?: string): string | undefined {
+    if (value === undefined) {
+        return undefined;
     }
 
     const date = new Date(value);

--- a/services/gatekeeper/server/src/identifiers-router.ts
+++ b/services/gatekeeper/server/src/identifiers-router.ts
@@ -78,6 +78,32 @@ function sendDidResolutionJson(res: express.Response, contentType: string, body:
     res.end(JSON.stringify(body));
 }
 
+function normalizeDidCoreDatetime(value: unknown): unknown {
+    if (typeof value !== 'string') {
+        return value;
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function normalizeDidDocumentMetadata(metadata: DidCidDocument['didDocumentMetadata']) {
+    if (!metadata) {
+        return metadata;
+    }
+
+    return {
+        ...metadata,
+        created: normalizeDidCoreDatetime(metadata.created),
+        updated: normalizeDidCoreDatetime(metadata.updated),
+        deleted: normalizeDidCoreDatetime(metadata.deleted),
+    };
+}
+
 /**
  * Build the standards-conformant DID resolution / dereferencing router, mounted at
  * `/1.0/identifiers` following the Universal Resolver driver convention. Extracted into a
@@ -214,7 +240,7 @@ export function createIdentifiersRouter(
             sendDidResolutionJson(res, contentType, {
                 didDocument,
                 didResolutionMetadata: stableDidResolutionMetadata,
-                didDocumentMetadata,
+                didDocumentMetadata: normalizeDidDocumentMetadata(didDocumentMetadata),
             });
         } catch (error: any) {
             const { status, resolutionError } = classifyResolveError(error);

--- a/tests/gatekeeper/api.test.ts
+++ b/tests/gatekeeper/api.test.ts
@@ -108,6 +108,38 @@ describe('GET /1.0/identifiers/:did (conformant resolution)', () => {
         expect(res.body.didDocumentMetadata.versionSequence).toBe('1');
     });
 
+    it('normalizes DID Core metadata datetimes on current and historical responses', async () => {
+        const resolveDID = async (_did: string, options: any) => ({
+            didDocument: { id: agentDid },
+            didResolutionMetadata: {},
+            didDocumentMetadata: options.versionSequence === 1
+                ? {
+                    created: '2026-01-28T21:29:32.495Z',
+                    versionSequence: '1',
+                }
+                : {
+                    created: '2026-01-28T21:29:32.495Z',
+                    updated: '2026-05-28T16:47:27.000Z',
+                    deleted: '2026-06-01T10:11:12.999Z',
+                    versionSequence: '2',
+                },
+        });
+        const stubApp = express();
+        stubApp.use('/1.0/identifiers', createIdentifiersRouter({ resolveDID } as any, mockLogger));
+
+        const current = await request(stubApp).get(`/1.0/identifiers/${agentDid}`);
+        expect(current.status).toBe(200);
+        expect(current.body.didDocumentMetadata.created).toBe('2026-01-28T21:29:32Z');
+        expect(current.body.didDocumentMetadata.updated).toBe('2026-05-28T16:47:27Z');
+        expect(current.body.didDocumentMetadata.deleted).toBe('2026-06-01T10:11:12Z');
+
+        const historical = await request(stubApp).get(`/1.0/identifiers/${agentDid}?versionSequence=1`);
+        expect(historical.status).toBe(200);
+        expect(historical.body.didDocumentMetadata.created).toBe('2026-01-28T21:29:32Z');
+        expect(historical.body.didDocumentMetadata.updated).toBeUndefined();
+        expect(historical.body.didDocumentMetadata.deleted).toBeUndefined();
+    });
+
     it('returns 400 invalidDid in didResolutionMetadata for a malformed DID', async () => {
         const res = await request(app).get('/1.0/identifiers/notadid');
 


### PR DESCRIPTION
## Summary

Fixes #701.

- normalizes DID Core metadata datetime fields on the conformant `/1.0/identifiers/{did}` success response
- applies the normalization to `created`, `updated`, and `deleted` without changing the internal resolver metadata model
- keeps TypeScript and Rust Gatekeeper conformant surfaces aligned
- adds current and historical response coverage so fixture output omits fractional seconds

## Validation

- `node --experimental-vm-modules node_modules/.bin/jest tests/gatekeeper/api.test.ts --runInBand --verbose`
- `cargo test --manifest-path rust/services/gatekeeper/Cargo.toml --test http_contract -- --nocapture`

Note: the Rust test run still reports the existing unused import warning for `queue_outbound_operation` in `rust/services/gatekeeper/src/lib.rs`.
