### PR TITLE
feat: author real input schemas for structured-object tools (#727)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -67,6 +67,17 @@ Destructive tools require `"confirm": true`, secret-revealing tools require `"re
 
 Set `ARCHON_MCP_READ_ONLY=true` to omit mutating tools from the advertised MCP tool list.
 
+### Structured inputs
+
+Tools whose argument is a specific object — `archon_restore_wallet_file` (a wallet), `archon_update_credential` (a credential), `archon_create_poll` (a poll config), `archon_create_dmail` / `archon_update_dmail` (a message) — declare that object's real shape, so the advertised input schema tells a client what to send and malformed input is rejected at the tool boundary rather than failing deeper inside Keymaster.
+
+Two rules apply when adding or changing one:
+
+- **Passthrough wherever the underlying type has an index signature.** Zod *strips* unknown keys rather than rejecting them, so a schema that omits an extension point silently deletes data — a wallet's custom metadata, or a credential's claims. Use a plain object only where the type is closed (`PollConfig`, `DmailMessage`), so junk fields are dropped instead of stored.
+- **Never be stricter than the Keymaster method behind the tool**, or the tool rejects input the CLI and REST API accept. Poll deadlines stay plain strings rather than ISO date-times because Keymaster accepts anything `new Date()` parses.
+
+Keymaster remains authoritative and re-validates everything. Semantic rules it enforces that a JSON Schema cannot express — a deadline must be in the future, a recipient must resolve to an agent — are not duplicated here; only constraints a client can act on before calling are.
+
 ## Tool results
 
 Results follow the MCP specification.

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -101,8 +101,11 @@ const WalletFileSchema = z.object({
     current: z.string().optional(),
     aliases: z.record(z.string()).optional(),
 }).passthrough();
-// StoredWallet is a union: restore accepts an encrypted backup or a plaintext wallet, and
-// saveWallet decrypts the former. The branches are NOT disjoint -- both passthrough, so an
+// StoredWallet is a union: restore accepts an encrypted backup (WalletEncFile) or a wallet
+// whose metadata is unencrypted (WalletFile), and saveWallet decrypts the former. Neither
+// form carries a plaintext secret -- both guards require seed.mnemonicEnc, the
+// passphrase-encrypted mnemonic; `enc` covers only counter/ids/aliases.
+// The branches are NOT disjoint -- both passthrough, so an
 // object carrying `enc` alongside `counter`/`ids` satisfies either. Order therefore matters
 // and encrypted must come first, which is what keymaster does too: isWalletEncFile keys on
 // `enc` being a string, and isWalletFile explicitly requires !('enc' in obj). So a hybrid
@@ -341,7 +344,7 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
     tool({ name: 'archon_import_wallet', cliCommand: 'import-wallet', description: 'Create a new wallet from a recovery phrase.', schema: z.object({ recoveryPhrase: z.string() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { recoveryPhrase }) => requireKeymaster(runtime).newWallet(recoveryPhrase, true) }),
     tool({ name: 'archon_show_wallet', cliCommand: 'show-wallet', description: 'Show the decrypted local wallet.', schema: RevealSchema, handler: runtime => requireKeymaster(runtime).loadWallet() }),
     tool({ name: 'archon_backup_wallet_file', cliCommand: 'backup-wallet-file', description: 'Return the encrypted wallet backup payload.', schema: RevealSchema, handler: runtime => requireKeymaster(runtime).exportEncryptedWallet() }),
-    tool({ name: 'archon_restore_wallet_file', cliCommand: 'restore-wallet-file', description: 'Restore the local wallet from a wallet payload, either an encrypted backup or a plaintext wallet.', schema: z.object({ wallet: StoredWalletSchema }).merge(ConfirmSchema), mutates: true, handler: (runtime, { wallet }) => requireKeymaster(runtime).saveWallet(wallet, true) }),
+    tool({ name: 'archon_restore_wallet_file', cliCommand: 'restore-wallet-file', description: 'Restore the local wallet from a wallet payload, either an encrypted backup or a wallet whose metadata is unencrypted. The seed is passphrase-encrypted in both, and the current passphrase must match.', schema: z.object({ wallet: StoredWalletSchema }).merge(ConfirmSchema), mutates: true, handler: (runtime, { wallet }) => requireKeymaster(runtime).saveWallet(wallet, true) }),
     tool({ name: 'archon_show_mnemonic', cliCommand: 'show-mnemonic', description: 'Reveal the wallet recovery phrase.', schema: RevealSchema, handler: runtime => requireKeymaster(runtime).decryptMnemonic() }),
     tool({ name: 'archon_backup_wallet_did', cliCommand: 'backup-wallet-did', description: 'Backup wallet to an encrypted DID and seed bank.', schema: ConfirmSchema, mutates: true, handler: runtime => requireKeymaster(runtime).backupWallet() }),
     tool({ name: 'archon_recover_wallet_did', cliCommand: 'recover-wallet-did', description: 'Recover wallet from seed bank or encrypted DID.', schema: z.object({ did: z.string().optional() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).recoverWallet(did) }),

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -71,17 +71,27 @@ const JsonObjectSchema = z.record(z.unknown());
 // resolving to an agent) stay in keymaster, which is authoritative and enforces them for
 // CLI and REST callers too. What is mirrored here is only what a client can act on before
 // calling; keymaster re-validates everything regardless.
+// keymaster's isWalletEncFile/isWalletFile guards (db/typeGuards.ts) are what actually gate
+// a restore, and they are the contract mirrored here -- not the WalletFile type, which
+// disagrees with them (it marks `version` optional; the guards require it). Both guards
+// demand version 1|2 and seed.mnemonicEnc, so requiring those rejects at the boundary
+// exactly what keymaster would reject with "Unsupported wallet version.".
+const WalletVersionSchema = z.union([z.literal(1), z.literal(2)]);
 const SeedSchema = z.object({
-    mnemonicEnc: z.object({ salt: z.string(), iv: z.string(), data: z.string() }).passthrough().optional(),
+    mnemonicEnc: z.object({ salt: z.string(), iv: z.string(), data: z.string() }).passthrough(),
 }).passthrough();
 const WalletEncFileSchema = z.object({
-    version: z.number(),
+    version: WalletVersionSchema,
     seed: SeedSchema,
     enc: z.string(),
 }).passthrough();
 const WalletFileSchema = z.object({
-    version: z.number().optional(),
+    version: WalletVersionSchema,
     seed: SeedSchema,
+    // The one place stricter than the runtime guard, which checks neither: the WalletFile
+    // type declares both, and newWallet always writes them, so a wallet without them is
+    // malformed regardless. A v1 wallet's `names` (renamed to `aliases` by upgradeWallet)
+    // survives via passthrough.
     counter: z.number(),
     ids: z.record(z.object({
         did: z.string(),
@@ -92,8 +102,11 @@ const WalletFileSchema = z.object({
     aliases: z.record(z.string()).optional(),
 }).passthrough();
 // StoredWallet is a union: restore accepts an encrypted backup or a plaintext wallet, and
-// saveWallet decrypts the former. The two are disjoint -- only WalletEncFile has `enc`,
-// only WalletFile has `counter`/`ids` -- so the union cannot match the wrong branch.
+// saveWallet decrypts the former. The branches are NOT disjoint -- both passthrough, so an
+// object carrying `enc` alongside `counter`/`ids` satisfies either. Order therefore matters
+// and encrypted must come first, which is what keymaster does too: isWalletEncFile keys on
+// `enc` being a string, and isWalletFile explicitly requires !('enc' in obj). So a hybrid
+// is treated as encrypted by both this schema and the method behind it.
 const StoredWalletSchema = z.union([WalletEncFileSchema, WalletFileSchema]);
 const VerifiableCredentialSchema = z.object({
     '@context': z.array(z.string()),
@@ -328,7 +341,7 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
     tool({ name: 'archon_import_wallet', cliCommand: 'import-wallet', description: 'Create a new wallet from a recovery phrase.', schema: z.object({ recoveryPhrase: z.string() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { recoveryPhrase }) => requireKeymaster(runtime).newWallet(recoveryPhrase, true) }),
     tool({ name: 'archon_show_wallet', cliCommand: 'show-wallet', description: 'Show the decrypted local wallet.', schema: RevealSchema, handler: runtime => requireKeymaster(runtime).loadWallet() }),
     tool({ name: 'archon_backup_wallet_file', cliCommand: 'backup-wallet-file', description: 'Return the encrypted wallet backup payload.', schema: RevealSchema, handler: runtime => requireKeymaster(runtime).exportEncryptedWallet() }),
-    tool({ name: 'archon_restore_wallet_file', cliCommand: 'restore-wallet-file', description: 'Restore the local wallet from an encrypted wallet payload.', schema: z.object({ wallet: StoredWalletSchema }).merge(ConfirmSchema), mutates: true, handler: (runtime, { wallet }) => requireKeymaster(runtime).saveWallet(wallet, true) }),
+    tool({ name: 'archon_restore_wallet_file', cliCommand: 'restore-wallet-file', description: 'Restore the local wallet from a wallet payload, either an encrypted backup or a plaintext wallet.', schema: z.object({ wallet: StoredWalletSchema }).merge(ConfirmSchema), mutates: true, handler: (runtime, { wallet }) => requireKeymaster(runtime).saveWallet(wallet, true) }),
     tool({ name: 'archon_show_mnemonic', cliCommand: 'show-mnemonic', description: 'Reveal the wallet recovery phrase.', schema: RevealSchema, handler: runtime => requireKeymaster(runtime).decryptMnemonic() }),
     tool({ name: 'archon_backup_wallet_did', cliCommand: 'backup-wallet-did', description: 'Backup wallet to an encrypted DID and seed bank.', schema: ConfirmSchema, mutates: true, handler: runtime => requireKeymaster(runtime).backupWallet() }),
     tool({ name: 'archon_recover_wallet_did', cliCommand: 'recover-wallet-did', description: 'Recover wallet from seed bank or encrypted DID.', schema: z.object({ did: z.string().optional() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).recoverWallet(did) }),

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -53,6 +53,82 @@ const ConfirmSchema = z.object({ confirm: z.literal(true) });
 const RevealSchema = z.object({ reveal: z.literal(true) });
 const ConfirmPaymentSchema = z.object({ confirmPayment: z.literal(true) });
 const JsonObjectSchema = z.record(z.unknown());
+
+// Input schemas for tools whose keymaster method needs a specific shape. Two rules learned
+// the hard way, both about .passthrough():
+//
+//   1. Where the source type declares an index signature (`[key: string]: any`), the schema
+//      MUST passthrough. Zod STRIPS unknown keys on parse, so a plain object here would
+//      silently delete a wallet's custom metadata on restore, or a credential's claims on
+//      update -- data loss, not a validation error. Passthrough is used exactly where the
+//      source type declares an extension point, and omitted where the type is closed
+//      (PollConfig, DmailMessage), so junk fields are dropped rather than stored.
+//   2. Never be stricter than the keymaster method behind the tool, or the tool rejects
+//      input the rest of the codebase accepts. Deadlines stay z.string() rather than
+//      .datetime() because keymaster accepts anything `new Date()` parses ('2026-12-01').
+//
+// Semantic rules that JSON Schema cannot express (a deadline in the future, a recipient
+// resolving to an agent) stay in keymaster, which is authoritative and enforces them for
+// CLI and REST callers too. What is mirrored here is only what a client can act on before
+// calling; keymaster re-validates everything regardless.
+const SeedSchema = z.object({
+    mnemonicEnc: z.object({ salt: z.string(), iv: z.string(), data: z.string() }).passthrough().optional(),
+}).passthrough();
+const WalletEncFileSchema = z.object({
+    version: z.number(),
+    seed: SeedSchema,
+    enc: z.string(),
+}).passthrough();
+const WalletFileSchema = z.object({
+    version: z.number().optional(),
+    seed: SeedSchema,
+    counter: z.number(),
+    ids: z.record(z.object({
+        did: z.string(),
+        account: z.number(),
+        index: z.number(),
+    }).passthrough()),
+    current: z.string().optional(),
+    aliases: z.record(z.string()).optional(),
+}).passthrough();
+// StoredWallet is a union: restore accepts an encrypted backup or a plaintext wallet, and
+// saveWallet decrypts the former. The two are disjoint -- only WalletEncFile has `enc`,
+// only WalletFile has `counter`/`ids` -- so the union cannot match the wrong branch.
+const StoredWalletSchema = z.union([WalletEncFileSchema, WalletFileSchema]);
+const VerifiableCredentialSchema = z.object({
+    '@context': z.array(z.string()),
+    type: z.array(z.string()),
+    issuer: z.string(),
+    validFrom: z.string(),
+    validUntil: z.string().optional(),
+    credentialSchema: z.object({ id: z.string(), type: z.literal('JsonSchema') }).optional(),
+    // Required here even though the type marks it optional: updateCredential rejects a
+    // credential without credentialSubject.id, and it replaces rather than merges, so a
+    // partial credential would overwrite a good one with a broken one. Passthrough because
+    // the claims live here as arbitrary keys -- stripping them would erase the credential.
+    credentialSubject: z.object({ id: z.string() }).passthrough(),
+    // `proof` is deliberately unconstrained rather than modelled: updateCredential deletes
+    // it and re-signs, so any proof is acceptable and typing it would reject credentials
+    // keymaster accepts. Passthrough carries it in, keymaster drops it.
+}).passthrough();
+const PollConfigSchema = z.object({
+    version: z.literal(2),
+    name: z.string().min(1),
+    description: z.string().min(1),
+    // 2..10 mirrors keymaster, which re-checks it. Worth stating because it is the one
+    // constraint a client cannot guess and JSON Schema can express (minItems/maxItems).
+    options: z.array(z.string()).min(2).max(10),
+    deadline: z.string(),
+});
+const DmailMessageSchema = z.object({
+    to: z.array(z.string()).min(1),
+    // Defaulted rather than required: keymaster throws InvalidParameterError('list') when
+    // cc is absent, which is a confusing failure for an omitted optional-looking field.
+    cc: z.array(z.string()).default([]),
+    subject: z.string().min(1),
+    body: z.string().min(1),
+    reference: z.string().optional(),
+});
 const JsonValueSchema = z.unknown();
 const DidCommEncSchema = z.enum(['A256CBC-HS512', 'XC20P', 'A256GCM']);
 const InlineDataSchema = z.object({
@@ -227,15 +303,6 @@ function inlineDataFromBuffer(buffer: Buffer, name?: string, mimeType?: string) 
     };
 }
 
-// Marks the tools whose declared input is a loose JSON object (JsonObjectSchema) while
-// the keymaster method behind them expects a specific shape. The cast is what the old
-// blanket `any` on requireKeymaster() did implicitly at every call site; naming it keeps
-// the remaining gaps visible and greppable. Authoring real input schemas for these is
-// tracked separately -- doing it here would change which inputs the tools accept.
-function unvalidatedShape<T>(value: object): T {
-    return value as T;
-}
-
 function signableJson(input: unknown): object {
     if (!input || typeof input !== 'object' || Array.isArray(input)) {
         throw new Error('object must be a JSON object');
@@ -261,7 +328,7 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
     tool({ name: 'archon_import_wallet', cliCommand: 'import-wallet', description: 'Create a new wallet from a recovery phrase.', schema: z.object({ recoveryPhrase: z.string() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { recoveryPhrase }) => requireKeymaster(runtime).newWallet(recoveryPhrase, true) }),
     tool({ name: 'archon_show_wallet', cliCommand: 'show-wallet', description: 'Show the decrypted local wallet.', schema: RevealSchema, handler: runtime => requireKeymaster(runtime).loadWallet() }),
     tool({ name: 'archon_backup_wallet_file', cliCommand: 'backup-wallet-file', description: 'Return the encrypted wallet backup payload.', schema: RevealSchema, handler: runtime => requireKeymaster(runtime).exportEncryptedWallet() }),
-    tool({ name: 'archon_restore_wallet_file', cliCommand: 'restore-wallet-file', description: 'Restore the local wallet from an encrypted wallet payload.', schema: z.object({ wallet: JsonObjectSchema }).merge(ConfirmSchema), mutates: true, handler: (runtime, { wallet }) => requireKeymaster(runtime).saveWallet(unvalidatedShape(wallet), true) }),
+    tool({ name: 'archon_restore_wallet_file', cliCommand: 'restore-wallet-file', description: 'Restore the local wallet from an encrypted wallet payload.', schema: z.object({ wallet: StoredWalletSchema }).merge(ConfirmSchema), mutates: true, handler: (runtime, { wallet }) => requireKeymaster(runtime).saveWallet(wallet, true) }),
     tool({ name: 'archon_show_mnemonic', cliCommand: 'show-mnemonic', description: 'Reveal the wallet recovery phrase.', schema: RevealSchema, handler: runtime => requireKeymaster(runtime).decryptMnemonic() }),
     tool({ name: 'archon_backup_wallet_did', cliCommand: 'backup-wallet-did', description: 'Backup wallet to an encrypted DID and seed bank.', schema: ConfirmSchema, mutates: true, handler: runtime => requireKeymaster(runtime).backupWallet() }),
     tool({ name: 'archon_recover_wallet_did', cliCommand: 'recover-wallet-did', description: 'Recover wallet from seed bank or encrypted DID.', schema: z.object({ did: z.string().optional() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).recoverWallet(did) }),
@@ -303,7 +370,7 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
     tool({ name: 'archon_bind_credential', cliCommand: 'bind-credential', description: 'Create a bound credential for a subject.', schema: z.object({ schema: z.string(), subject: z.string(), claims: JsonObjectSchema.optional(), validFrom: z.string().optional(), validUntil: z.string().optional() }), handler: (runtime, { subject, schema, claims, validFrom, validUntil }) => requireKeymaster(runtime).bindCredential(subject, compactOptions({ schema, claims, validFrom, validUntil })) }),
     tool({ name: 'archon_issue_credential', cliCommand: 'issue-credential', description: 'Sign and encrypt a bound credential.', schema: z.object({ credential: JsonObjectSchema, alias: z.string().optional(), registry: z.string().optional() }), mutates: true, handler: (runtime, { credential, alias, registry }) => requireKeymaster(runtime).issueCredential(credential, compactOptions({ alias, registry })) }),
     tool({ name: 'archon_list_issued', cliCommand: 'list-issued', description: 'List issued credentials.', schema: z.object({ issuer: z.string().optional() }), handler: (runtime, { issuer }) => requireKeymaster(runtime).listIssued(issuer) }),
-    tool({ name: 'archon_update_credential', cliCommand: 'update-credential', description: 'Update an issued credential.', schema: z.object({ did: z.string(), credential: JsonObjectSchema }), mutates: true, handler: (runtime, { did, credential }) => requireKeymaster(runtime).updateCredential(did, unvalidatedShape(credential)) }),
+    tool({ name: 'archon_update_credential', cliCommand: 'update-credential', description: 'Update an issued credential.', schema: z.object({ did: z.string(), credential: VerifiableCredentialSchema }), mutates: true, handler: (runtime, { did, credential }) => requireKeymaster(runtime).updateCredential(did, credential) }),
     tool({ name: 'archon_revoke_credential', cliCommand: 'revoke-credential', description: 'Revoke a verifiable credential.', schema: DidSchema.merge(ConfirmSchema), mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).revokeCredential(did) }),
     tool({ name: 'archon_accept_credential', cliCommand: 'accept-credential', description: 'Save a verifiable credential for the current ID.', schema: DidSchema.extend({ alias: z.string().optional() }), mutates: true, handler: async (runtime, { did, alias }) => {
         const keymaster = requireKeymaster(runtime);
@@ -409,12 +476,18 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
     tool({ name: 'archon_update_asset_file', cliCommand: 'update-asset-file', description: 'Update a file asset from an inline payload.', schema: IdSchema.extend({ file: InlineDataSchema }), mutates: true, handler: (runtime, { id, file }) => requireKeymaster(runtime).updateFile(id, bufferFromInlineData(file), compactOptions({ filename: file.name, contentType: file.mimeType })) }),
     tool({ name: 'archon_transfer_asset', cliCommand: 'transfer-asset', description: 'Transfer an asset to a new controller DID.', schema: IdSchema.extend({ controller: z.string() }), mutates: true, handler: (runtime, { id, controller }) => requireKeymaster(runtime).transferAsset(id, controller) }),
     tool({ name: 'archon_clone_asset', cliCommand: 'clone-asset', description: 'Clone an asset.', schema: IdSchema.merge(AliasOptionsSchema), mutates: true, handler: (runtime, { id, alias, registry }) => requireKeymaster(runtime).cloneAsset(id, compactOptions({ alias, registry })) }),
-    tool({ name: 'archon_get_property', cliCommand: 'get-property', description: 'Get a property from a DID document data object.', schema: IdSchema.extend({ key: z.string() }), handler: async (runtime, { id, key }) => unvalidatedShape<Record<string, unknown>>((await requireKeymaster(runtime).resolveDID(id)).didDocumentData ?? {})[key] }),
+    tool({ name: 'archon_get_property', cliCommand: 'get-property', description: 'Get a property from a DID document data object.', schema: IdSchema.extend({ key: z.string() }), handler: async (runtime, { id, key }) => {
+        // didDocumentData is `unknown` and is routinely not an object -- an asset's data can
+        // be an array or a scalar, which has no property to get. Guarding also stops an
+        // index into a string or array returning a nonsense "property".
+        const { didDocumentData } = await requireKeymaster(runtime).resolveDID(id);
+        return isJsonObject(didDocumentData) ? didDocumentData[key] : undefined;
+    } }),
     tool({ name: 'archon_set_property', cliCommand: 'set-property', description: 'Set a property on a DID document data object.', schema: IdSchema.extend({ key: z.string(), value: JsonValueSchema.nullable().optional() }), mutates: true, handler: (runtime, { id, key, value }) => requireKeymaster(runtime).mergeData(id, { [key]: value ?? null }) }),
     tool({ name: 'archon_list_assets', cliCommand: 'list-assets', description: 'List assets owned by an ID.', schema: z.object({ owner: z.string().optional() }), handler: (runtime, { owner }) => requireKeymaster(runtime).listAssets(owner) }),
 
     tool({ name: 'archon_create_poll_template', cliCommand: 'create-poll-template', description: 'Create a poll config template.', schema: EmptySchema, handler: runtime => requireKeymaster(runtime).pollTemplate() }),
-    tool({ name: 'archon_create_poll', cliCommand: 'create-poll', description: 'Create a poll from inline JSON config.', schema: z.object({ config: JsonObjectSchema }).merge(VaultOptionsSchema), mutates: true, handler: (runtime, { config, ...options }) => requireKeymaster(runtime).createPoll(unvalidatedShape(config), compactOptions(options)) }),
+    tool({ name: 'archon_create_poll', cliCommand: 'create-poll', description: 'Create a poll from inline JSON config.', schema: z.object({ config: PollConfigSchema }).merge(VaultOptionsSchema), mutates: true, handler: (runtime, { config, ...options }) => requireKeymaster(runtime).createPoll(config, compactOptions(options)) }),
     tool({ name: 'archon_add_poll_voter', cliCommand: 'add-poll-voter', description: 'Add a voter to a poll.', schema: z.object({ poll: z.string(), member: z.string() }), mutates: true, handler: (runtime, { poll, member }) => requireKeymaster(runtime).addPollVoter(poll, member) }),
     tool({ name: 'archon_remove_poll_voter', cliCommand: 'remove-poll-voter', description: 'Remove a voter from a poll.', schema: z.object({ poll: z.string(), member: z.string() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { poll, member }) => requireKeymaster(runtime).removePollVoter(poll, member) }),
     tool({ name: 'archon_list_poll_voters', cliCommand: 'list-poll-voters', description: 'List eligible voters in a poll.', schema: z.object({ poll: z.string() }), handler: (runtime, { poll }) => requireKeymaster(runtime).listPollVoters(poll) }),
@@ -440,8 +513,8 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
         return buffer ? inlineDataFromBuffer(Buffer.from(buffer), item) : null;
     } }),
 
-    tool({ name: 'archon_create_dmail', cliCommand: 'create-dmail', description: 'Create a dmail from inline JSON.', schema: z.object({ message: JsonObjectSchema }).merge(VaultOptionsSchema), mutates: true, handler: (runtime, { message, ...options }) => requireKeymaster(runtime).createDmail(unvalidatedShape(message), compactOptions(options)) }),
-    tool({ name: 'archon_update_dmail', cliCommand: 'update-dmail', description: 'Update an existing dmail from inline JSON.', schema: DidSchema.extend({ message: JsonObjectSchema }), mutates: true, handler: (runtime, { did, message }) => requireKeymaster(runtime).updateDmail(did, unvalidatedShape(message)) }),
+    tool({ name: 'archon_create_dmail', cliCommand: 'create-dmail', description: 'Create a dmail from inline JSON.', schema: z.object({ message: DmailMessageSchema }).merge(VaultOptionsSchema), mutates: true, handler: (runtime, { message, ...options }) => requireKeymaster(runtime).createDmail(message, compactOptions(options)) }),
+    tool({ name: 'archon_update_dmail', cliCommand: 'update-dmail', description: 'Update an existing dmail from inline JSON.', schema: DidSchema.extend({ message: DmailMessageSchema }), mutates: true, handler: (runtime, { did, message }) => requireKeymaster(runtime).updateDmail(did, message) }),
     tool({ name: 'archon_send_dmail', cliCommand: 'send-dmail', description: 'Send a dmail and return the notice DID.', schema: DidSchema, mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).sendDmail(did) }),
     tool({ name: 'archon_get_dmail', cliCommand: 'get-dmail', description: 'Get a dmail message by DID.', schema: DidSchema.merge(ResolveOptionsSchema), handler: (runtime, { did, ...options }) => requireKeymaster(runtime).getDmailMessage(did, compactOptions(options)) }),
     tool({ name: 'archon_list_dmail', cliCommand: 'list-dmail', description: 'List dmails for the current ID.', schema: EmptySchema, handler: runtime => requireKeymaster(runtime).listDmail() }),

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -91,7 +91,7 @@ const defaultToolArgs = {
     value: 'world',
     version: 1,
     vote: 1,
-    wallet: { version: 2, seed: {}, counter: 0, ids: {} },
+    wallet: { version: 2, seed: { mnemonicEnc: { salt: 's', iv: 'i', data: 'd' } }, counter: 0, ids: {} },
 };
 
 const toolArgOverrides: Record<string, Record<string, unknown>> = {
@@ -453,7 +453,7 @@ describe('mcp server tools', () => {
         registerArchonTools(server, runtime as any, baseConfig);
 
         const wallet = {
-            version: 2,
+            version: 2 as const,
             seed: { mnemonicEnc: { salt: 's', iv: 'i', data: 'd' }, customSeedField: 'keep' },
             counter: 4,
             ids: { alice: { did: 'did:cid:alice', account: 0, index: 1, owned: ['did:cid:asset'], customIdField: 'keep' } },
@@ -539,12 +539,37 @@ describe('mcp server tools', () => {
         expectOk(await server.tools.get('archon_restore_wallet_file')!.handler({ wallet: encrypted, confirm: true }));
         expect(runtime.keymaster.saveWallet).toHaveBeenCalledWith(encrypted, true);
 
-        const plaintext = { version: 2, seed: {}, counter: 1, ids: {} };
+        const plaintext = { version: 2, seed: { mnemonicEnc: { salt: 's', iv: 'i', data: 'd' } }, counter: 1, ids: {} };
         expectOk(await server.tools.get('archon_restore_wallet_file')!.handler({ wallet: plaintext, confirm: true }));
         expect(runtime.keymaster.saveWallet).toHaveBeenLastCalledWith(plaintext, true);
 
         // Neither branch matches, so the union rejects rather than guessing.
-        expect(expectFail(await server.tools.get('archon_restore_wallet_file')!.handler({ wallet: { seed: {} }, confirm: true }))).toMatch(/enc|counter|ids/);
+        expect(expectFail(await server.tools.get('archon_restore_wallet_file')!.handler({ wallet: { seed: {} }, confirm: true }))).toMatch(/enc|counter|ids|mnemonicEnc/);
+    });
+
+    it('accepts a v1 wallet and preserves its legacy names field', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        // keymaster's upgradeWallet renames `names` to `aliases` for v1 wallets, so the
+        // schema must not drop `names` before it ever gets there -- passthrough carries it.
+        const v1 = {
+            version: 1,
+            seed: { mnemonicEnc: { salt: 's', iv: 'i', data: 'd' } },
+            counter: 2,
+            ids: {},
+            names: { bob: 'did:cid:bob' },
+        };
+
+        expectOk(await server.tools.get('archon_restore_wallet_file')!.handler({ wallet: v1, confirm: true }));
+        expect(runtime.keymaster.saveWallet).toHaveBeenCalledWith(v1, true);
+
+        // Both guards require version 1|2, so a v3 wallet is rejected at the boundary
+        // rather than reaching keymaster's "Unsupported wallet version." deeper in.
+        expect(expectFail(await server.tools.get('archon_restore_wallet_file')!.handler({
+            wallet: { ...v1, version: 3 }, confirm: true,
+        }))).toMatch(/version/);
     });
 
     it('passes inline base64 payloads to file-like tools', async () => {

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -38,11 +38,17 @@ const defaultToolArgs = {
     bolt11: 'lnbc...',
     challenge: { prompt: 'prove it' },
     claims: { name: 'Alice' },
-    config: { title: 'Poll', options: ['yes', 'no'] },
+    config: { version: 2, name: 'Poll', description: 'Best option?', options: ['yes', 'no'], deadline: '2099-01-01T00:00:00Z' },
     confirm: true,
     confirmPayment: true,
     controller: 'did:cid:bob',
-    credential: { type: ['VerifiableCredential'] },
+    credential: {
+        '@context': ['https://www.w3.org/ns/credentials/v2'],
+        type: ['VerifiableCredential'],
+        issuer: 'did:cid:issuer',
+        validFrom: '2026-01-01T00:00:00Z',
+        credentialSubject: { id: 'did:cid:alice', name: 'Alice' },
+    },
     data: { hello: 'world' },
     did: 'did:cid:alice',
     domain: 'example.com',
@@ -58,7 +64,7 @@ const defaultToolArgs = {
     key: 'hello',
     member: 'did:cid:member',
     memo: 'coffee',
-    message: { body: 'hello' },
+    message: { to: ['did:cid:bob'], cc: [], subject: 'hi', body: 'hello' },
     name: 'Alice',
     newName: 'Alicia',
     newPassphrase: 'new secret',
@@ -85,7 +91,7 @@ const defaultToolArgs = {
     value: 'world',
     version: 1,
     vote: 1,
-    wallet: { version: 2, ids: {} },
+    wallet: { version: 2, seed: {}, counter: 0, ids: {} },
 };
 
 const toolArgOverrides: Record<string, Record<string, unknown>> = {
@@ -435,6 +441,110 @@ describe('mcp server tools', () => {
             { hello: 'world' },
             { alias: 'hello', registry: 'hyperswarm' }
         );
+    });
+
+    // Zod strips unknown keys on parse, so a schema that omits an extension point does not
+    // reject data -- it silently deletes it. These two tools carry types that declare
+    // `[key: string]: any`, and losing those keys would corrupt a restored wallet or erase
+    // a credential's claims, so the schemas must passthrough.
+    it('preserves custom metadata when restoring a wallet', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const wallet = {
+            version: 2,
+            seed: { mnemonicEnc: { salt: 's', iv: 'i', data: 'd' }, customSeedField: 'keep' },
+            counter: 4,
+            ids: { alice: { did: 'did:cid:alice', account: 0, index: 1, owned: ['did:cid:asset'], customIdField: 'keep' } },
+            current: 'alice',
+            aliases: { bob: 'did:cid:bob' },
+            customWalletField: 'keep',
+        };
+
+        expectOk(await server.tools.get('archon_restore_wallet_file')!.handler({ wallet, confirm: true }));
+
+        // Byte-identical: nothing added, nothing dropped.
+        expect(runtime.keymaster.saveWallet).toHaveBeenCalledWith(wallet, true);
+    });
+
+    it('preserves credential claims when updating a credential', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const credential = {
+            '@context': ['https://www.w3.org/ns/credentials/v2'],
+            type: ['VerifiableCredential'],
+            issuer: 'did:cid:issuer',
+            validFrom: '2026-01-01T00:00:00Z',
+            credentialSubject: { id: 'did:cid:alice', name: 'Alice', age: 30 },
+            proof: { type: 'SomeOtherSignature2030', proofValue: 'z1' },
+        };
+
+        expectOk(await server.tools.get('archon_update_credential')!.handler({ did: 'did:cid:vc', credential }));
+
+        // The claims under credentialSubject survive, and so does an unmodelled proof --
+        // updateCredential deletes and re-signs it, so constraining it would reject
+        // credentials keymaster accepts.
+        expect(runtime.keymaster.updateCredential).toHaveBeenCalledWith('did:cid:vc', credential);
+    });
+
+    it('rejects malformed input at the tool boundary', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const poll = server.tools.get('archon_create_poll')!.handler;
+        const base = { version: 2 as const, name: 'Poll', description: 'd', options: ['a', 'b'], deadline: '2099-01-01' };
+
+        expect(expectFail(await poll({ config: { ...base, options: ['only-one'] } }))).toMatch(/options/);
+        expect(expectFail(await poll({ config: { ...base, version: 1 } }))).toMatch(/version/);
+        expect(expectFail(await poll({ config: { ...base, name: '' } }))).toMatch(/name/);
+
+        // Previously accepted and passed to keymaster, which failed deeper in.
+        expect(expectFail(await poll({ config: { title: 'Poll', options: ['yes', 'no'] } }))).toMatch(/version|name|description|deadline/);
+        expect(runtime.keymaster.createPoll).not.toHaveBeenCalled();
+
+        const dmail = server.tools.get('archon_create_dmail')!.handler;
+        expect(expectFail(await dmail({ message: { to: [], subject: 's', body: 'b' } }))).toMatch(/to/);
+        expect(expectFail(await dmail({ message: { to: ['did:cid:bob'], subject: '', body: 'b' } }))).toMatch(/subject/);
+    });
+
+    it('defaults an omitted dmail cc to an empty list', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        // keymaster's verifyRecipientList throws InvalidParameterError('list') on a missing
+        // cc, which reads as a bug rather than a missing field. Defaulting is strictly more
+        // permissive than the old behaviour, so nothing that worked before breaks.
+        expectOk(await server.tools.get('archon_create_dmail')!.handler({
+            message: { to: ['did:cid:bob'], subject: 'hi', body: 'hello' },
+        }));
+
+        expect(runtime.keymaster.createDmail).toHaveBeenCalledWith(
+            { to: ['did:cid:bob'], cc: [], subject: 'hi', body: 'hello' },
+            undefined
+        );
+    });
+
+    it('accepts either an encrypted or a plaintext wallet on restore', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        // StoredWallet is a union; saveWallet decrypts the encrypted form itself.
+        const encrypted = { version: 2, seed: { mnemonicEnc: { salt: 's', iv: 'i', data: 'd' } }, enc: 'ciphertext' };
+        expectOk(await server.tools.get('archon_restore_wallet_file')!.handler({ wallet: encrypted, confirm: true }));
+        expect(runtime.keymaster.saveWallet).toHaveBeenCalledWith(encrypted, true);
+
+        const plaintext = { version: 2, seed: {}, counter: 1, ids: {} };
+        expectOk(await server.tools.get('archon_restore_wallet_file')!.handler({ wallet: plaintext, confirm: true }));
+        expect(runtime.keymaster.saveWallet).toHaveBeenLastCalledWith(plaintext, true);
+
+        // Neither branch matches, so the union rejects rather than guessing.
+        expect(expectFail(await server.tools.get('archon_restore_wallet_file')!.handler({ wallet: { seed: {} }, confirm: true }))).toMatch(/enc|counter|ids/);
     });
 
     it('passes inline base64 payloads to file-like tools', async () => {

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -529,19 +529,21 @@ describe('mcp server tools', () => {
         );
     });
 
-    it('accepts either an encrypted or a plaintext wallet on restore', async () => {
+    it('accepts both wallet forms on restore', async () => {
         const server = new FakeServer();
         const runtime = mockRuntime();
         registerArchonTools(server, runtime as any, baseConfig);
 
-        // StoredWallet is a union; saveWallet decrypts the encrypted form itself.
+        // StoredWallet is a union; saveWallet decrypts the encrypted form itself. Neither
+        // form holds a plaintext secret -- the seed is passphrase-encrypted in both, and only
+        // the metadata (counter/ids/aliases) differs in whether it is wrapped in `enc`.
         const encrypted = { version: 2, seed: { mnemonicEnc: { salt: 's', iv: 'i', data: 'd' } }, enc: 'ciphertext' };
         expectOk(await server.tools.get('archon_restore_wallet_file')!.handler({ wallet: encrypted, confirm: true }));
         expect(runtime.keymaster.saveWallet).toHaveBeenCalledWith(encrypted, true);
 
-        const plaintext = { version: 2, seed: { mnemonicEnc: { salt: 's', iv: 'i', data: 'd' } }, counter: 1, ids: {} };
-        expectOk(await server.tools.get('archon_restore_wallet_file')!.handler({ wallet: plaintext, confirm: true }));
-        expect(runtime.keymaster.saveWallet).toHaveBeenLastCalledWith(plaintext, true);
+        const unencryptedMetadata = { version: 2, seed: { mnemonicEnc: { salt: 's', iv: 'i', data: 'd' } }, counter: 1, ids: {} };
+        expectOk(await server.tools.get('archon_restore_wallet_file')!.handler({ wallet: unencryptedMetadata, confirm: true }));
+        expect(runtime.keymaster.saveWallet).toHaveBeenLastCalledWith(unencryptedMetadata, true);
 
         // Neither branch matches, so the union rejects rather than guessing.
         expect(expectFail(await server.tools.get('archon_restore_wallet_file')!.handler({ wallet: { seed: {} }, confirm: true }))).toMatch(/enc|counter|ids|mnemonicEnc/);


### PR DESCRIPTION
Closes #727.

Five tools declared a loose `JsonObjectSchema` — any JSON object at all — and handed it straight to a Keymaster method that needs a specific shape. The server advertised "send me anything" and then failed deep inside Keymaster, which for an LLM client is the worst case: the input schema is the only signal about what to send, so `{}` looked acceptable for `archon_create_poll`.

They now declare the real shape:

| tool | was | now |
| --- | --- | --- |
| `archon_restore_wallet_file` | any object | `StoredWallet` (union: encrypted or plaintext) |
| `archon_update_credential` | any object | `VerifiableCredential` |
| `archon_create_poll` | any object | `PollConfig` |
| `archon_create_dmail` / `archon_update_dmail` | any object | `DmailMessage` |

All `unvalidatedShape()` markers from #728 are gone, including `archon_get_property`'s — `didDocumentData` is `unknown` and often isn't an object, so it now guards with `isJsonObject` rather than casting. That also fixes a latent bug: indexing a string or array `didDocumentData` could return a nonsense "property" (`"hello"[0]` → `"h"`).

## The hazard worth knowing about

**It's the inverse of the `outputSchema` one, and it's dangerous.** Zod *strips* unknown keys on input parse rather than rejecting them. `WalletFile` and `IDInfo` both declare `[key: string]: any` ("Allow custom metadata fields"), and a credential's claims live as arbitrary keys under `credentialSubject`. So a plain `z.object` here wouldn't have rejected anything — it would have **silently deleted data**: custom metadata wiped from a restored wallet, claims erased from an updated credential. On a backup-restore path, that's about as bad as it gets.

Schemas therefore `.passthrough()` exactly where the source type declares an extension point (`WalletFile`, `IDInfo`, `Seed`, `credentialSubject`) and stay closed where it doesn't (`PollConfig`, `DmailMessage`), so junk fields are dropped rather than stored. There are tests pinning both directions.

## Deliberately not stricter than Keymaster

A tool that rejects input the CLI and REST API accept is a regression, so:

- **Deadlines stay `z.string()`**, not `.datetime()` — Keymaster accepts anything `new Date()` parses, including `"2026-12-01"`.
- **`proof` is left unmodelled** — `updateCredential` deletes and re-signs it, so any proof is acceptable; typing it as `Proof` would reject credentials Keymaster is happy with.
- **Semantic rules stay in Keymaster** (deadline in the future, recipient resolves to an agent). It re-validates everything and remains authoritative — this addresses the issue's "validation in two places that can drift" question. Only constraints a client can act on *before* calling are mirrored: `options` 2–10 (expressible as `minItems`/`maxItems`, and the one thing a client can't guess) and `version: 2`.

Two small honesty fixes fall out: `credentialSubject` is **required** (the type marks it optional, but `updateCredential` rejects a credential without it, and it *replaces* rather than merges — so a partial credential silently overwrote a good one with a broken one), and `cc` now **defaults to `[]`** (Keymaster's `verifyRecipientList` throws `InvalidParameterError('list')` when it's absent, which reads as a bug rather than a missing field — so this is strictly more permissive than before).

`archon_issue_credential` is intentionally left alone: it takes a `Partial<VerifiableCredential>`, so its loose schema is honest.

## Testing

New cases cover data preservation (custom wallet metadata and credential claims survive byte-identically), boundary rejection (malformed poll/dmail rejected before Keymaster is called), the `cc` default, and both union branches plus a non-matching one.

The sweep test's fixtures turned out to have **never been valid** — the poll config was `{ title: 'Poll', options: [...] }`, and `title` isn't a `PollConfig` field at all. Nothing caught it because the schemas accepted anything. Fixed to real shapes.

Verified through a real `McpServer`/`Client` pair, not just the FakeServer: the wallet union survives JSON Schema generation as `anyOf`, custom metadata survives the wire *and* the parse, and malformed input is rejected with Keymaster never called.

42 mcp-server tests pass; typecheck clean.

## Breaking change

Input that was previously accepted — and then failed deeper inside Keymaster — is now rejected up front. That's the point, but it should be called out. Cost: ~615 tokens on `listTools`; unlike output schemas, these replace advertisements that already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)