### PR TITLE
feat: return vault items and dmail attachments as resource blocks (#726)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -61,7 +61,7 @@ CLI file commands use inline data instead of arbitrary local paths. Binary/text 
 }
 ```
 
-Use `"encoding": "utf8"` when passing plain text directly. This inline shape is for tool *arguments*; returned binary data uses MCP content blocks instead — see [Tool results](#tool-results).
+Use `"encoding": "utf8"` when passing plain text directly. This inline shape is for tool *arguments* only — MCP defines content blocks for results, not arguments, and file paths aren't usable in an MCP server context. No tool *returns* this shape; returned binary data uses MCP content blocks — see [Tool results](#tool-results).
 
 Destructive tools require `"confirm": true`, secret-revealing tools require `"reveal": true`, and Lightning payment/broadcast tools require `"confirmPayment": true`.
 
@@ -119,6 +119,20 @@ Tools returning binary assets use the content block types the protocol defines f
 
 Both return `null` when the asset carries no data.
 
+`archon_get_vault_item` and `archon_get_dmail_attachment` return an embedded `resource` block the same way, identified by the container's DID plus the item name as a fragment, with the mimeType the vault recorded when the item was written — the same value `archon_list_vault_items` reports:
+
+```json
+{
+  "content": [
+    { "type": "resource", "resource": { "uri": "did:cid:z3v8Auah...#notes.txt", "mimeType": "text/plain", "blob": "<base64>" } },
+    { "type": "text", "text": "{\"name\":\"notes.txt\",\"mimeType\":\"text/plain\"}" }
+  ],
+  "structuredContent": { "name": "notes.txt", "mimeType": "text/plain" }
+}
+```
+
+Both return `null` when the item does not exist.
+
 Failures — including input validation, a locked wallet, and node errors — are reported as MCP tool execution errors, with `isError: true` and the message in a text content block:
 
 ```json
@@ -156,6 +170,14 @@ The server implements the MCP `resources` capability. An Archon asset DID is alr
 ```
 
 File and image assets return their bytes; any other asset returns its JSON data with `mimeType: "application/json"`. URIs that are not `did:cid:` are not matched.
+
+A vault item — or a dmail attachment, which is the same thing, since a dmail is a vault — has no DID of its own. It's a named entry keyed by (container DID, name), so it's addressed as a DID URL fragment, which is also the URI `archon_get_vault_item` and `archon_get_dmail_attachment` put in their resource blocks:
+
+```
+did:cid:z3v8Auah...#notes.txt
+```
+
+Item names may contain any printable character, including `#` and spaces, so the fragment is percent-encoded (`#my%20notes%20%232.txt`).
 
 **`resources/list` is empty by design.** Enumerating every asset in the wallet would disclose its contents to any connected client, whether or not it ever reads one. Reads are by a DID the caller already holds, which reveals nothing that resolving that DID wouldn't. `resources/templates/list` advertises `did:cid:{id}`, so the read path is still discoverable. What a filtered list should expose is an open question.
 

--- a/packages/mcp-server/src/resources.ts
+++ b/packages/mcp-server/src/resources.ts
@@ -7,6 +7,16 @@ import { ArchonRuntime, requireKeymaster } from './runtime.js';
 // what makes that URI dereferenceable instead of decorative.
 export const ARCHON_ASSET_URI_TEMPLATE = 'did:cid:{id}';
 
+// A vault item has no DID of its own -- it is a named entry inside a vault, keyed by
+// (container DID, name) -- so it is addressed as a DID URL fragment. Item names allow
+// anything printable (validateAlias only rejects control characters), including '#' and
+// spaces, so the fragment must be percent-encoded.
+export const ARCHON_VAULT_ITEM_URI_TEMPLATE = 'did:cid:{id}#{item}';
+
+export function vaultItemUri(containerDid: string, name: string): string {
+    return `${containerDid}#${encodeURIComponent(name)}`;
+}
+
 type RegisterableResourceServer = {
     registerResource?: (
         name: string,
@@ -58,10 +68,53 @@ async function readAsset(runtime: ArchonRuntime, uri: URL): Promise<ReadResource
     };
 }
 
+// A dmail attachment is a vault item: addDmailAttachment delegates to addVaultItem and
+// getDmailAttachment to getVaultItem, so a dmail IS a vault as far as items go. One
+// template and one reader therefore cover both surfaces.
+async function readVaultItem(runtime: ArchonRuntime, variables: { id: string; item: string }): Promise<ReadResourceResult> {
+    const keymaster = requireKeymaster(runtime);
+    const did = `did:cid:${variables.id}`;
+    const name = decodeURIComponent(variables.item);
+    const uri = vaultItemUri(did, name);
+
+    const buffer = await keymaster.getVaultItem(did, name);
+
+    if (!buffer) {
+        throw new Error(`Vault item not found: ${uri}`);
+    }
+
+    // The recorded type, not a re-sniff of the bytes: addVaultItem stores what getMimeType
+    // detected at write time and list_vault_items reports that value, so deriving it again
+    // here risks two surfaces disagreeing about one item. Costs a second vault decrypt.
+    const items = await keymaster.listVaultItems(did);
+
+    return {
+        contents: [{
+            uri,
+            mimeType: items?.[name]?.type ?? 'application/octet-stream',
+            blob: Buffer.from(buffer).toString('base64'),
+        }],
+    };
+}
+
 export function registerArchonResources(server: RegisterableResourceServer, runtime: ArchonRuntime): void {
     if (!server.registerResource) {
         throw new Error('MCP server does not support resource registration');
     }
+
+    // Registered BEFORE the asset template, and the order is load-bearing: the SDK returns
+    // the first template whose URI matches, and 'did:cid:{id}' matches greedily -- it would
+    // otherwise swallow 'did:cid:vault#item' as id='vault#item' and fail inside the asset
+    // reader. The reverse cannot happen: this template does not match a bare DID.
+    server.registerResource(
+        'archon-vault-item',
+        new ResourceTemplate(ARCHON_VAULT_ITEM_URI_TEMPLATE, { list: undefined }),
+        {
+            title: 'Archon vault item',
+            description: 'Read an item stored in a vault, or an attachment on a dmail, by the container DID plus the item name as a percent-encoded fragment.',
+        },
+        (_uri: URL, variables: unknown) => readVaultItem(runtime, variables as { id: string; item: string })
+    );
 
     server.registerResource(
         'archon-asset',

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { McpServerConfig } from './config.js';
 import { ArchonRuntime, requireKeymaster } from './runtime.js';
+import { vaultItemUri } from './resources.js';
 import { errorMessage } from './redact.js';
 
 type RegisterableServer = {
@@ -302,13 +303,30 @@ function bufferFromInlineData(input: z.infer<typeof InlineDataSchema>): Buffer {
     return Buffer.from(input.data, input.encoding === 'utf8' ? 'utf8' : 'base64');
 }
 
-function inlineDataFromBuffer(buffer: Buffer, name?: string, mimeType?: string) {
-    return {
-        name,
-        mimeType,
-        encoding: 'base64',
-        data: buffer.toString('base64'),
-    };
+// Shared by the vault-item and dmail-attachment tools: a dmail attachment IS a vault item
+// (addDmailAttachment/getDmailAttachment delegate to the vault ones), so both produce the
+// same resource block. `containerDid` must already be resolved -- callers look it up once
+// and pass the DID down, so the keymaster calls below skip their own alias resolution.
+async function vaultItemResult(
+    keymaster: any,
+    containerDid: string,
+    name: string,
+    buffer: Buffer,
+    options?: Record<string, unknown>
+) {
+    // The recorded type rather than a re-sniff of the bytes: addVaultItem stores what
+    // getMimeType detected at write time, and list_vault_items reports that value. Deriving
+    // it again here would risk two surfaces disagreeing about the same item.
+    const items = await keymaster.listVaultItems(containerDid, options);
+    const mimeType = items?.[name]?.type ?? 'application/octet-stream';
+
+    return contentResult(
+        [{
+            type: 'resource',
+            resource: { uri: vaultItemUri(containerDid, name), mimeType, blob: buffer.toString('base64') },
+        }],
+        { name, mimeType }
+    );
 }
 
 function signableJson(input: unknown): object {
@@ -516,9 +534,13 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
     tool({ name: 'archon_list_vault_members', cliCommand: 'list-vault-members', description: 'List members of a vault.', schema: IdSchema, handler: (runtime, { id }) => requireKeymaster(runtime).listVaultMembers(id) }),
     tool({ name: 'archon_add_vault_item', cliCommand: 'add-vault-item', description: 'Add an inline item to a vault.', schema: IdSchema.extend({ item: InlineDataSchema }), mutates: true, handler: (runtime, { id, item }) => requireKeymaster(runtime).addVaultItem(id, item.name ?? 'item', bufferFromInlineData(item)) }),
     tool({ name: 'archon_remove_vault_item', cliCommand: 'remove-vault-item', description: 'Remove an item from a vault.', schema: IdSchema.extend({ item: z.string() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { id, item }) => requireKeymaster(runtime).removeVaultItem(id, item) }),
-    tool({ name: 'archon_get_vault_item', cliCommand: 'get-vault-item', description: 'Return a vault item as inline base64 data.', schema: IdSchema.extend({ item: z.string() }).merge(ResolveOptionsSchema), handler: async (runtime, { id, item, ...options }) => {
-        const buffer = await requireKeymaster(runtime).getVaultItem(id, item, compactOptions(options));
-        return buffer ? inlineDataFromBuffer(Buffer.from(buffer), item) : null;
+    tool({ name: 'archon_get_vault_item', cliCommand: 'get-vault-item', description: 'Return a vault item as an embedded resource content block.', schema: IdSchema.extend({ item: z.string() }).merge(ResolveOptionsSchema), handler: async (runtime, { id, item, ...options }) => {
+        const keymaster = requireKeymaster(runtime);
+        // Resolve once so the URI names a real DID rather than an alias, and so the calls
+        // below skip their own lookups.
+        const vault = await keymaster.lookupDID(id);
+        const buffer = await keymaster.getVaultItem(vault, item, compactOptions(options));
+        return buffer ? vaultItemResult(keymaster, vault, item, Buffer.from(buffer), compactOptions(options)) : null;
     } }),
 
     tool({ name: 'archon_create_dmail', cliCommand: 'create-dmail', description: 'Create a dmail from inline JSON.', schema: z.object({ message: DmailMessageSchema }).merge(VaultOptionsSchema), mutates: true, handler: (runtime, { message, ...options }) => requireKeymaster(runtime).createDmail(message, compactOptions(options)) }),
@@ -532,9 +554,11 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
     tool({ name: 'archon_remove_dmail', cliCommand: 'remove-dmail', description: 'Delete a dmail from the local list.', schema: DidSchema.merge(ConfirmSchema), mutates: true, handler: (runtime, { did }) => requireKeymaster(runtime).removeDmail(did) }),
     tool({ name: 'archon_add_dmail_attachment', cliCommand: 'add-dmail-attachment', description: 'Add an inline attachment to a dmail.', schema: DidSchema.extend({ attachment: InlineDataSchema }), mutates: true, handler: (runtime, { did, attachment }) => requireKeymaster(runtime).addDmailAttachment(did, attachment.name ?? 'attachment', bufferFromInlineData(attachment)) }),
     tool({ name: 'archon_remove_dmail_attachment', cliCommand: 'remove-dmail-attachment', description: 'Remove an attachment from a dmail.', schema: DidSchema.extend({ name: z.string() }).merge(ConfirmSchema), mutates: true, handler: (runtime, { did, name }) => requireKeymaster(runtime).removeDmailAttachment(did, name) }),
-    tool({ name: 'archon_get_dmail_attachment', cliCommand: 'get-dmail-attachment', description: 'Return a dmail attachment as inline base64 data.', schema: DidSchema.extend({ name: z.string() }), handler: async (runtime, { did, name }) => {
-        const buffer = await requireKeymaster(runtime).getDmailAttachment(did, name);
-        return buffer ? inlineDataFromBuffer(Buffer.from(buffer), name) : null;
+    tool({ name: 'archon_get_dmail_attachment', cliCommand: 'get-dmail-attachment', description: 'Return a dmail attachment as an embedded resource content block.', schema: DidSchema.extend({ name: z.string() }), handler: async (runtime, { did, name }) => {
+        const keymaster = requireKeymaster(runtime);
+        const dmail = await keymaster.lookupDID(did);
+        const buffer = await keymaster.getDmailAttachment(dmail, name);
+        return buffer ? vaultItemResult(keymaster, dmail, name, Buffer.from(buffer)) : null;
     } }),
     tool({ name: 'archon_list_dmail_attachments', cliCommand: 'list-dmail-attachments', description: 'List attachments of a dmail.', schema: DidSchema.merge(ResolveOptionsSchema), handler: (runtime, { did, ...options }) => requireKeymaster(runtime).listDmailAttachments(did, compactOptions(options)) }),
 

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -539,8 +539,11 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
         // Resolve once so the URI names a real DID rather than an alias, and so the calls
         // below skip their own lookups.
         const vault = await keymaster.lookupDID(id);
-        const buffer = await keymaster.getVaultItem(vault, item, compactOptions(options));
-        return buffer ? vaultItemResult(keymaster, vault, item, Buffer.from(buffer), compactOptions(options)) : null;
+        // One options object for both calls: the item read and the metadata read must see
+        // the same resolve options, or they could look at different versions of the vault.
+        const resolveOptions = compactOptions(options);
+        const buffer = await keymaster.getVaultItem(vault, item, resolveOptions);
+        return buffer ? vaultItemResult(keymaster, vault, item, Buffer.from(buffer), resolveOptions) : null;
     } }),
 
     tool({ name: 'archon_create_dmail', cliCommand: 'create-dmail', description: 'Create a dmail from inline JSON.', schema: z.object({ message: DmailMessageSchema }).merge(VaultOptionsSchema), mutates: true, handler: (runtime, { message, ...options }) => requireKeymaster(runtime).createDmail(message, compactOptions(options)) }),

--- a/tests/mcp-server/resources.test.ts
+++ b/tests/mcp-server/resources.test.ts
@@ -16,10 +16,18 @@ const baseConfig: McpServerConfig = {
 const FILE_DID = 'did:cid:z3v8AuahBQrJDVCNhhVQNzTbdMGmCyUM8b7WrqQKmYYqNZmMbfR';
 const JSON_DID = 'did:cid:z3v8AuahBQrJDVCNhhVQNzTbdMGmCyUM8b7WrqQKmYYqNZmMbfX';
 
+const VAULT_DID = 'did:cid:z3v8AuahBQrJDVCNhhVQNzTbdMGmCyUM8b7WrqQKmYYqNZmMbfV';
+
 function mockKeymaster() {
     return {
         getFile: jest.fn<any>().mockResolvedValue({ filename: 'hello.txt', type: 'text/plain', data: Buffer.from('hello') }),
         resolveAsset: jest.fn<any>().mockResolvedValue({ hello: 'world' }),
+        lookupDID: jest.fn<any>(async (id: string) => (id.startsWith('did:') ? id : VAULT_DID)),
+        getVaultItem: jest.fn<any>().mockResolvedValue(Buffer.from('item bytes')),
+        listVaultItems: jest.fn<any>().mockResolvedValue({
+            'notes.txt': { cid: 'bafy', type: 'text/plain', bytes: 10 },
+            'my notes #2.txt': { cid: 'bafy2', type: 'application/json', bytes: 4 },
+        }),
     };
 }
 
@@ -95,9 +103,58 @@ describe('mcp server resources', () => {
         expect(listed.resources).toStrictEqual([]);
 
         const templates = await client.listResourceTemplates();
-        expect(templates.resourceTemplates.map((t: any) => t.uriTemplate)).toStrictEqual(['did:cid:{id}']);
+        // Order is load-bearing, not cosmetic: the SDK reads the first template whose URI
+        // matches, and 'did:cid:{id}' matches greedily. If the vault-item template were
+        // registered second, a 'did:cid:vault#item' read would be swallowed by the asset
+        // reader as id='vault#item'.
+        expect(templates.resourceTemplates.map((t: any) => t.uriTemplate)).toStrictEqual([
+            'did:cid:{id}#{item}',
+            'did:cid:{id}',
+        ]);
         expect(keymaster.getFile).not.toHaveBeenCalled();
         expect(keymaster.resolveAsset).not.toHaveBeenCalled();
+    });
+
+    it('reads a vault item by its DID URL fragment', async () => {
+        const keymaster = mockKeymaster();
+        const client = await connect(keymaster);
+
+        const result: any = await client.readResource({ uri: `${VAULT_DID}#notes.txt` });
+
+        expect(result.contents).toStrictEqual([{
+            uri: `${VAULT_DID}#notes.txt`,
+            // The type the vault recorded at write time, so this agrees with what
+            // archon_list_vault_items reports for the same item.
+            mimeType: 'text/plain',
+            blob: Buffer.from('item bytes').toString('base64'),
+        }]);
+        expect(keymaster.getVaultItem).toHaveBeenCalledWith(VAULT_DID, 'notes.txt');
+        // A fragment URI must not fall through to the asset reader.
+        expect(keymaster.getFile).not.toHaveBeenCalled();
+    });
+
+    it('round-trips an item name that needs percent-encoding', async () => {
+        const keymaster = mockKeymaster();
+        const client = await connect(keymaster);
+
+        // validateAlias only rejects control characters, so names can contain '#' and
+        // spaces. The fragment is encoded on the way out and decoded on the way back.
+        const name = 'my notes #2.txt';
+        const uri = `${VAULT_DID}#${encodeURIComponent(name)}`;
+
+        const result: any = await client.readResource({ uri });
+
+        expect(keymaster.getVaultItem).toHaveBeenCalledWith(VAULT_DID, name);
+        expect(result.contents[0].mimeType).toBe('application/json');
+        expect(result.contents[0].uri).toBe(uri);
+    });
+
+    it('errors when a vault item does not exist', async () => {
+        const keymaster = mockKeymaster();
+        keymaster.getVaultItem.mockResolvedValue(null);
+        const client = await connect(keymaster);
+
+        await expect(client.readResource({ uri: `${VAULT_DID}#missing.txt` })).rejects.toThrow(/not found/i);
     });
 
     it('rejects a URI that is not an Archon asset DID', async () => {
@@ -112,6 +169,29 @@ describe('mcp server resources', () => {
 
         // Resources are wallet-backed and must fail the same way the equivalent tools do.
         await expect(client.readResource({ uri: FILE_DID })).rejects.toThrow(/ARCHON_PASSPHRASE/);
+    });
+
+    it('makes the URI in a vault item tool result dereferenceable', async () => {
+        const keymaster = mockKeymaster();
+        const server = new McpServer({ name: 'archon-test', version: '0.0.0' });
+        const runtime = { node: {} as any, keymaster };
+        registerArchonTools(server as any, runtime as any, baseConfig);
+        registerArchonResources(server as any, runtime as any);
+
+        const client = new Client({ name: 'archon-test-client', version: '0.0.0' });
+        const [ct, st] = InMemoryTransport.createLinkedPair();
+        await Promise.all([server.connect(st), client.connect(ct)]);
+
+        // Called with an alias, so this also proves the URI names the resolved DID rather
+        // than the alias -- an alias-based URI would be meaningless to another client.
+        const called: any = await client.callTool({ name: 'archon_get_vault_item', arguments: { id: 'my-vault', item: 'notes.txt' } });
+        const block = (called.content as any[]).find(b => b.type === 'resource');
+
+        expect(block.resource.uri).toBe(`${VAULT_DID}#notes.txt`);
+
+        const read: any = await client.readResource({ uri: block.resource.uri });
+        expect(read.contents[0].blob).toBe(block.resource.blob);
+        expect(read.contents[0].mimeType).toBe(block.resource.mimeType);
     });
 
     // The point of the capability: the URI archon_get_asset_file already puts in its

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -574,6 +574,57 @@ describe('mcp server tools', () => {
         }))).toMatch(/version/);
     });
 
+    it('returns vault items and dmail attachments as resource blocks', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        runtime.keymaster.lookupDID.mockResolvedValue('did:cid:vault');
+        runtime.keymaster.getVaultItem.mockResolvedValue(Buffer.from('item'));
+        runtime.keymaster.getDmailAttachment.mockResolvedValue(Buffer.from('item'));
+        runtime.keymaster.listVaultItems.mockResolvedValue({ 'hello.txt': { cid: 'bafy', type: 'text/plain' } });
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const vault: any = await server.tools.get('archon_get_vault_item')!.handler({ id: 'my-vault', item: 'hello.txt' });
+
+        expect(vault.content).toStrictEqual([
+            {
+                type: 'resource',
+                // The item has no DID of its own, so it is addressed as a fragment on the
+                // container's DID -- and the DID, not the alias it was called with.
+                resource: { uri: 'did:cid:vault#hello.txt', mimeType: 'text/plain', blob: Buffer.from('item').toString('base64') },
+            },
+            { type: 'text', text: JSON.stringify({ name: 'hello.txt', mimeType: 'text/plain' }) },
+        ]);
+        expect(vault.structuredContent).toStrictEqual({ name: 'hello.txt', mimeType: 'text/plain' });
+
+        // A dmail attachment is a vault item, so it produces the same shape.
+        const attachment: any = await server.tools.get('archon_get_dmail_attachment')!.handler({ did: 'did:cid:vault', name: 'hello.txt' });
+        expect(attachment.content[0].resource.uri).toBe('did:cid:vault#hello.txt');
+        expect(attachment.content[0].mimeType ?? attachment.content[0].resource.mimeType).toBe('text/plain');
+    });
+
+    it('falls back to a generic mimeType when the vault recorded none', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        runtime.keymaster.lookupDID.mockResolvedValue('did:cid:vault');
+        runtime.keymaster.listVaultItems.mockResolvedValue({ 'hello.txt': { cid: 'bafy' } });
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const vault: any = await server.tools.get('archon_get_vault_item')!.handler({ id: 'my-vault', item: 'hello.txt' });
+
+        expect(vault.content[0].resource.mimeType).toBe('application/octet-stream');
+    });
+
+    it('returns null for a vault item that does not exist', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        runtime.keymaster.getVaultItem.mockResolvedValue(null);
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        expect(expectOk(await server.tools.get('archon_get_vault_item')!.handler({ id: 'my-vault', item: 'nope.txt' }))).toBeNull();
+        // No point paying for the metadata decrypt when there are no bytes.
+        expect(runtime.keymaster.listVaultItems).not.toHaveBeenCalled();
+    });
+
     it('passes inline base64 payloads to file-like tools', async () => {
         const server = new FakeServer();
         const runtime = mockRuntime();


### PR DESCRIPTION
Closes #726.

`archon_get_vault_item` and `archon_get_dmail_attachment` were the last two tools returning binary data as base64 inside a private JSON object. They now return an embedded `resource` block.

`inlineDataFromBuffer` is **deleted** — no tool returns the private inline shape any more. It survives only on the *input* side, where MCP has no content blocks to offer and file paths aren't usable. That closes the thread #691 started.

## Both of #726's premises were wrong

I wrote that issue, so this is my own error twice over. Worth stating plainly since the fix is better than the plan:

**"No mimeType is available."** It is. `addVaultItem` records `type` from `getMimeType()` — real magic-number detection — at write time, and `addDmailAttachment` delegates to it, so *every* item has one. `list_vault_items` has been reporting it all along. I claimed otherwise from `getVaultItem`'s bare-`Buffer` signature without reading the write path. So the issue's suggestion to sniff from the file extension, or to record a type at write time, was solving a problem that doesn't exist.

The tools now report the **stored** type rather than re-sniffing the bytes. Deriving it again would agree in almost every case (same function, same bytes), but "almost" is the problem: `list_vault_items` and `get_vault_item` disagreeing about one item is a bug, and the recorded value is the one of record. Costs a second vault decrypt on the read path, which is called out in a comment.

**"Neither has a DID-shaped URI."** Neither has a DID, but both have a DID *URL*. An item is keyed by (container DID, name) — which is exactly what a fragment expresses:

```
did:cid:z3v8Auah...#notes.txt
```

And it collapses the issue's two-tool problem into one: **a dmail IS a vault.** `addDmailAttachment` → `addVaultItem`, `getDmailAttachment` → `getVaultItem`. So one URI template, one reader, one code path covers both.

## Not just decorative

`resources/read` dereferences these URIs (via #725/#734), so they resolve. Emitting a URI nothing can resolve is precisely the problem #725 existed to fix, and doing it here would have repeated it a week later. A test registers both surfaces on one server and feeds the tool's own URI back through `readResource`.

**The vault-item template must register before the asset template**, and that's load-bearing: the SDK returns the first template whose URI matches, and `did:cid:{id}` matches *greedily* — it would otherwise swallow `did:cid:vault#item` as `id='vault#item'` and fail inside the asset reader. Same overlapping-matcher shape as the `StoredWallet` union in #732. There's a test asserting the order rather than a comment hoping for it.

**Names need encoding.** `validateAlias` only rejects control characters, so an item name can contain `#` and spaces. The fragment is percent-encoded on the way out and decoded on the way back; verified end-to-end with `my notes #2.txt`.

Callers resolve the container DID once and pass it down, so the URI names a DID rather than the alias it was called with (an alias-based URI would be meaningless to another client), and the keymaster calls skip their own lookups.

## Testing

58 mcp-server tests pass; typecheck clean. New coverage: both tools' block shape, the stored mimeType, the `application/octet-stream` fallback, `null` for a missing item (without paying for the metadata decrypt), fragment reads, the encoded round trip, and template order.

Also verified through a real `McpServer`/`Client` pair that the result validates against `CallToolResultSchema` and that a `#`-and-space name round-trips from tool result to `resources/read` byte-identically.

## Breaking change

Both tools' result shape changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)