### PR TITLE
fix: return asset image/file tools as MCP content blocks (#721)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -61,7 +61,7 @@ CLI file commands use inline data instead of arbitrary local paths. Binary/text 
 }
 ```
 
-Use `"encoding": "utf8"` when passing plain text directly. Returned file-like data uses the same shape with base64 encoding.
+Use `"encoding": "utf8"` when passing plain text directly. This inline shape is for tool *arguments*; returned binary data uses MCP content blocks instead — see [Tool results](#tool-results).
 
 Destructive tools require `"confirm": true`, secret-revealing tools require `"reveal": true`, and Lightning payment/broadcast tools require `"confirmPayment": true`.
 
@@ -81,6 +81,32 @@ On success, the result is serialized as JSON into a text content block. When the
 ```
 
 MCP requires `structuredContent` to be a JSON object, so tools returning an array or a scalar (for example `archon_list_ids`, or the DID returned by `archon_create_id`) return the text content block only.
+
+Tools returning binary assets use the content block types the protocol defines for them, so clients can render them natively. `archon_get_asset_image` returns an `image` block plus a text block carrying the filename and dimensions:
+
+```json
+{
+  "content": [
+    { "type": "image", "data": "<base64>", "mimeType": "image/png" },
+    { "type": "text", "text": "{\"name\":\"image.png\",\"image\":{\"width\":1,\"height\":1}}" }
+  ],
+  "structuredContent": { "name": "image.png", "image": { "width": 1, "height": 1 } }
+}
+```
+
+`archon_get_asset_file` returns an embedded `resource` block identified by the asset's DID:
+
+```json
+{
+  "content": [
+    { "type": "resource", "resource": { "uri": "did:cid:file", "mimeType": "text/plain", "blob": "<base64>" } },
+    { "type": "text", "text": "{\"name\":\"file.txt\",\"mimeType\":\"text/plain\"}" }
+  ],
+  "structuredContent": { "name": "file.txt", "mimeType": "text/plain" }
+}
+```
+
+Both return `null` when the asset carries no data.
 
 Failures — including input validation, a locked wallet, and node errors — are reported as MCP tool execution errors, with `isError: true` and the message in a text content block:
 

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -52,9 +52,37 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+const CONTENT_RESULT = Symbol('archon.contentResult');
+
+type ContentResult = {
+    [CONTENT_RESULT]: true;
+    content: CallToolResult['content'];
+    structuredContent?: Record<string, unknown>;
+};
+
+// Lets a handler emit MCP content blocks (image, resource) directly instead of the
+// JSON text block ok() builds for every other tool.
+function contentResult(content: CallToolResult['content'], structuredContent?: Record<string, unknown>): ContentResult {
+    return { [CONTENT_RESULT]: true, content, structuredContent };
+}
+
+function isContentResult(value: unknown): value is ContentResult {
+    return isJsonObject(value) && (value as any)[CONTENT_RESULT] === true;
+}
+
 // MCP requires structuredContent to be a JSON object, so array and scalar results
 // are carried by the text block alone rather than in an invented wrapper object.
 function ok(result: unknown): CallToolResult {
+    if (isContentResult(result)) {
+        const response: CallToolResult = { content: result.content };
+
+        if (result.structuredContent !== undefined) {
+            response.structuredContent = result.structuredContent;
+        }
+
+        return response;
+    }
+
     const json = result === undefined ? undefined : JSON.stringify(result);
     const response: CallToolResult = {
         content: [
@@ -250,16 +278,40 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
     tool({ name: 'archon_create_asset_file', cliCommand: 'create-asset-file', description: 'Create a file asset DID from an inline payload.', schema: z.object({ file: InlineDataSchema }).merge(AssetOptionsSchema), mutates: true, handler: (runtime, { file, ...options }) => requireKeymaster(runtime).createFile(bufferFromInlineData(file), compactOptions({ ...options, filename: file.name, contentType: file.mimeType })) }),
     tool({ name: 'archon_get_asset', cliCommand: 'get-asset', description: 'Resolve an asset by local name, alias, or DID.', schema: IdSchema.merge(ResolveOptionsSchema), handler: (runtime, { id, ...options }) => requireKeymaster(runtime).resolveAsset(id, compactOptions(options)) }),
     tool({ name: 'archon_get_asset_json', cliCommand: 'get-asset-json', description: 'Return a JSON asset as an inline object.', schema: IdSchema.merge(ResolveOptionsSchema), handler: (runtime, { id, ...options }) => requireKeymaster(runtime).resolveAsset(id, compactOptions(options)) }),
-    tool({ name: 'archon_get_asset_image', cliCommand: 'get-asset-image', description: 'Return an image asset as an inline base64 payload.', schema: IdSchema, handler: async (runtime, { id }) => {
+    tool({ name: 'archon_get_asset_image', cliCommand: 'get-asset-image', description: 'Return an image asset as an image content block.', schema: IdSchema, handler: async (runtime, { id }) => {
         const image = await requireKeymaster(runtime).getImage(id);
-        return image?.file?.data ? {
-            file: inlineDataFromBuffer(Buffer.from(image.file.data), image.file.filename, image.file.type),
-            image: image.image,
-        } : null;
+
+        if (!image?.file?.data) {
+            return null;
+        }
+
+        const metadata = { name: image.file.filename, image: image.image };
+        return contentResult([
+            { type: 'image', data: Buffer.from(image.file.data).toString('base64'), mimeType: image.file.type ?? 'application/octet-stream' },
+            { type: 'text', text: JSON.stringify(metadata) },
+        ], metadata);
     } }),
-    tool({ name: 'archon_get_asset_file', cliCommand: 'get-asset-file', description: 'Return a file asset as an inline base64 payload.', schema: IdSchema, handler: async (runtime, { id }) => {
+    tool({ name: 'archon_get_asset_file', cliCommand: 'get-asset-file', description: 'Return a file asset as an embedded resource content block.', schema: IdSchema, handler: async (runtime, { id }) => {
         const file = await requireKeymaster(runtime).getFile(id);
-        return file?.data ? inlineDataFromBuffer(Buffer.from(file.data), file.filename, file.type) : null;
+
+        if (!file?.data) {
+            return null;
+        }
+
+        const metadata = { name: file.filename, mimeType: file.type };
+        return contentResult([
+            {
+                type: 'resource',
+                resource: {
+                    // The asset DID is itself a URI, so the resource is named by a real
+                    // identifier rather than an invented scheme.
+                    uri: await requireKeymaster(runtime).lookupDID(id),
+                    mimeType: file.type ?? 'application/octet-stream',
+                    blob: Buffer.from(file.data).toString('base64'),
+                },
+            },
+            { type: 'text', text: JSON.stringify(metadata) },
+        ], metadata);
     } }),
     tool({ name: 'archon_update_asset_json', cliCommand: 'update-asset-json', description: 'Merge JSON object data into an existing asset.', schema: IdSchema.extend({ data: JsonObjectSchema }), mutates: true, handler: (runtime, { id, data }) => requireKeymaster(runtime).mergeData(id, data) }),
     tool({ name: 'archon_update_asset_image', cliCommand: 'update-asset-image', description: 'Update an image asset from an inline payload.', schema: IdSchema.extend({ file: InlineDataSchema }), mutates: true, handler: (runtime, { id, file }) => requireKeymaster(runtime).updateImage(id, bufferFromInlineData(file), compactOptions({ filename: file.name })) }),

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -61,9 +61,17 @@ type ContentResult = {
 };
 
 // Lets a handler emit MCP content blocks (image, resource) directly instead of the
-// JSON text block ok() builds for every other tool.
-function contentResult(content: CallToolResult['content'], structuredContent?: Record<string, unknown>): ContentResult {
-    return { [CONTENT_RESULT]: true, content, structuredContent };
+// JSON text block ok() builds for every other tool. Metadata is round-tripped through
+// JSON so structuredContent is exactly the payload the text block carries -- keys with
+// undefined values are dropped by both, not one, as in ok().
+function contentResult(content: CallToolResult['content'], metadata: Record<string, unknown>): ContentResult {
+    const json = JSON.stringify(metadata);
+
+    return {
+        [CONTENT_RESULT]: true,
+        content: [...content, { type: 'text', text: json }],
+        structuredContent: JSON.parse(json),
+    };
 }
 
 function isContentResult(value: unknown): value is ContentResult {
@@ -285,11 +293,11 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
             return null;
         }
 
-        const metadata = { name: image.file.filename, image: image.image };
-        return contentResult([
-            { type: 'image', data: Buffer.from(image.file.data).toString('base64'), mimeType: image.file.type ?? 'application/octet-stream' },
-            { type: 'text', text: JSON.stringify(metadata) },
-        ], metadata);
+        const mimeType = image.file.type ?? 'application/octet-stream';
+        return contentResult(
+            [{ type: 'image', data: Buffer.from(image.file.data).toString('base64'), mimeType }],
+            { name: image.file.filename, mimeType, image: image.image }
+        );
     } }),
     tool({ name: 'archon_get_asset_file', cliCommand: 'get-asset-file', description: 'Return a file asset as an embedded resource content block.', schema: IdSchema, handler: async (runtime, { id }) => {
         const file = await requireKeymaster(runtime).getFile(id);
@@ -298,20 +306,20 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
             return null;
         }
 
-        const metadata = { name: file.filename, mimeType: file.type };
-        return contentResult([
-            {
+        const mimeType = file.type ?? 'application/octet-stream';
+        return contentResult(
+            [{
                 type: 'resource',
                 resource: {
                     // The asset DID is itself a URI, so the resource is named by a real
                     // identifier rather than an invented scheme.
                     uri: await requireKeymaster(runtime).lookupDID(id),
-                    mimeType: file.type ?? 'application/octet-stream',
+                    mimeType,
                     blob: Buffer.from(file.data).toString('base64'),
                 },
-            },
-            { type: 'text', text: JSON.stringify(metadata) },
-        ], metadata);
+            }],
+            { name: file.filename, mimeType }
+        );
     } }),
     tool({ name: 'archon_update_asset_json', cliCommand: 'update-asset-json', description: 'Merge JSON object data into an existing asset.', schema: IdSchema.extend({ data: JsonObjectSchema }), mutates: true, handler: (runtime, { id, data }) => requireKeymaster(runtime).mergeData(id, data) }),
     tool({ name: 'archon_update_asset_image', cliCommand: 'update-asset-image', description: 'Update an image asset from an inline payload.', schema: IdSchema.extend({ file: InlineDataSchema }), mutates: true, handler: (runtime, { id, file }) => requireKeymaster(runtime).updateImage(id, bufferFromInlineData(file), compactOptions({ filename: file.name })) }),

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -98,13 +98,15 @@ const toolArgOverrides: Record<string, Record<string, unknown>> = {
 };
 
 // Asserts a spec-shaped success: no isError, and structuredContent (when the result is a
-// JSON object) mirrors the serialized text block. Returns the payload.
+// JSON object) mirrors the serialized text block. Returns the payload. Tools that emit
+// image/resource blocks carry their metadata in a trailing text block, so this looks the
+// text block up by type rather than assuming it comes first.
 function expectOk(response: any) {
     if (response.isError) {
         throw new Error(`unexpected tool error: ${response.content[0].text}`);
     }
 
-    const text = response.content[0].text;
+    const text = response.content.find((block: any) => block.type === 'text').text;
     const payload = text === '' ? undefined : JSON.parse(text);
 
     if (isJsonObject(payload)) {
@@ -220,6 +222,7 @@ function mockRuntime(overrides: Record<string, unknown> = {}) {
         resolveAsset: jest.fn().mockResolvedValue({ hello: 'world' }),
         getImage: jest.fn().mockResolvedValue({ file: { filename: 'image.png', type: 'image/png', data: Buffer.from('image') }, image: { width: 1, height: 1 } }),
         getFile: jest.fn().mockResolvedValue({ filename: 'file.txt', type: 'text/plain', data: Buffer.from('file') }),
+        lookupDID: jest.fn().mockResolvedValue('did:cid:file'),
         mergeData: jest.fn().mockResolvedValue(true),
         updateImage: jest.fn().mockResolvedValue(true),
         updateFile: jest.fn().mockResolvedValue(true),
@@ -452,32 +455,53 @@ describe('mcp server tools', () => {
         );
     });
 
-    it('returns file-like assets as inline payloads', async () => {
+    it('returns an image asset as an image content block', async () => {
         const server = new FakeServer();
         const runtime = mockRuntime();
         registerArchonTools(server, runtime as any, baseConfig);
 
-        const fileResponse = await server.tools.get('archon_get_asset_file')!.handler({ id: 'did:cid:file' });
-        expect(expectOk(fileResponse)).toStrictEqual({
-            name: 'file.txt',
-            mimeType: 'text/plain',
-            encoding: 'base64',
-            data: Buffer.from('file').toString('base64'),
-        });
+        const response: any = await server.tools.get('archon_get_asset_image')!.handler({ id: 'did:cid:image' });
 
-        const imageResponse = await server.tools.get('archon_get_asset_image')!.handler({ id: 'did:cid:image' });
-        expect(expectOk(imageResponse)).toStrictEqual({
-            file: {
-                name: 'image.png',
-                mimeType: 'image/png',
-                encoding: 'base64',
-                data: Buffer.from('image').toString('base64'),
+        expect(response.isError).toBeUndefined();
+        expect(response.content).toStrictEqual([
+            { type: 'image', data: Buffer.from('image').toString('base64'), mimeType: 'image/png' },
+            { type: 'text', text: JSON.stringify({ name: 'image.png', image: { width: 1, height: 1 } }) },
+        ]);
+        expect(response.structuredContent).toStrictEqual({ name: 'image.png', image: { width: 1, height: 1 } });
+    });
+
+    it('returns a file asset as an embedded resource content block', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const response: any = await server.tools.get('archon_get_asset_file')!.handler({ id: 'file-alias' });
+
+        expect(response.isError).toBeUndefined();
+        expect(response.content).toStrictEqual([
+            {
+                type: 'resource',
+                resource: {
+                    uri: 'did:cid:file',
+                    mimeType: 'text/plain',
+                    blob: Buffer.from('file').toString('base64'),
+                },
             },
-            image: {
-                width: 1,
-                height: 1,
-            },
-        });
+            { type: 'text', text: JSON.stringify({ name: 'file.txt', mimeType: 'text/plain' }) },
+        ]);
+        expect(response.structuredContent).toStrictEqual({ name: 'file.txt', mimeType: 'text/plain' });
+        expect(runtime.keymaster.lookupDID).toHaveBeenCalledWith('file-alias');
+    });
+
+    it('returns null for file-like assets with no data', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        runtime.keymaster.getImage.mockResolvedValue(null);
+        runtime.keymaster.getFile.mockResolvedValue(null);
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        expect(expectOk(await server.tools.get('archon_get_asset_image')!.handler({ id: 'did:cid:image' }))).toBeNull();
+        expect(expectOk(await server.tools.get('archon_get_asset_file')!.handler({ id: 'did:cid:file' }))).toBeNull();
     });
 
     it('redacts secrets from tool errors', async () => {

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -106,7 +106,10 @@ function expectOk(response: any) {
         throw new Error(`unexpected tool error: ${response.content[0].text}`);
     }
 
-    const text = response.content.find((block: any) => block.type === 'text').text;
+    const textBlock = response.content.find((block: any) => block.type === 'text');
+    expect(textBlock).toBeDefined();
+
+    const text = textBlock.text;
     const payload = text === '' ? undefined : JSON.parse(text);
 
     if (isJsonObject(payload)) {
@@ -463,11 +466,12 @@ describe('mcp server tools', () => {
         const response: any = await server.tools.get('archon_get_asset_image')!.handler({ id: 'did:cid:image' });
 
         expect(response.isError).toBeUndefined();
+        const metadata = { name: 'image.png', mimeType: 'image/png', image: { width: 1, height: 1 } };
         expect(response.content).toStrictEqual([
             { type: 'image', data: Buffer.from('image').toString('base64'), mimeType: 'image/png' },
-            { type: 'text', text: JSON.stringify({ name: 'image.png', image: { width: 1, height: 1 } }) },
+            { type: 'text', text: JSON.stringify(metadata) },
         ]);
-        expect(response.structuredContent).toStrictEqual({ name: 'image.png', image: { width: 1, height: 1 } });
+        expect(response.structuredContent).toStrictEqual(metadata);
     });
 
     it('returns a file asset as an embedded resource content block', async () => {
@@ -491,6 +495,21 @@ describe('mcp server tools', () => {
         ]);
         expect(response.structuredContent).toStrictEqual({ name: 'file.txt', mimeType: 'text/plain' });
         expect(runtime.keymaster.lookupDID).toHaveBeenCalledWith('file-alias');
+    });
+
+    it('defaults the mimeType and drops absent metadata from both mirrors', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        runtime.keymaster.getFile.mockResolvedValue({ data: Buffer.from('file') });
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const response: any = await server.tools.get('archon_get_asset_file')!.handler({ id: 'did:cid:file' });
+
+        expect((response.content[0] as any).resource.mimeType).toBe('application/octet-stream');
+        // structuredContent must be exactly the text block's payload: an absent filename
+        // is dropped by both, not left as an undefined key on one side.
+        expect(response.structuredContent).toStrictEqual({ mimeType: 'application/octet-stream' });
+        expect(JSON.parse(response.content[1].text)).toStrictEqual(response.structuredContent);
     });
 
     it('returns null for file-like assets with no data', async () => {


### PR DESCRIPTION
Closes #721.

`archon_get_asset_image` and `archon_get_asset_file` returned binary payloads as base64 inside a private JSON object (`{name, mimeType, encoding, data}`), so a spec-compliant client had to know our inline-data convention to render data MCP would otherwise display natively — the content-side counterpart to the envelope problem #691 reported.

## Changes

- `archon_get_asset_image` returns an `image` content block plus a text block with the filename and `width`/`height`, mirrored into `structuredContent`.
- `archon_get_asset_file` returns an embedded `resource` block, using the asset's DID as the resource URI (a DID is itself a URI, so no invented scheme), plus a metadata text block.
- Both still return `null` when the asset carries no data.
- Handlers reach this via a small tagged `contentResult()` wrapper that `ok()` passes through; every other tool's shape is untouched.

## Decisions

**Embedded resource over `resource_link`** (the open question in the issue): `resource_link` hands the client a URI it is expected to fetch via `resources/read`, which this server does not implement — the link would dangle. An embedded resource carries the bytes inline and works against any client today. The spec's requirement here is a SHOULD, not a MUST; adding the `resources` capability properly is worth its own issue, which I'll open.

**Input inline data is unchanged.** MCP defines content blocks for tool results, not arguments, and file paths aren't usable in an MCP server context.

`archon_get_vault_item` and `archon_get_dmail_attachment` have the same shape but are outside this issue's scope — they're a separate breaking-change decision.

## Breaking change

The result shape of both tools changes. No other tool is affected.

## Testing

`tests/mcp-server/tools.test.ts` asserts the new blocks for both tools and adds a null-data case; `expectOk` now finds the text block by type rather than assuming it's first, so the existing every-tool sweep still checks the text/`structuredContent` mirror invariant on these two. All 32 mcp-server tests pass.

Because the unit tests use a fake server, I also ran both tool results through the MCP SDK's own `CallToolResultSchema` — both validate (`["image","text"]`, `["resource","text"]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)