### PR TITLE
feat: link large file assets instead of inlining base64 (#735)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -39,6 +39,7 @@ Example MCP client config:
 | `ARCHON_PASSPHRASE` | unset | Required for wallet-backed tools; node health tools work without it |
 | `ARCHON_DEFAULT_REGISTRY` | Keymaster default | Default registry for new DIDs |
 | `ARCHON_MCP_READ_ONLY` | `false` | Set to `true` to omit mutating tools from `tools/list` |
+| `ARCHON_MCP_INLINE_LIMIT` | `16384` | Bytes at or below which `archon_get_asset_file` inlines a file rather than linking it |
 
 ## Tools
 
@@ -105,7 +106,7 @@ Tools returning binary assets use the content block types the protocol defines f
 }
 ```
 
-`archon_get_asset_file` returns an embedded `resource` block identified by the asset's DID, which is a URI the server also serves as an MCP resource — see [Resources](#resources):
+`archon_get_asset_file` returns a file asset by its DID, which is a URI the server also serves as an MCP resource — see [Resources](#resources). Small files come back as an embedded `resource` block:
 
 ```json
 {
@@ -118,6 +119,25 @@ Tools returning binary assets use the content block types the protocol defines f
 ```
 
 Both return `null` when the asset carries no data.
+
+### Large files are linked, not inlined
+
+A file's bytes are base64 in a tool result, costing roughly `bytes / 3` tokens of the model's context. A 1 MB asset is ~350k tokens and a 10 MB one — the largest a node accepts — is ~3.5M, more than any context window holds. So above `ARCHON_MCP_INLINE_LIMIT` (16 KiB by default) `archon_get_asset_file` returns a `resource_link` instead:
+
+```json
+{
+  "content": [
+    { "type": "resource_link", "uri": "did:cid:z3v8Auah...", "name": "big.pdf", "mimeType": "application/pdf", "size": 2097152 },
+    { "type": "text", "text": "{\"name\":\"big.pdf\",\"mimeType\":\"application/pdf\",\"bytes\":2097152,\"linked\":true}" }
+  ]
+}
+```
+
+The client fetches the bytes with `resources/read` on that URI, if and when it wants them — the same URI, so both shapes point at the same thing. The size comes from the asset's DID document, so a linked file is never fetched at all; `size` lets a host estimate the cost before asking. An asset with no recorded size is linked rather than gambled on.
+
+The default is low because base64 is not something a model can read — inlining only helps a client render or save the bytes, so it should stay cheap. Raise `ARCHON_MCP_INLINE_LIMIT` to inline more (a very large value restores the old always-inline behaviour, for clients that don't follow resource links); set it to `0` to link everything.
+
+`archon_get_asset_image` always inlines, whatever its size: an `image` block is how a model actually sees an image, and there is no link equivalent it could look at.
 
 `archon_get_vault_item` and `archon_get_dmail_attachment` return an embedded `resource` block the same way, identified by the container's DID plus the item name as a fragment, with the mimeType the vault recorded when the item was written — the same value `archon_list_vault_items` reports:
 

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -9,7 +9,17 @@ export interface McpServerConfig {
     passphrase?: string;
     defaultRegistry?: string;
     readOnly: boolean;
+    /** Byte size at or below which a file asset is inlined rather than linked. */
+    inlineLimit: number;
 }
+
+// A file asset's bytes are base64 in a tool result, so they cost roughly bytes/3 tokens of
+// the model's context (4/3 expansion, ~4 chars per token). 16 KiB is ~5.5k tokens: enough
+// for the small text, JSON, and icon assets where a link would just add a round trip, and
+// far below the point where one call crowds out the conversation. The bar is deliberately
+// low because base64 is not something a model can read -- inlining only ever helps the
+// client render or save it, so paying much context for it buys nothing.
+export const DEFAULT_INLINE_LIMIT = 16 * 1024;
 
 function parseWalletType(value: string | undefined): WalletType {
     switch (value) {
@@ -28,6 +38,20 @@ function parseBool(value: string | undefined): boolean {
     return value === 'true' || value === '1' || value === 'yes';
 }
 
+function parseInlineLimit(value: string | undefined): number {
+    if (value === undefined || value === '') {
+        return DEFAULT_INLINE_LIMIT;
+    }
+
+    const limit = Number(value);
+
+    if (!Number.isInteger(limit) || limit < 0) {
+        throw new Error(`ARCHON_MCP_INLINE_LIMIT must be a non-negative integer, got "${value}"`);
+    }
+
+    return limit;
+}
+
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): McpServerConfig {
     return {
         nodeUrl: env.ARCHON_NODE_URL || env.ARCHON_GATEKEEPER_URL || 'https://archon.technology',
@@ -36,6 +60,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): McpServerConfi
         passphrase: env.ARCHON_PASSPHRASE,
         defaultRegistry: env.ARCHON_DEFAULT_REGISTRY,
         readOnly: parseBool(env.ARCHON_MCP_READ_ONLY),
+        inlineLimit: parseInlineLimit(env.ARCHON_MCP_INLINE_LIMIT),
     };
 }
 

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -39,17 +39,21 @@ function parseBool(value: string | undefined): boolean {
 }
 
 function parseInlineLimit(value: string | undefined): number {
-    if (value === undefined || value === '') {
+    const trimmed = value?.trim();
+
+    if (trimmed === undefined || trimmed === '') {
         return DEFAULT_INLINE_LIMIT;
     }
 
-    const limit = Number(value);
-
-    if (!Number.isInteger(limit) || limit < 0) {
-        throw new Error(`ARCHON_MCP_INLINE_LIMIT must be a non-negative integer, got "${value}"`);
+    // Match digits before converting, rather than leaning on Number(): it reads ' ' as 0,
+    // '0x10' as 16 and '1e4' as 10000, all of which pass an isInteger check. A stray space
+    // in an env var would otherwise silently mean 0 -- link everything -- while an empty
+    // value means the default, which is an absurd distinction to hang on whitespace.
+    if (!/^\d+$/.test(trimmed) || !Number.isSafeInteger(Number(trimmed))) {
+        throw new Error(`ARCHON_MCP_INLINE_LIMIT must be a non-negative whole number of bytes, got "${value}"`);
     }
 
-    return limit;
+    return Number(trimmed);
 }
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): McpServerConfig {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -24,7 +24,7 @@ type ToolDefinitionBase = {
 // What tool() accepts: the handler's args are tied to this tool's own input schema.
 type TypedToolDefinition<S extends z.ZodTypeAny> = ToolDefinitionBase & {
     schema: S;
-    handler: (runtime: ArchonRuntime, args: z.infer<S>) => Promise<unknown> | unknown;
+    handler: (runtime: ArchonRuntime, args: z.infer<S>, config: McpServerConfig) => Promise<unknown> | unknown;
 };
 
 // What the registry holds. The per-tool arg type can't survive into a homogeneous list
@@ -32,7 +32,7 @@ type TypedToolDefinition<S extends z.ZodTypeAny> = ToolDefinitionBase & {
 // at authoring time by tool() instead. Args reaching a handler are schema.parse() output.
 export type ArchonToolDefinition = ToolDefinitionBase & {
     schema: z.ZodTypeAny;
-    handler: (runtime: ArchonRuntime, args: any) => Promise<unknown> | unknown;
+    handler: (runtime: ArchonRuntime, args: any, config: McpServerConfig) => Promise<unknown> | unknown;
 };
 
 const EmptySchema = z.object({});
@@ -476,19 +476,45 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
             { name: image.file.filename, mimeType, image: image.image }
         );
     } }),
-    tool({ name: 'archon_get_asset_file', cliCommand: 'get-asset-file', description: 'Return a file asset as an embedded resource content block.', schema: IdSchema, handler: async (runtime, { id }) => {
-        // Resolve once and hand getFile the DID: it resolves internally too, and for an
-        // alias each resolution decrypts the wallet. lookupDID short-circuits on a DID.
+    tool({ name: 'archon_get_asset_file', cliCommand: 'get-asset-file', description: 'Return a file asset. Small files come back as an embedded resource block; larger ones as a resource_link the client can read on demand.', schema: IdSchema, handler: async (runtime, { id }, config) => {
+        const keymaster = requireKeymaster(runtime);
+        // Resolve once and hand the DID down: each call resolves internally too, and for an
+        // alias that decrypts the wallet. lookupDID short-circuits on a DID.
         // The asset DID is itself a URI, so the resource block is named by a real
         // identifier rather than an invented scheme.
-        const uri = await requireKeymaster(runtime).lookupDID(id);
-        const file = await requireKeymaster(runtime).getFile(uri);
+        const uri = await keymaster.lookupDID(id);
+
+        // Size first, from the DID document, before fetching anything: a file asset records
+        // `bytes` alongside its CID, so a large asset can be linked without ever pulling
+        // data we would only discard. That costs small assets a second resolve, which is
+        // the cheaper mistake -- the alternative is fetching megabytes to then measure them.
+        const asset = await keymaster.resolveAsset(uri) as { file?: { cid?: string; filename?: string; type?: string; bytes?: number } };
+        const summary = asset?.file;
+
+        if (!summary?.cid) {
+            return null;
+        }
+
+        const mimeType = summary.type ?? 'application/octet-stream';
+        const name = summary.filename ?? 'file';
+
+        // Unknown size counts as too large: guessing "small" risks inlining something that
+        // buries the conversation, and a link costs the client only a resources/read.
+        if (summary.bytes === undefined || summary.bytes > config.inlineLimit) {
+            // MCP's `size` is documented for exactly this -- hosts use it to display file
+            // sizes and estimate context window usage before fetching.
+            return contentResult(
+                [{ type: 'resource_link', uri, name, mimeType, ...(summary.bytes !== undefined && { size: summary.bytes }) }],
+                { name, mimeType, ...(summary.bytes !== undefined && { bytes: summary.bytes }), linked: true }
+            );
+        }
+
+        const file = await keymaster.getFile(uri);
 
         if (!file?.data) {
             return null;
         }
 
-        const mimeType = file.type ?? 'application/octet-stream';
         return contentResult(
             [{
                 type: 'resource',
@@ -594,7 +620,7 @@ function registerToolDefinition(
                 throw new Error('Tool disabled by ARCHON_MCP_READ_ONLY=true');
             }
             const args = definition.schema.parse(rawArgs ?? {});
-            return ok(await definition.handler(runtime, args));
+            return ok(await definition.handler(runtime, args, config));
         } catch (error) {
             return fail(error);
         }

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -498,9 +498,14 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
         const mimeType = summary.type ?? 'application/octet-stream';
         const name = summary.filename ?? 'file';
 
-        // Unknown size counts as too large: guessing "small" risks inlining something that
-        // buries the conversation, and a link costs the client only a resources/read.
-        if (summary.bytes === undefined || summary.bytes > config.inlineLimit) {
+        // Stated as what may be inlined, so a limit of 0 means "link everything" for every
+        // file including an empty one -- `bytes > limit` would quietly inline the 0-byte
+        // case and contradict the documented escape hatch. Unknown size counts as too
+        // large: guessing "small" risks inlining something that buries the conversation,
+        // while a link costs the client only a resources/read.
+        const inlineable = config.inlineLimit > 0 && summary.bytes !== undefined && summary.bytes <= config.inlineLimit;
+
+        if (!inlineable) {
             // MCP's `size` is documented for exactly this -- hosts use it to display file
             // sizes and estimate context window usage before fetching.
             return contentResult(

--- a/tests/mcp-server/config.test.ts
+++ b/tests/mcp-server/config.test.ts
@@ -26,9 +26,23 @@ describe('mcp server config', () => {
         expect(loadConfig({ ARCHON_MCP_INLINE_LIMIT: '0' }).inlineLimit).toBe(0);
         expect(loadConfig({ ARCHON_MCP_INLINE_LIMIT: '' }).inlineLimit).toBe(16 * 1024);
 
-        expect(() => loadConfig({ ARCHON_MCP_INLINE_LIMIT: 'lots' })).toThrow(/non-negative integer/);
-        expect(() => loadConfig({ ARCHON_MCP_INLINE_LIMIT: '-1' })).toThrow(/non-negative integer/);
-        expect(() => loadConfig({ ARCHON_MCP_INLINE_LIMIT: '1.5' })).toThrow(/non-negative integer/);
+        expect(() => loadConfig({ ARCHON_MCP_INLINE_LIMIT: 'lots' })).toThrow(/whole number/);
+        expect(() => loadConfig({ ARCHON_MCP_INLINE_LIMIT: '-1' })).toThrow(/whole number/);
+        expect(() => loadConfig({ ARCHON_MCP_INLINE_LIMIT: '1.5' })).toThrow(/whole number/);
+    });
+
+    it('does not let Number() coercion smuggle in a surprising limit', () => {
+        // Number(' ') is 0, which would silently mean "link everything" -- and would make a
+        // stray space behave completely differently from an empty value, which means the
+        // default. Whitespace is trimmed to nothing and treated as unset.
+        expect(loadConfig({ ARCHON_MCP_INLINE_LIMIT: ' ' }).inlineLimit).toBe(16 * 1024);
+        expect(loadConfig({ ARCHON_MCP_INLINE_LIMIT: ' 65536 ' }).inlineLimit).toBe(65536);
+
+        // Number() reads these as 16 and 10000; neither is what an operator typing them
+        // means, so they are rejected rather than guessed at.
+        expect(() => loadConfig({ ARCHON_MCP_INLINE_LIMIT: '0x10' })).toThrow(/whole number/);
+        expect(() => loadConfig({ ARCHON_MCP_INLINE_LIMIT: '1e4' })).toThrow(/whole number/);
+        expect(() => loadConfig({ ARCHON_MCP_INLINE_LIMIT: '  ' })).toBeTruthy();
     });
 
     it('uses ARCHON_NODE_URL before legacy ARCHON_GATEKEEPER_URL', () => {

--- a/tests/mcp-server/config.test.ts
+++ b/tests/mcp-server/config.test.ts
@@ -15,7 +15,20 @@ describe('mcp server config', () => {
             passphrase: undefined,
             defaultRegistry: undefined,
             readOnly: false,
+            inlineLimit: 16 * 1024,
         });
+    });
+
+    it('parses ARCHON_MCP_INLINE_LIMIT and rejects nonsense', () => {
+        expect(loadConfig({ ARCHON_MCP_INLINE_LIMIT: '65536' }).inlineLimit).toBe(65536);
+        // 0 links everything; a huge value inlines everything, which is the escape hatch
+        // for a client that does not follow resource links.
+        expect(loadConfig({ ARCHON_MCP_INLINE_LIMIT: '0' }).inlineLimit).toBe(0);
+        expect(loadConfig({ ARCHON_MCP_INLINE_LIMIT: '' }).inlineLimit).toBe(16 * 1024);
+
+        expect(() => loadConfig({ ARCHON_MCP_INLINE_LIMIT: 'lots' })).toThrow(/non-negative integer/);
+        expect(() => loadConfig({ ARCHON_MCP_INLINE_LIMIT: '-1' })).toThrow(/non-negative integer/);
+        expect(() => loadConfig({ ARCHON_MCP_INLINE_LIMIT: '1.5' })).toThrow(/non-negative integer/);
     });
 
     it('uses ARCHON_NODE_URL before legacy ARCHON_GATEKEEPER_URL', () => {

--- a/tests/mcp-server/output-schema.test.ts
+++ b/tests/mcp-server/output-schema.test.ts
@@ -11,6 +11,7 @@ const baseConfig: McpServerConfig = {
     passphrase: 'secret',
     defaultRegistry: undefined,
     readOnly: false,
+    inlineLimit: 16 * 1024,
 };
 
 // A DID document with the fields a real gatekeeper returns, including ones the output

--- a/tests/mcp-server/resources.test.ts
+++ b/tests/mcp-server/resources.test.ts
@@ -11,6 +11,7 @@ const baseConfig: McpServerConfig = {
     passphrase: 'secret',
     defaultRegistry: undefined,
     readOnly: false,
+    inlineLimit: 16 * 1024,
 };
 
 const FILE_DID = 'did:cid:z3v8AuahBQrJDVCNhhVQNzTbdMGmCyUM8b7WrqQKmYYqNZmMbfR';
@@ -202,7 +203,8 @@ describe('mcp server resources', () => {
         const keymaster = {
             lookupDID: jest.fn<any>().mockResolvedValue(FILE_DID),
             getFile: jest.fn<any>().mockResolvedValue({ filename: 'hello.txt', type: 'text/plain', data: Buffer.from('hello') }),
-            resolveAsset: jest.fn<any>().mockResolvedValue({}),
+            // Small enough to embed, so the tool still emits a URI to dereference.
+            resolveAsset: jest.fn<any>().mockResolvedValue({ file: { cid: 'bafy', filename: 'hello.txt', type: 'text/plain', bytes: 5 } }),
         };
 
         const server = new McpServer({ name: 'archon-test', version: '0.0.0' });

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -760,6 +760,34 @@ describe('mcp server tools', () => {
         expect(runtime.keymaster.getFile).not.toHaveBeenCalled();
     });
 
+    it('links every file when the limit is zero, including an empty one', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        // 0 means link everything. A `bytes > limit` test would inline this one, since
+        // 0 > 0 is false -- contradicting the documented escape hatch on the one file where
+        // nobody would notice until they relied on it.
+        runtime.keymaster.resolveAsset.mockResolvedValue({ file: { cid: 'bafy', filename: 'empty.txt', type: 'text/plain', bytes: 0 } });
+        registerArchonTools(server, runtime as any, { ...baseConfig, inlineLimit: 0 });
+
+        const response: any = await server.tools.get('archon_get_asset_file')!.handler({ id: 'did:cid:file' });
+
+        expect(response.content[0].type).toBe('resource_link');
+        expect(runtime.keymaster.getFile).not.toHaveBeenCalled();
+    });
+
+    it('inlines an empty file under a normal limit', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        runtime.keymaster.resolveAsset.mockResolvedValue({ file: { cid: 'bafy', filename: 'empty.txt', type: 'text/plain', bytes: 0 } });
+        runtime.keymaster.getFile.mockResolvedValue({ filename: 'empty.txt', type: 'text/plain', data: Buffer.alloc(0) });
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const response: any = await server.tools.get('archon_get_asset_file')!.handler({ id: 'did:cid:file' });
+
+        expect(response.content[0].type).toBe('resource');
+        expect(response.content[0].resource.blob).toBe('');
+    });
+
     it('inlines everything when the limit is raised', async () => {
         const server = new FakeServer();
         const runtime = mockRuntime();

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -18,6 +18,7 @@ const baseConfig: McpServerConfig = {
     passphrase: 'secret',
     defaultRegistry: undefined,
     readOnly: false,
+    inlineLimit: 16 * 1024,
 };
 
 const mutatingTools = ARCHON_MCP_TOOL_DEFINITIONS.filter(definition => definition.mutates).map(definition => definition.name);
@@ -665,6 +666,9 @@ describe('mcp server tools', () => {
     it('returns a file asset as an embedded resource content block', async () => {
         const server = new FakeServer();
         const runtime = mockRuntime();
+        // A file asset's DID document carries the file's summary -- cid, filename, type and
+        // bytes -- with the data itself behind the CID.
+        runtime.keymaster.resolveAsset.mockResolvedValue({ file: { cid: 'bafy', filename: 'file.txt', type: 'text/plain', bytes: 4 } });
         registerArchonTools(server, runtime as any, baseConfig);
 
         const response: any = await server.tools.get('archon_get_asset_file')!.handler({ id: 'file-alias' });
@@ -692,6 +696,7 @@ describe('mcp server tools', () => {
     it('defaults the mimeType and drops absent metadata from both mirrors', async () => {
         const server = new FakeServer();
         const runtime = mockRuntime();
+        runtime.keymaster.resolveAsset.mockResolvedValue({ file: { cid: 'bafy', bytes: 4 } });
         runtime.keymaster.getFile.mockResolvedValue({ data: Buffer.from('file') });
         registerArchonTools(server, runtime as any, baseConfig);
 
@@ -702,6 +707,68 @@ describe('mcp server tools', () => {
         // is dropped by both, not left as an undefined key on one side.
         expect(response.structuredContent).toStrictEqual({ mimeType: 'application/octet-stream' });
         expect(JSON.parse(response.content[1].text)).toStrictEqual(response.structuredContent);
+    });
+
+    it('links a large file asset instead of inlining it, without fetching the data', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        const bytes = baseConfig.inlineLimit + 1;
+        runtime.keymaster.resolveAsset.mockResolvedValue({ file: { cid: 'bafy', filename: 'big.pdf', type: 'application/pdf', bytes } });
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const response: any = await server.tools.get('archon_get_asset_file')!.handler({ id: 'did:cid:file' });
+
+        expect(response.content).toStrictEqual([
+            { type: 'resource_link', uri: 'did:cid:file', name: 'big.pdf', mimeType: 'application/pdf', size: bytes },
+            { type: 'text', text: JSON.stringify({ name: 'big.pdf', mimeType: 'application/pdf', bytes, linked: true }) },
+        ]);
+        // The whole point: the bytes never left the gatekeeper, let alone entered the
+        // model's context. Size came from the DID document.
+        expect(runtime.keymaster.getFile).not.toHaveBeenCalled();
+    });
+
+    it('inlines a file asset exactly at the limit', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        // The limit is inclusive: at the boundary it still embeds.
+        runtime.keymaster.resolveAsset.mockResolvedValue({ file: { cid: 'bafy', filename: 'edge.txt', type: 'text/plain', bytes: baseConfig.inlineLimit } });
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const response: any = await server.tools.get('archon_get_asset_file')!.handler({ id: 'did:cid:file' });
+
+        expect(response.content[0].type).toBe('resource');
+        expect(runtime.keymaster.getFile).toHaveBeenCalled();
+    });
+
+    it('links a file asset whose size is unknown', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        // An asset with no recorded `bytes` could be any size, so it is linked rather than
+        // gambled on. No `size` is advertised, because none is known.
+        runtime.keymaster.resolveAsset.mockResolvedValue({ file: { cid: 'bafy', filename: 'mystery.bin' } });
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const response: any = await server.tools.get('archon_get_asset_file')!.handler({ id: 'did:cid:file' });
+
+        expect(response.content[0]).toStrictEqual({
+            type: 'resource_link',
+            uri: 'did:cid:file',
+            name: 'mystery.bin',
+            mimeType: 'application/octet-stream',
+        });
+        expect(response.structuredContent).toStrictEqual({ name: 'mystery.bin', mimeType: 'application/octet-stream', linked: true });
+        expect(runtime.keymaster.getFile).not.toHaveBeenCalled();
+    });
+
+    it('inlines everything when the limit is raised', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        runtime.keymaster.resolveAsset.mockResolvedValue({ file: { cid: 'bafy', filename: 'big.pdf', type: 'application/pdf', bytes: 10_000_000 } });
+        registerArchonTools(server, runtime as any, { ...baseConfig, inlineLimit: Number.MAX_SAFE_INTEGER });
+
+        // The escape hatch for clients that ignore resource links.
+        const response: any = await server.tools.get('archon_get_asset_file')!.handler({ id: 'did:cid:file' });
+        expect(response.content[0].type).toBe('resource');
     });
 
     it('returns null for file-like assets with no data', async () => {


### PR DESCRIPTION
Closes #735. This is the payoff #725/#734 unblocked.

## The problem

`archon_get_asset_file` put the entire asset into the model's context as base64, at roughly `bytes / 3` tokens:

| asset | result cost |
| --- | --- |
| 100 KB | ~35k tokens |
| 1 MB | ~350k tokens |
| 10 MB (the largest a node accepts) | ~3.5M tokens — more than any context window holds |

Nothing warned; one call just consumed the session. Above `ARCHON_MCP_INLINE_LIMIT` (16 KiB default) it now returns a `resource_link`, and the client fetches the bytes via `resources/read` if and when it wants them. Before #734 that link would have dangled — there was no read path — which is why this waited.

Measured through a real client, a **2 MB asset**:

```
block          : {"name":"big.pdf","uri":"did:cid:z3v8AuahBQrJ","mimeType":"application/pdf","size":2097152,"type":"resource_link"}
result bytes   : 341 chars (~85 tokens)
data fetched?  : NO — never left the gatekeeper
resources/read : 2097152 bytes returned on demand
```

**~700k tokens → 85.**

## Decisions

**Size is checked before anything is fetched.** `generateFileAsset` records `bytes` next to the CID, so it's in the DID document — a linked asset is never pulled from the gatekeeper at all. This costs *small* assets one extra resolve, which is the cheaper mistake: fetching megabytes to then measure them defeats the purpose. It rides in MCP's `size` field, which the spec documents for hosts to "display file sizes and estimate context window usage" — exactly this.

**The threshold is 16 KiB (~5.5k tokens).** Deliberately low: base64 is not something a model can *read*, so inlining only ever helps a client render or save the bytes. Paying real context for it buys nothing, and the bar should be "cheap enough not to think about" — small text, JSON, and icon assets, where a link would only add a round trip.

**It's configurable, and that's the escape hatch.** #735 flagged that clients ignoring links now get a link where they got bytes — a real breaking change. A very large `ARCHON_MCP_INLINE_LIMIT` restores the old always-inline behaviour; `0` links everything. (The compose-default pitfall from CLAUDE.md doesn't apply — the mcp-server isn't in any compose file. I checked.)

**Unknown size links rather than gambles.** An asset with no recorded `bytes` could be anything; guessing "small" risks burying the conversation, while a needless link costs one `resources/read`. No `size` is advertised when none is known.

**Images still always inline** — the other question #735 raised. An `image` block is *how a model sees an image*; a link is not something it can look at. So the context cost is the price of the feature, unlike base64 that nothing can read.

Handlers now receive the resolved config as a third argument, which is how the tool reads the limit — most ignore it.

## Testing

63 mcp-server tests pass; typecheck clean. New coverage: the link path (asserting `getFile` is **never called**), inclusive behaviour exactly at the limit, unknown size, a raised limit inlining a 10 MB asset, and `ARCHON_MCP_INLINE_LIMIT` parsing including rejection of negatives, decimals and junk.

Also verified through a real `McpServer`/`Client` pair that the `resource_link` result validates against `CallToolResultSchema` and that the emitted link resolves to the full bytes.

## Breaking change

Large file results change shape. Clients that don't follow resource links see a link where bytes used to be, with `ARCHON_MCP_INLINE_LIMIT` as the escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)