### PR TITLE
feat: implement the MCP resources capability (#725)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -105,7 +105,7 @@ Tools returning binary assets use the content block types the protocol defines f
 }
 ```
 
-`archon_get_asset_file` returns an embedded `resource` block identified by the asset's DID:
+`archon_get_asset_file` returns an embedded `resource` block identified by the asset's DID, which is a URI the server also serves as an MCP resource — see [Resources](#resources):
 
 ```json
 {
@@ -143,6 +143,23 @@ They are declared selectively rather than everywhere, by design:
 So the bar is: the result is an object the tool always returns, and something downstream consumes a field from it. Schemas describe the nesting a caller must navigate — leaves are intentionally loose, and fields typed `unknown` at the source (such as `didDocumentData`) stay unknown.
 
 If you add one, it must be a `.passthrough()` object. A plain zod object serializes to `additionalProperties: false`, which makes clients reject any field the schema doesn't enumerate.
+
+## Resources
+
+The server implements the MCP `resources` capability. An Archon asset DID is already a URI, so it is the resource URI verbatim — the same one `archon_get_asset_file` puts in its embedded `resource` block. `resources/read` on that URI returns the asset:
+
+```json
+{
+  "uri": "did:cid:z3v8Auah...",
+  "contents": [{ "uri": "did:cid:z3v8Auah...", "mimeType": "text/plain", "blob": "<base64>" }]
+}
+```
+
+File and image assets return their bytes; any other asset returns its JSON data with `mimeType: "application/json"`. URIs that are not `did:cid:` are not matched.
+
+**`resources/list` is empty by design.** Enumerating every asset in the wallet would disclose its contents to any connected client, whether or not it ever reads one. Reads are by a DID the caller already holds, which reveals nothing that resolving that DID wouldn't. `resources/templates/list` advertises `did:cid:{id}`, so the read path is still discoverable. What a filtered list should expose is an open question.
+
+Resource reads are wallet-backed and require `ARCHON_PASSPHRASE`, the same as the equivalent tools. They are reads, so `ARCHON_MCP_READ_ONLY` does not affect them.
 
 ## Examples
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,13 +3,15 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { loadConfig } from './config.js';
 import { createArchonRuntime } from './runtime.js';
 import { registerArchonTools } from './tools.js';
+import { registerArchonResources } from './resources.js';
 
 export { loadConfig, walletLocation } from './config.js';
 export type { McpServerConfig, WalletType } from './config.js';
-export { createArchonRuntime, createWallet } from './runtime.js';
+export { createArchonRuntime, createWallet, requireKeymaster } from './runtime.js';
 export type { ArchonRuntime } from './runtime.js';
 export { ARCHON_MCP_CLI_COMMANDS, ARCHON_MCP_TOOL_DEFINITIONS, registerArchonTools } from './tools.js';
 export type { ArchonToolDefinition } from './tools.js';
+export { ARCHON_ASSET_URI_TEMPLATE, registerArchonResources } from './resources.js';
 
 export async function main(): Promise<void> {
     const config = loadConfig();
@@ -20,6 +22,7 @@ export async function main(): Promise<void> {
     });
 
     registerArchonTools(server as any, runtime, config);
+    registerArchonResources(server as any, runtime);
 
     const transport = new StdioServerTransport();
     await server.connect(transport);

--- a/packages/mcp-server/src/resources.ts
+++ b/packages/mcp-server/src/resources.ts
@@ -1,0 +1,72 @@
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import { ArchonRuntime, requireKeymaster } from './runtime.js';
+
+// An Archon asset DID is already a URI, so it is the resource URI verbatim -- the same one
+// archon_get_asset_file puts in its embedded resource block. Registering this template is
+// what makes that URI dereferenceable instead of decorative.
+export const ARCHON_ASSET_URI_TEMPLATE = 'did:cid:{id}';
+
+type RegisterableResourceServer = {
+    registerResource?: (
+        name: string,
+        uriOrTemplate: unknown,
+        config: Record<string, unknown>,
+        readCallback: (uri: URL, variables: unknown, extra: unknown) => Promise<ReadResourceResult>
+    ) => void;
+};
+
+async function readAsset(runtime: ArchonRuntime, uri: URL): Promise<ReadResourceResult> {
+    const keymaster = requireKeymaster(runtime);
+    const did = uri.href;
+
+    // getFile first, and deliberately: it covers image assets too (an image asset stores
+    // { file, image }, so asset.file is present for both), and binary assets are the ones
+    // clients actually arrive here holding a URI for -- get_asset_file's resource block is
+    // where these URIs come from. That costs one resolve for the common case; the JSON
+    // fallback below pays a second.
+    const file = await keymaster.getFile(did);
+
+    if (file?.data) {
+        return {
+            contents: [{
+                uri: did,
+                mimeType: file.type ?? 'application/octet-stream',
+                blob: Buffer.from(file.data).toString('base64'),
+            }],
+        };
+    }
+
+    // Any other asset is readable as its JSON data, so a did:cid URI resolves to something
+    // sensible rather than erroring based on which flavour of asset it happens to be.
+    const asset = await keymaster.resolveAsset(did);
+
+    return {
+        contents: [{
+            uri: did,
+            mimeType: 'application/json',
+            text: JSON.stringify(asset),
+        }],
+    };
+}
+
+export function registerArchonResources(server: RegisterableResourceServer, runtime: ArchonRuntime): void {
+    if (!server.registerResource) {
+        throw new Error('MCP server does not support resource registration');
+    }
+
+    server.registerResource(
+        'archon-asset',
+        // `list: undefined` is the SDK's explicit opt-out, not an oversight: enumerating
+        // every asset in the wallet would hand its whole contents to any connected client,
+        // read or not. Reads are by URI you already hold, so nothing is disclosed that
+        // resolving the DID would not already reveal. Deciding what a filtered list should
+        // expose is left open.
+        new ResourceTemplate(ARCHON_ASSET_URI_TEMPLATE, { list: undefined }),
+        {
+            title: 'Archon asset',
+            description: 'Read an Archon asset by its DID. File and image assets return their bytes; any other asset returns its JSON data.',
+        },
+        (uri: URL) => readAsset(runtime, uri)
+    );
+}

--- a/packages/mcp-server/src/resources.ts
+++ b/packages/mcp-server/src/resources.ts
@@ -27,7 +27,15 @@ async function readAsset(runtime: ArchonRuntime, uri: URL): Promise<ReadResource
     // fallback below pays a second.
     const file = await keymaster.getFile(did);
 
-    if (file?.data) {
+    if (file) {
+        // getFile returns the file WITHOUT data when the gatekeeper cannot fetch its CID,
+        // and returns null only when the asset is not a file asset at all. Those are
+        // different failures and must not collapse: falling back to JSON here would answer
+        // a request for bytes with metadata, reporting an unavailable CID as a success.
+        if (!file.data) {
+            throw new Error(`Asset data is unavailable for ${did}`);
+        }
+
         return {
             contents: [{
                 uri: did,
@@ -37,8 +45,8 @@ async function readAsset(runtime: ArchonRuntime, uri: URL): Promise<ReadResource
         };
     }
 
-    // Any other asset is readable as its JSON data, so a did:cid URI resolves to something
-    // sensible rather than erroring based on which flavour of asset it happens to be.
+    // Not a file or image asset. Any other asset is readable as its JSON data, so a did:cid
+    // URI resolves to something sensible rather than erroring on the flavour of asset.
     const asset = await keymaster.resolveAsset(did);
 
     return {

--- a/packages/mcp-server/src/runtime.ts
+++ b/packages/mcp-server/src/runtime.ts
@@ -11,6 +11,16 @@ export interface ArchonRuntime {
     keymaster?: Keymaster;
 }
 
+// Shared by tools and resources: both surfaces are wallet-backed and must fail the same
+// way when the server was started without a passphrase.
+export function requireKeymaster(runtime: ArchonRuntime): Keymaster {
+    if (!runtime.keymaster) {
+        throw new Error('ARCHON_PASSPHRASE is required for wallet-backed MCP tools');
+    }
+
+    return runtime.keymaster;
+}
+
 export async function createWallet(config: McpServerConfig) {
     const { directory, file } = walletLocation(config.walletPath);
 

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { McpServerConfig } from './config.js';
-import { ArchonRuntime } from './runtime.js';
+import { ArchonRuntime, requireKeymaster } from './runtime.js';
 import { errorMessage } from './redact.js';
 
 type RegisterableServer = {
@@ -291,14 +291,6 @@ function fail(error: unknown): CallToolResult {
         ],
         isError: true,
     };
-}
-
-function requireKeymaster(runtime: ArchonRuntime) {
-    if (!runtime.keymaster) {
-        throw new Error('ARCHON_PASSPHRASE is required for wallet-backed MCP tools');
-    }
-
-    return runtime.keymaster;
 }
 
 function compactOptions<T extends Record<string, unknown>>(options: T): Partial<T> | undefined {

--- a/tests/mcp-server/resources.test.ts
+++ b/tests/mcp-server/resources.test.ts
@@ -1,0 +1,136 @@
+import { jest } from '@jest/globals';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { registerArchonResources, registerArchonTools, McpServerConfig } from '@didcid/mcp-server';
+
+const baseConfig: McpServerConfig = {
+    nodeUrl: 'http://localhost:4224',
+    walletType: 'json',
+    walletPath: './wallet.json',
+    passphrase: 'secret',
+    defaultRegistry: undefined,
+    readOnly: false,
+};
+
+const FILE_DID = 'did:cid:z3v8AuahBQrJDVCNhhVQNzTbdMGmCyUM8b7WrqQKmYYqNZmMbfR';
+const JSON_DID = 'did:cid:z3v8AuahBQrJDVCNhhVQNzTbdMGmCyUM8b7WrqQKmYYqNZmMbfX';
+
+function mockKeymaster() {
+    return {
+        getFile: jest.fn<any>().mockResolvedValue({ filename: 'hello.txt', type: 'text/plain', data: Buffer.from('hello') }),
+        resolveAsset: jest.fn<any>().mockResolvedValue({ hello: 'world' }),
+    };
+}
+
+async function connect(keymaster: any) {
+    const server = new McpServer({ name: 'archon-test', version: '0.0.0' });
+    registerArchonResources(server as any, { node: {} as any, keymaster });
+
+    const client = new Client({ name: 'archon-test-client', version: '0.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    return client;
+}
+
+describe('mcp server resources', () => {
+    it('advertises the resources capability', async () => {
+        const client = await connect(mockKeymaster());
+
+        // This is the SHOULD that #721 left unmet: a server embedding resource blocks in
+        // tool results is expected to implement the capability.
+        expect(client.getServerCapabilities()?.resources).toBeDefined();
+    });
+
+    it('reads a file asset by its DID', async () => {
+        const keymaster = mockKeymaster();
+        const client = await connect(keymaster);
+
+        const result: any = await client.readResource({ uri: FILE_DID });
+
+        expect(result.contents).toStrictEqual([{
+            uri: FILE_DID,
+            mimeType: 'text/plain',
+            blob: Buffer.from('hello').toString('base64'),
+        }]);
+        expect(keymaster.getFile).toHaveBeenCalledWith(FILE_DID);
+        // The binary path must not pay for a second resolve.
+        expect(keymaster.resolveAsset).not.toHaveBeenCalled();
+    });
+
+    it('reads a non-binary asset as its JSON data', async () => {
+        const keymaster = mockKeymaster();
+        keymaster.getFile.mockResolvedValue(null);
+        const client = await connect(keymaster);
+
+        const result: any = await client.readResource({ uri: JSON_DID });
+
+        expect(result.contents).toStrictEqual([{
+            uri: JSON_DID,
+            mimeType: 'application/json',
+            text: JSON.stringify({ hello: 'world' }),
+        }]);
+    });
+
+    it('does not enumerate wallet assets', async () => {
+        const keymaster = mockKeymaster();
+        const client = await connect(keymaster);
+
+        // Reads are by a URI the caller already holds. Listing every asset would disclose
+        // the wallet's contents to any connected client, so the template opts out.
+        const listed = await client.listResources();
+        expect(listed.resources).toStrictEqual([]);
+
+        const templates = await client.listResourceTemplates();
+        expect(templates.resourceTemplates.map((t: any) => t.uriTemplate)).toStrictEqual(['did:cid:{id}']);
+        expect(keymaster.getFile).not.toHaveBeenCalled();
+        expect(keymaster.resolveAsset).not.toHaveBeenCalled();
+    });
+
+    it('rejects a URI that is not an Archon asset DID', async () => {
+        const client = await connect(mockKeymaster());
+
+        await expect(client.readResource({ uri: 'did:web:example.com' })).rejects.toThrow();
+        await expect(client.readResource({ uri: 'https://example.com/secret' })).rejects.toThrow();
+    });
+
+    it('fails cleanly when the server has no wallet', async () => {
+        const client = await connect(undefined);
+
+        // Resources are wallet-backed and must fail the same way the equivalent tools do.
+        await expect(client.readResource({ uri: FILE_DID })).rejects.toThrow(/ARCHON_PASSPHRASE/);
+    });
+
+    // The point of the capability: the URI archon_get_asset_file already puts in its
+    // embedded resource block is now one a client can actually dereference. Registering
+    // both surfaces on one server proves the two halves line up, which is exactly what
+    // shipping the resource block without resources/read left unproven.
+    it('makes the URI in a tool result dereferenceable', async () => {
+        const keymaster = {
+            lookupDID: jest.fn<any>().mockResolvedValue(FILE_DID),
+            getFile: jest.fn<any>().mockResolvedValue({ filename: 'hello.txt', type: 'text/plain', data: Buffer.from('hello') }),
+            resolveAsset: jest.fn<any>().mockResolvedValue({}),
+        };
+
+        const server = new McpServer({ name: 'archon-test', version: '0.0.0' });
+        const runtime = { node: {} as any, keymaster };
+        registerArchonTools(server as any, runtime as any, baseConfig);
+        registerArchonResources(server as any, runtime as any);
+
+        const client = new Client({ name: 'archon-test-client', version: '0.0.0' });
+        const [ct, st] = InMemoryTransport.createLinkedPair();
+        await Promise.all([server.connect(st), client.connect(ct)]);
+
+        const called: any = await client.callTool({ name: 'archon_get_asset_file', arguments: { id: 'hello-alias' } });
+        const block = (called.content as any[]).find(b => b.type === 'resource');
+        const uri = block.resource.uri;
+
+        expect(uri).toBe(FILE_DID);
+
+        // Hand the tool's own URI straight back to resources/read.
+        const read: any = await client.readResource({ uri });
+        expect(read.contents[0].blob).toBe(block.resource.blob);
+        expect(read.contents[0].mimeType).toBe(block.resource.mimeType);
+    });
+});

--- a/tests/mcp-server/resources.test.ts
+++ b/tests/mcp-server/resources.test.ts
@@ -73,6 +73,18 @@ describe('mcp server resources', () => {
         }]);
     });
 
+    it('errors rather than answering with metadata when asset bytes are unavailable', async () => {
+        const keymaster = mockKeymaster();
+        // What getFile really returns when the gatekeeper cannot fetch the CID: the file
+        // asset, minus its data. Distinct from null, which means "not a file asset".
+        keymaster.getFile.mockResolvedValue({ filename: 'hello.txt', type: 'text/plain', cid: 'bafy...' });
+        const client = await connect(keymaster);
+
+        await expect(client.readResource({ uri: FILE_DID })).rejects.toThrow(/unavailable/i);
+        // Must not silently degrade into a JSON read of the asset's metadata.
+        expect(keymaster.resolveAsset).not.toHaveBeenCalled();
+    });
+
     it('does not enumerate wallet assets', async () => {
         const keymaster = mockKeymaster();
         const client = await connect(keymaster);


### PR DESCRIPTION
Closes #725.

#721 shipped an embedded `resource` block from `archon_get_asset_file` without the `resources` capability the spec says such a server **SHOULD** implement. That left the DID in that block decorative — accurate, but nothing could resolve it. The server now serves asset DIDs as resources.

## What it does

An Archon asset DID is already a URI, so it's the resource URI verbatim — the same one the tool emits. `resources/read` on `did:cid:{id}` returns the asset: bytes for file and image assets, JSON data for anything else. Non-`did:cid:` URIs aren't matched.

The test that matters registers **both surfaces on one server**, calls `archon_get_asset_file`, and feeds the tool's own URI straight back into `resources/read`, asserting identical bytes. That round trip is exactly what shipping the resource block without a read path left unproven.

## Two decisions worth review

**`resources/list` is empty, deliberately.** This was #725's open question. Enumerating every asset would hand the wallet's contents to any connected client, whether or not it ever reads one — a real disclosure for a capability whose purpose here is dereferencing URIs you already hold. Reads by DID reveal nothing that resolving that DID wouldn't. The template uses the SDK's explicit `list: undefined` (its own comment says that parameter exists "to avoid accidentally forgetting resource listing"), so this is a supported opt-out, not a workaround. `resources/templates/list` still advertises `did:cid:{id}`, so the read path stays discoverable, and a test pins that listing touches Keymaster zero times.

**`getFile` is tried first rather than branching on asset kind.** An image asset stores `{ file, image }`, so `getFile` covers both, and binary assets are what a client holding one of these URIs actually has. One resolve for the common case; the JSON fallback pays a second. (Given the double-resolve bug review caught in #732, there's a test asserting the binary path never calls `resolveAsset`.)

`requireKeymaster` moves from `tools.ts` to `runtime.ts` — resources are wallet-backed and must fail identically when the server has no passphrase, which is tested. `ARCHON_MCP_READ_ONLY` doesn't gate them; they're reads.

## What this deliberately doesn't do

It doesn't switch large files to `resource_link`, which is the actual payoff the read path unblocks. `archon_get_asset_file` inlines base64 into the model's context today:

| file | as base64 | tokens |
| --- | --- | --- |
| 100 KB | 0.1 MB | ~35k |
| 1 MB | 1.3 MB | ~350k |
| 5 MB | 6.7 MB | ~1.75M |

A `resource_link` becomes viable exactly when `resources/read` exists — which is now — but it needs a size threshold and a decision about clients that don't follow links, so it's worth its own change rather than being smuggled in here. Happy to open the follow-up. (Not a regression: the pre-#724 inline-JSON shape had the same problem.)

## Testing

New `tests/mcp-server/resources.test.ts` drives a real `McpServer` through a real `Client` over `InMemoryTransport` — the capability is only observable that way. Covers: capability advertised, file read, JSON fallback, no enumeration, non-DID URIs rejected, no-wallet failure, and the tool→resource round trip.

50 mcp-server tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)