### PR TITLE
fix: Move DID anchoring provenance to registration

### DIFF
--- a/docs/gatekeeper-api.json
+++ b/docs/gatekeeper-api.json
@@ -2281,7 +2281,7 @@
     "/1.0/identifiers/{did}": {
       "get": {
         "summary": "Resolve a DID (standards-conformant)",
-        "description": "Resolves a DID following the DID Resolution data model, returning only the standard result triple (`didDocument`, `didResolutionMetadata`, `didDocumentMetadata`). Follows the Universal Resolver driver convention. The method-specific `didDocumentData` and `didDocumentRegistration` objects are NOT part of this result — they are exposed as dereferenceable resources at `/1.0/identifiers/{did}/data` and `/1.0/identifiers/{did}/registration`. Always returns confirmed, cryptographically verified state; the internal `/api/v1/did/{did}` endpoint remains available for raw or unconfirmed state.\n",
+        "description": "Resolves a DID following the DID Resolution data model, returning only the standard result triple (`didDocument`, `didResolutionMetadata`, `didDocumentMetadata`). Follows the Universal Resolver driver convention. The method-specific `didDocumentData` and `didDocumentRegistration` objects are NOT part of this result — they are exposed as dereferenceable resources at `/1.0/identifiers/{did}/data` and `/1.0/identifiers/{did}/registration`. Always returns confirmed, cryptographically verified state; the internal `/api/v1/did/{did}` endpoint remains available for raw or unconfirmed state. Method-specific anchoring provenance such as confirmation state and block timestamp bounds is exposed by `/1.0/identifiers/{did}/registration`, not in `didDocumentMetadata`.\n",
         "parameters": [
           {
             "in": "path",
@@ -2447,7 +2447,7 @@
     "/1.0/identifiers/{did}/registration": {
       "get": {
         "summary": "Dereference the registration resource of a DID",
-        "description": "Dereferences the method-specific registration/anchoring resource associated with a DID (the DID URL `did:cid:<cid>/registration`). This is provenance about how and where the DID was registered and anchored — it is NOT DID Core metadata and NOT part of the DID resolution result. Standard document metadata (created, versionId, deactivated, etc.) remains in `didDocumentMetadata` on the resolution result.\n",
+        "description": "Dereferences the method-specific registration/anchoring resource associated with a DID (the DID URL `did:cid:<cid>/registration`). This is provenance about how and where the DID was registered and anchored — it is NOT DID Core metadata and NOT part of the DID resolution result. Standard document metadata (created, versionId, deactivated, etc.) remains in `didDocumentMetadata` on the resolution result. Confirmation state and block timestamp bounds are included here when known.\n",
         "parameters": [
           {
             "in": "path",

--- a/docs/services/gatekeeper/README.md
+++ b/docs/services/gatekeeper/README.md
@@ -170,7 +170,7 @@ which permits only three top-level members in a resolution result.
 | --- | --- | --- |
 | `GET` | `/1.0/identifiers/:did` | The DID Resolution result: exactly `didDocument`, `didResolutionMetadata`, `didDocumentMetadata`. See [§6.5](#65-conformant-resolution-result). |
 | `GET` | `/1.0/identifiers/:did/data` | The DID's data resource (`didDocumentData`), returned as the raw resource (empty object for agents). |
-| `GET` | `/1.0/identifiers/:did/registration` | The DID's registration/anchoring provenance (`didDocumentRegistration`), returned as the raw resource. |
+| `GET` | `/1.0/identifiers/:did/registration` | The DID's registration/anchoring provenance (`didDocumentRegistration` plus confirmation/timestamp provenance), returned as the raw resource. |
 
 Shared behavior:
 
@@ -188,6 +188,10 @@ Shared behavior:
   `did:cid:<cid>/registration`), retrieved by content address. They are NOT
   part of the resolution result and are returned as the raw resource value
   (not wrapped in a named envelope).
+- **Anchoring provenance:** confirmation state and block timestamp bounds are
+  method-specific provenance. The conformant resolution result omits
+  `didDocumentMetadata.confirmed` and `didDocumentMetadata.timestamp`; use
+  `/registration` for those details.
 - **Local-only (no fallback delegation):** unlike `/api/v1/did/:did`, this
   surface resolves solely from local state — it MUST NOT delegate to the
   universal-resolver `fallbackURL` or the confirmed-Gatekeeper peer on a local
@@ -326,8 +330,8 @@ standards-conformant `/1.0/identifiers/:did` surface returns only the
     "canonicalId": "<DID>",                   // present iff registration.prefix was overridden
     "versionId": "<CID of latest event>",
     "versionSequence": "<int as string>",      // "1" for create, increments on update/delete
-    "confirmed": true | false,
-    "timestamp": {                             // when registration registry has block info
+    "confirmed": true | false,                 // internal/API provenance; omitted from /1.0/identifiers
+    "timestamp": {                             // internal/API provenance; omitted from /1.0/identifiers
       "chain": "BTC:signet",
       "opid": "<CID>",
       "lowerBound": { time, timeISO, blockid, height } | null,
@@ -650,8 +654,7 @@ by the DID Resolution data model:
   "didDocumentMetadata": {
     "created": "<RFC 3339>",
     "versionId": "<CID>",
-    "versionSequence": "1",
-    "confirmed": true
+    "versionSequence": "1"
     // ...plus updated / deleted / deactivated / canonicalId when applicable
   }
 }
@@ -668,8 +671,9 @@ W3C DID test-suite fixtures remain stable.
 internal [`DidCidDocument`](#37-didciddocument-resolution-result)) MUST be
 omitted here and instead exposed via the `/data` and `/registration`
 dereference resources. Standard document metadata (`created`, `updated`,
-`versionId`, `versionSequence`, `deactivated`, `canonicalId`, `confirmed`)
-remains in `didDocumentMetadata`.
+`versionId`, `versionSequence`, `deactivated`, `canonicalId`) remains in
+`didDocumentMetadata`. Method-specific anchoring provenance (`confirmed` and
+`timestamp`) is omitted here and exposed by `/registration`.
 
 ---
 

--- a/rust/services/gatekeeper/src/api.rs
+++ b/rust/services/gatekeeper/src/api.rs
@@ -1328,7 +1328,38 @@ fn normalize_did_document_metadata(mut metadata: Value) -> Value {
         }
     }
 
+    if let Some(object) = metadata.as_object_mut() {
+        object.remove("confirmed");
+        object.remove("timestamp");
+    }
+
     metadata
+}
+
+fn build_registration_resource(doc: &Value) -> Value {
+    let mut registration = doc
+        .get("didDocumentRegistration")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+
+    if let Some(object) = registration.as_object_mut() {
+        if let Some(confirmed) = doc
+            .get("didDocumentMetadata")
+            .and_then(|metadata| metadata.get("confirmed"))
+            .cloned()
+        {
+            object.insert("confirmed".to_string(), confirmed);
+        }
+        if let Some(timestamp) = doc
+            .get("didDocumentMetadata")
+            .and_then(|metadata| metadata.get("timestamp"))
+            .cloned()
+        {
+            object.insert("timestamp".to_string(), timestamp);
+        }
+    }
+
+    registration
 }
 
 fn preferred_did_content_type(headers: &HeaderMap) -> &'static str {
@@ -1463,10 +1494,7 @@ pub(crate) async fn conformant_dereference_registration(
     let start = Instant::now();
     match resolve_conformant(&state, &did, &query).await {
         Ok(doc) => {
-            let registration = doc
-                .get("didDocumentRegistration")
-                .cloned()
-                .unwrap_or_else(|| json!({}));
+            let registration = build_registration_resource(&doc);
             record_metrics(
                 &state,
                 "GET",

--- a/rust/services/gatekeeper/tests/http_contract.rs
+++ b/rust/services/gatekeeper/tests/http_contract.rs
@@ -192,11 +192,34 @@ async fn universal_resolver_surface_returns_fixture_stable_did_resolution_result
         "application/did+ld+json"
     );
     assert!(doc["didResolutionMetadata"].get("retrieved").is_none());
-    assert_eq!(doc["didDocumentMetadata"]["confirmed"], true);
-    assert_eq!(doc["didDocumentMetadata"]["created"], "2026-04-11T12:03:00Z");
-    assert_eq!(doc["didDocumentMetadata"]["updated"], "2026-05-28T16:47:27Z");
+    assert!(doc["didDocumentMetadata"].get("confirmed").is_none());
+    assert!(doc["didDocumentMetadata"].get("timestamp").is_none());
+    assert_eq!(
+        doc["didDocumentMetadata"]["created"],
+        "2026-04-11T12:03:00Z"
+    );
+    assert_eq!(
+        doc["didDocumentMetadata"]["updated"],
+        "2026-05-28T16:47:27Z"
+    );
     assert!(doc.get("didDocumentData").is_none());
     assert!(doc.get("didDocumentRegistration").is_none());
+
+    let response = service
+        .client
+        .get(format!(
+            "{}/1.0/identifiers/{did}/registration",
+            service.root_url
+        ))
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+    let registration = response.json::<Value>().await?;
+    assert_eq!(registration["version"], 1);
+    assert_eq!(registration["type"], "agent");
+    assert_eq!(registration["registry"], "local");
+    assert_eq!(registration["confirmed"], true);
+    assert!(registration.get("timestamp").is_none());
 
     let response = service
         .client

--- a/services/gatekeeper/server/src/identifiers-router.ts
+++ b/services/gatekeeper/server/src/identifiers-router.ts
@@ -96,12 +96,29 @@ function normalizeDidDocumentMetadata(metadata: DidCidDocument['didDocumentMetad
         return metadata;
     }
 
+    const standardMetadata = { ...metadata };
+    delete standardMetadata.confirmed;
+    delete standardMetadata.timestamp;
+
     return {
-        ...metadata,
-        created: normalizeDidCoreDatetime(metadata.created),
-        updated: normalizeDidCoreDatetime(metadata.updated),
-        deleted: normalizeDidCoreDatetime(metadata.deleted),
+        ...standardMetadata,
+        created: normalizeDidCoreDatetime(standardMetadata.created),
+        updated: normalizeDidCoreDatetime(standardMetadata.updated),
+        deleted: normalizeDidCoreDatetime(standardMetadata.deleted),
     };
+}
+
+function buildRegistrationResource(doc: DidCidDocument) {
+    const registration = { ...(doc.didDocumentRegistration ?? {}) } as Record<string, unknown>;
+
+    if (doc.didDocumentMetadata?.confirmed !== undefined) {
+        registration.confirmed = doc.didDocumentMetadata.confirmed;
+    }
+    if (doc.didDocumentMetadata?.timestamp !== undefined) {
+        registration.timestamp = doc.didDocumentMetadata.timestamp;
+    }
+
+    return registration;
 }
 
 /**
@@ -163,7 +180,9 @@ export function createIdentifiersRouter(
      *       dereferenceable resources at `/1.0/identifiers/{did}/data` and
      *       `/1.0/identifiers/{did}/registration`. Always returns confirmed, cryptographically
      *       verified state; the internal `/api/v1/did/{did}` endpoint remains available for raw or
-     *       unconfirmed state.
+     *       unconfirmed state. Method-specific anchoring provenance such as confirmation state and
+     *       block timestamp bounds is exposed by `/1.0/identifiers/{did}/registration`, not in
+     *       `didDocumentMetadata`.
      *     parameters:
      *       - in: path
      *         name: did
@@ -348,7 +367,8 @@ export function createIdentifiersRouter(
      *       (the DID URL `did:cid:<cid>/registration`). This is provenance about how and where the
      *       DID was registered and anchored — it is NOT DID Core metadata and NOT part of the DID
      *       resolution result. Standard document metadata (created, versionId, deactivated, etc.)
-     *       remains in `didDocumentMetadata` on the resolution result.
+     *       remains in `didDocumentMetadata` on the resolution result. Confirmation state and block
+     *       timestamp bounds are included here when known.
      *     parameters:
      *       - in: path
      *         name: did
@@ -409,7 +429,7 @@ export function createIdentifiersRouter(
 
             // Dereference the method-specific registration resource (did:cid:<cid>/registration).
             // Not part of the DID resolution result — returned as the resource itself.
-            res.json(result.doc.didDocumentRegistration ?? {});
+            res.json(buildRegistrationResource(result.doc));
         } catch (error: any) {
             const { status, resolutionError } = classifyResolveError(error);
             if (status >= 500) {

--- a/tests/gatekeeper/api.test.ts
+++ b/tests/gatekeeper/api.test.ts
@@ -62,7 +62,8 @@ describe('GET /1.0/identifiers/:did (conformant resolution)', () => {
         expect(res.body.didDocumentData).toBeUndefined();
         expect(res.body.didDocumentRegistration).toBeUndefined();
         expect(res.body.didDocument.id).toBe(agentDid);
-        expect(res.body.didDocumentMetadata.confirmed).toBe(true);
+        expect(res.body.didDocumentMetadata.confirmed).toBeUndefined();
+        expect(res.body.didDocumentMetadata.timestamp).toBeUndefined();
         expect(res.body.didResolutionMetadata.contentType).toBe('application/did+ld+json');
         expect(res.body.didResolutionMetadata.retrieved).toBeUndefined();
         expect(res.headers.vary).toContain('Accept');
@@ -122,7 +123,19 @@ describe('GET /1.0/identifiers/:did (conformant resolution)', () => {
                     updated: '2026-05-28T16:47:27.000Z',
                     deleted: '2026-06-01T10:11:12.999Z',
                     versionSequence: '2',
+                    confirmed: true,
+                    timestamp: {
+                        chain: 'BTC:mainnet',
+                        opid: 'mock-opid',
+                        lowerBound: null,
+                        upperBound: { height: 101 },
+                    },
                 },
+            didDocumentRegistration: {
+                version: 1,
+                type: 'agent',
+                registry: 'BTC:mainnet',
+            },
         });
         const stubApp = express();
         stubApp.use('/1.0/identifiers', createIdentifiersRouter({ resolveDID } as any, mockLogger));
@@ -132,12 +145,29 @@ describe('GET /1.0/identifiers/:did (conformant resolution)', () => {
         expect(current.body.didDocumentMetadata.created).toBe('2026-01-28T21:29:32Z');
         expect(current.body.didDocumentMetadata.updated).toBe('2026-05-28T16:47:27Z');
         expect(current.body.didDocumentMetadata.deleted).toBe('2026-06-01T10:11:12Z');
+        expect(current.body.didDocumentMetadata.confirmed).toBeUndefined();
+        expect(current.body.didDocumentMetadata.timestamp).toBeUndefined();
 
         const historical = await request(stubApp).get(`/1.0/identifiers/${agentDid}?versionSequence=1`);
         expect(historical.status).toBe(200);
         expect(historical.body.didDocumentMetadata.created).toBe('2026-01-28T21:29:32Z');
         expect(historical.body.didDocumentMetadata.updated).toBeUndefined();
         expect(historical.body.didDocumentMetadata.deleted).toBeUndefined();
+
+        const registration = await request(stubApp).get(`/1.0/identifiers/${agentDid}/registration`);
+        expect(registration.status).toBe(200);
+        expect(registration.body).toMatchObject({
+            version: 1,
+            type: 'agent',
+            registry: 'BTC:mainnet',
+            confirmed: true,
+            timestamp: {
+                chain: 'BTC:mainnet',
+                opid: 'mock-opid',
+                lowerBound: null,
+                upperBound: { height: 101 },
+            },
+        });
     });
 
     it('returns 400 invalidDid in didResolutionMetadata for a malformed DID', async () => {
@@ -196,6 +226,7 @@ describe('GET /1.0/identifiers/:did/registration (dereference)', () => {
         expect(res.body.type).toBe('agent');
         expect(res.body.registry).toBe('local');
         expect(res.body.version).toBe(1);
+        expect(res.body.confirmed).toBe(true);
     });
 
     it('returns 404 { error: notFound } for an unknown DID', async () => {


### PR DESCRIPTION
## Summary

Fixes #702.

- omits method-specific anchoring provenance from conformant `/1.0/identifiers/{did}` metadata
- removes `didDocumentMetadata.confirmed` and `didDocumentMetadata.timestamp` from the conformant DID Resolution result
- exposes `confirmed` and `timestamp` through `/1.0/identifiers/{did}/registration` alongside the registration resource
- keeps TypeScript and Rust Gatekeeper surfaces aligned
- updates Gatekeeper docs and generated Gatekeeper OpenAPI descriptions

## Validation

- `node --experimental-vm-modules node_modules/.bin/jest tests/gatekeeper/api.test.ts --runInBand --verbose`
- `cargo test --manifest-path rust/services/gatekeeper/Cargo.toml --test http_contract -- --nocapture`
- `npm run generate-openapi`

Note: the Rust test run still reports the existing unused import warning for `queue_outbound_operation` in `rust/services/gatekeeper/src/lib.rs`.
