### PR TITLE
fix: return MCP-spec tool results (isError, structuredContent)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -67,6 +67,32 @@ Destructive tools require `"confirm": true`, secret-revealing tools require `"re
 
 Set `ARCHON_MCP_READ_ONLY=true` to omit mutating tools from the advertised MCP tool list.
 
+## Tool results
+
+Results follow the MCP specification.
+
+On success, the result is serialized as JSON into a text content block. When the result is a JSON object it is also returned in `structuredContent`:
+
+```json
+{
+  "content": [{ "type": "text", "text": "{\"didDocument\":{\"id\":\"did:cid:alice\"}}" }],
+  "structuredContent": { "didDocument": { "id": "did:cid:alice" } }
+}
+```
+
+MCP requires `structuredContent` to be a JSON object, so tools returning an array or a scalar (for example `archon_list_ids`, or the DID returned by `archon_create_id`) return the text content block only.
+
+Failures — including input validation, a locked wallet, and node errors — are reported as MCP tool execution errors, with `isError: true` and the message in a text content block:
+
+```json
+{
+  "content": [{ "type": "text", "text": "ARCHON_PASSPHRASE is required for wallet-backed MCP tools" }],
+  "isError": true
+}
+```
+
+Error messages are redacted of secrets (passphrases, recovery phrases, nsec keys, credentialed URLs).
+
 ## Examples
 
 Create an ID:

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -55,20 +55,26 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
 // MCP requires structuredContent to be a JSON object, so array and scalar results
 // are carried by the text block alone rather than in an invented wrapper object.
 function ok(result: unknown): CallToolResult {
-    const text = result === undefined ? '' : JSON.stringify(result);
+    const json = result === undefined ? undefined : JSON.stringify(result);
     const response: CallToolResult = {
         content: [
             {
                 type: 'text',
-                text,
+                text: json ?? '',
             },
         ],
     };
 
-    if (isJsonObject(result)) {
-        // Round-trip through the serialized text so structuredContent is exactly the JSON
-        // mirrored in the text block: keys with undefined values are dropped by both, not one.
-        response.structuredContent = JSON.parse(text);
+    if (json !== undefined) {
+        // Gate on the serialized payload rather than the raw result: a value can be a JS
+        // object yet serialize to a JSON scalar (a Date, or any toJSON() returning a
+        // non-object). This also keeps structuredContent exactly the JSON mirrored in the
+        // text block -- keys with undefined values are dropped by both, not one.
+        const payload = JSON.parse(json);
+
+        if (isJsonObject(payload)) {
+            response.structuredContent = payload;
+        }
     }
 
     return response;

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { McpServerConfig } from './config.js';
 import { ArchonRuntime } from './runtime.js';
 import { errorMessage } from './redact.js';
@@ -47,23 +48,42 @@ const InlineDataSchema = z.object({
     data: z.string(),
 });
 
-function jsonResult(result: unknown) {
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+// MCP requires structuredContent to be a JSON object, so array and scalar results
+// are carried by the text block alone rather than in an invented wrapper object.
+function ok(result: unknown): CallToolResult {
+    const text = result === undefined ? '' : JSON.stringify(result);
+    const response: CallToolResult = {
+        content: [
+            {
+                type: 'text',
+                text,
+            },
+        ],
+    };
+
+    if (isJsonObject(result)) {
+        // Round-trip through the serialized text so structuredContent is exactly the JSON
+        // mirrored in the text block: keys with undefined values are dropped by both, not one.
+        response.structuredContent = JSON.parse(text);
+    }
+
+    return response;
+}
+
+function fail(error: unknown): CallToolResult {
     return {
         content: [
             {
                 type: 'text',
-                text: JSON.stringify(result),
+                text: errorMessage(error),
             },
         ],
+        isError: true,
     };
-}
-
-function ok(result: unknown) {
-    return jsonResult({ ok: true, result });
-}
-
-function fail(error: unknown) {
-    return jsonResult({ ok: false, error: errorMessage(error) });
 }
 
 function requireKeymaster(runtime: ArchonRuntime) {

--- a/tests/mcp-server/stdio.test.ts
+++ b/tests/mcp-server/stdio.test.ts
@@ -3,8 +3,12 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { execFileSync } from 'child_process';
 import { ARCHON_MCP_TOOL_DEFINITIONS } from '@didcid/mcp-server';
 
-function parseToolResult(response: any) {
-    return JSON.parse(response.content[0].text);
+// A spec-compliant client detects failure from isError alone; the message is the text block.
+function expectToolError(response: any): string {
+    expect(response.isError).toBe(true);
+    expect(response.structuredContent).toBeUndefined();
+
+    return (response.content as any[])[0].text;
 }
 
 describe('mcp server stdio smoke', () => {
@@ -38,23 +42,23 @@ describe('mcp server stdio smoke', () => {
             expect(toolNames).toContain('archon_create_id');
             expect(toolNames.length).toBe(ARCHON_MCP_TOOL_DEFINITIONS.length);
 
-            const readResult = parseToolResult(await client.callTool({
+            const readResult = await client.callTool({
                 name: 'archon_list_ids',
                 arguments: {},
-            }));
-            expect(readResult).toStrictEqual({
-                ok: false,
-                error: 'ARCHON_PASSPHRASE is required for wallet-backed MCP tools',
             });
+            expect(expectToolError(readResult)).toBe('ARCHON_PASSPHRASE is required for wallet-backed MCP tools');
 
-            const writeResult = parseToolResult(await client.callTool({
+            const writeResult = await client.callTool({
                 name: 'archon_create_id',
                 arguments: { name: 'alice' },
-            }));
-            expect(writeResult).toStrictEqual({
-                ok: false,
-                error: 'ARCHON_PASSPHRASE is required for wallet-backed MCP tools',
             });
+            expect(expectToolError(writeResult)).toBe('ARCHON_PASSPHRASE is required for wallet-backed MCP tools');
+
+            const invalidArgsResult = await client.callTool({
+                name: 'archon_create_id',
+                arguments: {},
+            });
+            expect(expectToolError(invalidArgsResult)).toContain('Required');
         } finally {
             await client.close();
         }

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -97,8 +97,35 @@ const toolArgOverrides: Record<string, Record<string, unknown>> = {
     archon_get_vault_item: { item: 'hello.txt' },
 };
 
-function parseToolResult(response: any) {
-    return JSON.parse(response.content[0].text);
+// Asserts a spec-shaped success: no isError, and structuredContent (when the result is a
+// JSON object) mirrors the serialized text block. Returns the payload.
+function expectOk(response: any) {
+    if (response.isError) {
+        throw new Error(`unexpected tool error: ${response.content[0].text}`);
+    }
+
+    const text = response.content[0].text;
+    const payload = text === '' ? undefined : JSON.parse(text);
+
+    if (isJsonObject(payload)) {
+        expect(response.structuredContent).toStrictEqual(payload);
+    } else {
+        expect(response.structuredContent).toBeUndefined();
+    }
+
+    return payload;
+}
+
+// Asserts a spec-shaped tool execution error. Returns the message.
+function expectFail(response: any): string {
+    expect(response.isError).toBe(true);
+    expect(response.structuredContent).toBeUndefined();
+
+    return response.content[0].text;
+}
+
+function isJsonObject(value: unknown) {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function argsForTool(name: string) {
@@ -267,7 +294,7 @@ describe('mcp server tools', () => {
 
         const response = await server.tools.get('archon_list_registries')!.handler({});
 
-        expect(parseToolResult(response)).toStrictEqual({ ok: true, result: ['hyperswarm'] });
+        expect(expectOk(response)).toStrictEqual(['hyperswarm']);
         expect(runtime.node.listRegistries).toHaveBeenCalledTimes(1);
     });
 
@@ -278,12 +305,38 @@ describe('mcp server tools', () => {
 
         for (const definition of ARCHON_MCP_TOOL_DEFINITIONS) {
             const response = await server.tools.get(definition.name)!.handler(argsForTool(definition.name));
-            const result = parseToolResult(response);
-            if (!result.ok) {
-                throw new Error(`${definition.name}: ${result.error}`);
+            if (response.isError) {
+                throw new Error(`${definition.name}: ${response.content[0].text}`);
             }
-            expect(result.ok).toBe(true);
+            expectOk(response);
         }
+    });
+
+    it('carries object results in structuredContent, mirrored by the text block', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const response = await server.tools.get('archon_resolve_did')!.handler({ did: 'did:cid:alice' });
+
+        expect(response.isError).toBeUndefined();
+        expect(response.structuredContent).toStrictEqual({ didDocument: { id: 'did:cid:alice' } });
+        expect(JSON.parse(response.content[0].text)).toStrictEqual(response.structuredContent);
+    });
+
+    it('omits structuredContent for non-object results', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        // MCP requires structuredContent to be a JSON object, so an array result rides the text block alone.
+        const listResponse = await server.tools.get('archon_list_ids')!.handler({});
+        expect(listResponse.structuredContent).toBeUndefined();
+        expect(JSON.parse(listResponse.content[0].text)).toStrictEqual(['alice']);
+
+        const stringResponse = await server.tools.get('archon_create_id')!.handler({ name: 'Alice' });
+        expect(stringResponse.structuredContent).toBeUndefined();
+        expect(JSON.parse(stringResponse.content[0].text)).toBe('did:cid:new');
     });
 
     it('does not advertise mutating tools in read-only mode', () => {
@@ -304,10 +357,8 @@ describe('mcp server tools', () => {
         registerArchonTools(server, runtime as any, baseConfig);
 
         const response = await server.tools.get('archon_revoke_did')!.handler({ did: 'did:cid:alice' });
-        const result = parseToolResult(response);
 
-        expect(result.ok).toBe(false);
-        expect(result.error).toContain('Invalid literal value');
+        expect(expectFail(response)).toContain('Invalid literal value');
         expect(runtime.keymaster.revokeDID).not.toHaveBeenCalled();
     });
 
@@ -317,23 +368,19 @@ describe('mcp server tools', () => {
         registerArchonTools(server, runtime as any, baseConfig);
 
         const response = await server.tools.get('archon_show_mnemonic')!.handler({});
-        const result = parseToolResult(response);
 
-        expect(result.ok).toBe(false);
-        expect(result.error).toContain('Invalid literal value');
+        expect(expectFail(response)).toContain('Invalid literal value');
         expect(runtime.keymaster.decryptMnemonic).not.toHaveBeenCalled();
     });
 
-    it('returns a clear passphrase error for wallet-backed tools without keymaster runtime', async () => {
+    it('flags a locked wallet as a tool execution error', async () => {
         const server = new FakeServer();
         registerArchonTools(server, { node: mockRuntime().node } as any, { ...baseConfig, passphrase: undefined });
 
         const response = await server.tools.get('archon_list_ids')!.handler({});
 
-        expect(parseToolResult(response)).toStrictEqual({
-            ok: false,
-            error: 'ARCHON_PASSPHRASE is required for wallet-backed MCP tools',
-        });
+        expect(response.isError).toBe(true);
+        expect(expectFail(response)).toBe('ARCHON_PASSPHRASE is required for wallet-backed MCP tools');
     });
 
     it('validates required inputs', async () => {
@@ -342,10 +389,8 @@ describe('mcp server tools', () => {
         registerArchonTools(server, runtime as any, baseConfig);
 
         const response = await server.tools.get('archon_create_id')!.handler({});
-        const result = parseToolResult(response);
 
-        expect(result.ok).toBe(false);
-        expect(result.error).toContain('Required');
+        expect(expectFail(response)).toContain('Required');
         expect(runtime.keymaster.createId).not.toHaveBeenCalled();
     });
 
@@ -360,7 +405,7 @@ describe('mcp server tools', () => {
             registry: 'hyperswarm',
         });
 
-        expect(parseToolResult(response)).toStrictEqual({ ok: true, result: 'did:cid:asset' });
+        expect(expectOk(response)).toBe('did:cid:asset');
         expect(runtime.keymaster.createAsset).toHaveBeenCalledWith(
             { hello: 'world' },
             { alias: 'hello', registry: 'hyperswarm' }
@@ -381,7 +426,7 @@ describe('mcp server tools', () => {
             alias: 'hello',
         });
 
-        expect(parseToolResult(response)).toStrictEqual({ ok: true, result: 'did:cid:file' });
+        expect(expectOk(response)).toBe('did:cid:file');
         expect(runtime.keymaster.createFile).toHaveBeenCalledWith(
             Buffer.from('hello'),
             { alias: 'hello', filename: 'hello.txt', contentType: 'text/plain' }
@@ -394,30 +439,24 @@ describe('mcp server tools', () => {
         registerArchonTools(server, runtime as any, baseConfig);
 
         const fileResponse = await server.tools.get('archon_get_asset_file')!.handler({ id: 'did:cid:file' });
-        expect(parseToolResult(fileResponse)).toStrictEqual({
-            ok: true,
-            result: {
-                name: 'file.txt',
-                mimeType: 'text/plain',
-                encoding: 'base64',
-                data: Buffer.from('file').toString('base64'),
-            },
+        expect(expectOk(fileResponse)).toStrictEqual({
+            name: 'file.txt',
+            mimeType: 'text/plain',
+            encoding: 'base64',
+            data: Buffer.from('file').toString('base64'),
         });
 
         const imageResponse = await server.tools.get('archon_get_asset_image')!.handler({ id: 'did:cid:image' });
-        expect(parseToolResult(imageResponse)).toStrictEqual({
-            ok: true,
-            result: {
-                file: {
-                    name: 'image.png',
-                    mimeType: 'image/png',
-                    encoding: 'base64',
-                    data: Buffer.from('image').toString('base64'),
-                },
-                image: {
-                    width: 1,
-                    height: 1,
-                },
+        expect(expectOk(imageResponse)).toStrictEqual({
+            file: {
+                name: 'image.png',
+                mimeType: 'image/png',
+                encoding: 'base64',
+                data: Buffer.from('image').toString('base64'),
+            },
+            image: {
+                width: 1,
+                height: 1,
             },
         });
     });
@@ -432,17 +471,16 @@ describe('mcp server tools', () => {
         registerArchonTools(server, runtime as any, baseConfig);
 
         const response = await server.tools.get('archon_list_ids')!.handler({});
-        const result = parseToolResult(response);
+        const error = expectFail(response);
 
-        expect(result.ok).toBe(false);
-        expect(result.error).toContain('ARCHON_PASSPHRASE=<redacted>');
-        expect(result.error).toContain('https://<redacted>@bitcoin-mainnet.g.alchemy.com/v3/<redacted>?api_key=<redacted>');
-        expect(result.error).not.toContain('secret');
-        expect(result.error).not.toContain('phrase');
-        expect(result.error).not.toContain('seed');
-        expect(result.error).not.toContain('words');
-        expect(result.error).not.toContain('nsec-secret');
-        expect(result.error).not.toContain('lnbc-secret');
-        expect(result.error).not.toContain('api-token');
+        expect(error).toContain('ARCHON_PASSPHRASE=<redacted>');
+        expect(error).toContain('https://<redacted>@bitcoin-mainnet.g.alchemy.com/v3/<redacted>?api_key=<redacted>');
+        expect(error).not.toContain('secret');
+        expect(error).not.toContain('phrase');
+        expect(error).not.toContain('seed');
+        expect(error).not.toContain('words');
+        expect(error).not.toContain('nsec-secret');
+        expect(error).not.toContain('lnbc-secret');
+        expect(error).not.toContain('api-token');
     });
 });

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -339,6 +339,25 @@ describe('mcp server tools', () => {
         expect(JSON.parse(stringResponse.content[0].text)).toBe('did:cid:new');
     });
 
+    it('omits structuredContent for objects that serialize to a JSON scalar', async () => {
+        const server = new FakeServer();
+        // A Date is a JS object but serializes to a JSON string, as is anything with a
+        // toJSON() returning a non-object. structuredContent must stay a JSON object.
+        const runtime = mockRuntime({
+            resolveDID: jest.fn().mockResolvedValue(new Date('2026-01-01T00:00:00.000Z')),
+            getCredential: jest.fn().mockResolvedValue({ toJSON: () => 'did:cid:credential' }),
+        });
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const dateResponse = await server.tools.get('archon_resolve_did')!.handler({ did: 'did:cid:alice' });
+        expect(dateResponse.structuredContent).toBeUndefined();
+        expect(JSON.parse(dateResponse.content[0].text)).toBe('2026-01-01T00:00:00.000Z');
+
+        const toJsonResponse = await server.tools.get('archon_get_credential')!.handler({ did: 'did:cid:credential' });
+        expect(toJsonResponse.structuredContent).toBeUndefined();
+        expect(JSON.parse(toJsonResponse.content[0].text)).toBe('did:cid:credential');
+    });
+
     it('does not advertise mutating tools in read-only mode', () => {
         const server = new FakeServer();
         const runtime = mockRuntime();


### PR DESCRIPTION
Closes #691.

## Problem

Every MCP tool result was wrapped in a custom `{ ok: true, result }` / `{ ok: false, error }` envelope, `JSON.stringify`-ed into a text block, with **`isError` never set**. So every failure — the `ARCHON_PASSPHRASE` wallet lock, node/network errors, business-logic errors — reached the client as a *successful* tool call. A spec-compliant client (or an LLM driving one) sees success and has to know to parse our private `ok` field to learn otherwise.

## What the spec says

- **Tool execution errors** are "reported in tool results with `isError: true`", and clients **SHOULD** hand them to the model so it can self-correct — exactly what the old shape prevented.
- **Structured content** "is returned as a JSON object in the `structuredContent` field", and a tool returning it **SHOULD** also return the serialized JSON in a text block.
- **Output schema**: "If an output schema is provided: Servers **MUST** provide structured results that conform to this schema."
- There is no `ok` field in the protocol.

## Changes

`packages/mcp-server/src/tools.ts`, in the `ok`/`fail` helpers only — the ~150 tool definitions and the registration path are untouched:

- `fail()` sets `isError: true`, message in a text block. Still routed through `errorMessage()`, so redaction does not regress.
- `ok()` always emits the serialized text block, and adds `structuredContent` **when the result is a JSON object**. Arrays and scalars (`archon_list_ids`, the DID from `archon_create_id`) ride the text block alone rather than in an invented `{result: ...}` wrapper — the spec requires `structuredContent` to be an object and offers no wrapper convention, and swapping one non-standard envelope for another isn't a fix.
- Results are typed as the SDK's `CallToolResult` rather than an untyped object literal, so the shape is actually checked.
- `structuredContent` is derived from the serialized text. **This caught a latent bug**: `inlineDataFromBuffer` yields `{ mimeType: undefined, ... }`; `JSON.stringify` drops that key but a raw object assignment keeps it, so the text block and `structuredContent` would have disagreed and `structuredContent` would have carried a value that isn't valid JSON.

**No `outputSchema`** — deliberately. Declaring one obligates the server to a MUST-conform result, but handlers return `unknown` from a Keymaster cast to `any`. That would trade this violation for a new one. Per-tool output schemas + typed handler returns are a worthwhile follow-up, not this PR.

## Verification

All 29 tests in `tests/mcp-server` pass, including `stdio.test.ts` driving a real SDK `Client` over `StdioClientTransport` (now asserting `isError`). I also drove the built server over stdio against a temp wallet:

| call | result |
|---|---|
| `archon_list_aliases` (object) | `structuredContent: {}` + matching text block |
| `archon_list_ids` (array) | text `"[]"`, no `structuredContent` |
| `archon_check_wallet` (dead node) | `isError: true`, `"connect ECONNREFUSED 127.0.0.1:1"` |

That last row is the class of failure that used to read as success.

## Notes for review

- **Breaking** response shape. Commit carries a `BREAKING CHANGE:` footer so lerna handles the bump (0.4.0); `CHANGELOG.md`/`package.json` are intentionally not hand-edited. The only in-repo consumers of the old envelope were these two test files.
- Invalid *arguments* are rejected by the SDK's own `inputSchema` validation before our handler runs, so they already returned `isError` and now surface the SDK's verbose `MCP error -32602: ...` text rather than our redacted message. No leak risk (zod issues carry paths, not input values) and spec-conformant either way, but it does mean our internal zod re-parse is largely redundant on the `registerTool` path. Left alone as out of scope.
- `archon_get_asset_image` / `archon_get_asset_file` still return base64 as JSON rather than MCP `image`/`resource` content blocks. Arguably also a spec-fit issue, but not what #691 reports — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)