### PR TITLE
fix: report unfetchable asset bytes as an error, not as null (#738)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -118,7 +118,7 @@ Tools returning binary assets use the content block types the protocol defines f
 }
 ```
 
-Both return `null` when the asset carries no data.
+Both return `null` when the DID is not a file or image asset — that is the only thing `null` means here. If the asset's bytes cannot be fetched from the node (unpinned data, or a gateway that is down), that is reported as a tool error naming the CID, not as an empty result: the bytes exist, they just could not be retrieved, and the two are not the same answer. `resources/read` and `archon_get_vault_item` fail the same way.
 
 ### Large files are linked, not inlined
 

--- a/packages/mcp-server/src/resources.ts
+++ b/packages/mcp-server/src/resources.ts
@@ -22,7 +22,9 @@ export function vaultItemUri(containerDid: string, name: string): string {
 // that makes the failure diagnosable -- unpinned data, or a gateway that is down -- and it
 // is not a secret, being already in the DID document.
 export function assetDataUnavailable(id: string, cid?: string): Error {
-    return new Error(`Asset data is unavailable for ${id}${cid ? ` (CID: ${cid})` : ''}`);
+    const which = cid ? ` (CID: ${cid})` : '';
+
+    return new Error(`Asset data is unavailable for ${id}${which}`);
 }
 
 type RegisterableResourceServer = {

--- a/packages/mcp-server/src/resources.ts
+++ b/packages/mcp-server/src/resources.ts
@@ -17,6 +17,14 @@ export function vaultItemUri(containerDid: string, name: string): string {
     return `${containerDid}#${encodeURIComponent(name)}`;
 }
 
+// Shared by the tools and the resource reader so one failure reads the same everywhere.
+// The message names the CID, as keymaster's own getVaultItem error does: it is the detail
+// that makes the failure diagnosable -- unpinned data, or a gateway that is down -- and it
+// is not a secret, being already in the DID document.
+export function assetDataUnavailable(id: string, cid?: string): Error {
+    return new Error(`Asset data is unavailable for ${id}${cid ? ` (CID: ${cid})` : ''}`);
+}
+
 type RegisterableResourceServer = {
     registerResource?: (
         name: string,
@@ -43,7 +51,7 @@ async function readAsset(runtime: ArchonRuntime, uri: URL): Promise<ReadResource
         // different failures and must not collapse: falling back to JSON here would answer
         // a request for bytes with metadata, reporting an unavailable CID as a success.
         if (!file.data) {
-            throw new Error(`Asset data is unavailable for ${did}`);
+            throw assetDataUnavailable(did, file.cid);
         }
 
         return {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -524,12 +524,17 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
         const file = await keymaster.getFile(uri);
 
         // Reaching here means the asset IS a file asset -- summary.cid was checked above --
-        // so getFile cannot return null and missing data can only mean the fetch failed.
-        // Returning null would report that as "this asset has no data", and would make the
-        // same broken asset behave differently either side of the inline limit: linked
-        // above it (erroring later at resources/read), silently empty below.
+        // so missing data means the fetch failed. Returning null would report that as "this
+        // asset has no data", and would make the same broken asset behave differently either
+        // side of the inline limit: linked above it (erroring later at resources/read),
+        // silently empty below.
+        //
+        // Name the CID getFile actually tried, not the one from the resolve above: getFile
+        // resolves the asset again, and an asset is mutable (updateFile), so the two can
+        // disagree if the document changed in between. summary.cid is the fallback for the
+        // same race turning it into a non-file asset, which makes getFile return null.
         if (!file?.data) {
-            throw assetDataUnavailable(uri, summary.cid);
+            throw assetDataUnavailable(uri, file?.cid ?? summary.cid);
         }
 
         return contentResult(

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { McpServerConfig } from './config.js';
 import { ArchonRuntime, requireKeymaster } from './runtime.js';
-import { vaultItemUri } from './resources.js';
+import { assetDataUnavailable, vaultItemUri } from './resources.js';
 import { errorMessage } from './redact.js';
 
 type RegisterableServer = {
@@ -466,8 +466,15 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
     tool({ name: 'archon_get_asset_image', cliCommand: 'get-asset-image', description: 'Return an image asset as an image content block.', schema: IdSchema, handler: async (runtime, { id }) => {
         const image = await requireKeymaster(runtime).getImage(id);
 
-        if (!image?.file?.data) {
+        // getImage returns null only when this is not an image asset. When it cannot fetch
+        // the CID it returns the file WITHOUT data, which is a failure to report rather
+        // than an absence to shrug at -- the bytes exist, we just could not get them.
+        if (!image) {
             return null;
+        }
+
+        if (!image.file?.data) {
+            throw assetDataUnavailable(id, image.file?.cid);
         }
 
         const mimeType = image.file.type ?? 'application/octet-stream';
@@ -516,8 +523,13 @@ export const ARCHON_MCP_TOOL_DEFINITIONS: ArchonToolDefinition[] = [
 
         const file = await keymaster.getFile(uri);
 
+        // Reaching here means the asset IS a file asset -- summary.cid was checked above --
+        // so getFile cannot return null and missing data can only mean the fetch failed.
+        // Returning null would report that as "this asset has no data", and would make the
+        // same broken asset behave differently either side of the inline limit: linked
+        // above it (erroring later at resources/read), silently empty below.
         if (!file?.data) {
-            return null;
+            throw assetDataUnavailable(uri, summary.cid);
         }
 
         return contentResult(

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -830,6 +830,33 @@ describe('mcp server tools', () => {
         expect(message).toContain('bafyUNPINNED');
     });
 
+    it('names the CID that was actually fetched, not the one resolved earlier', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        // getFile resolves the asset again, and an asset is mutable, so the document can
+        // change between the two resolves. The CID whose fetch failed is getFile's.
+        runtime.keymaster.resolveAsset.mockResolvedValue({ file: { cid: 'bafySTALE', filename: 'gone.txt', type: 'text/plain', bytes: 4 } });
+        runtime.keymaster.getFile.mockResolvedValue({ filename: 'gone.txt', type: 'text/plain', cid: 'bafyCURRENT' });
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const message = expectFail(await server.tools.get('archon_get_asset_file')!.handler({ id: 'did:cid:file' }));
+
+        expect(message).toContain('bafyCURRENT');
+        expect(message).not.toContain('bafySTALE');
+    });
+
+    it('falls back to the resolved CID when getFile returns nothing', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        // The same race the other way: the asset stopped being a file asset between the
+        // resolves, so getFile has no CID to offer.
+        runtime.keymaster.resolveAsset.mockResolvedValue({ file: { cid: 'bafySTALE', filename: 'gone.txt', type: 'text/plain', bytes: 4 } });
+        runtime.keymaster.getFile.mockResolvedValue(null);
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        expect(expectFail(await server.tools.get('archon_get_asset_file')!.handler({ id: 'did:cid:file' }))).toContain('bafySTALE');
+    });
+
     it('errors when an image asset\'s bytes cannot be fetched', async () => {
         const server = new FakeServer();
         const runtime = mockRuntime();

--- a/tests/mcp-server/tools.test.ts
+++ b/tests/mcp-server/tools.test.ts
@@ -799,15 +799,47 @@ describe('mcp server tools', () => {
         expect(response.content[0].type).toBe('resource');
     });
 
-    it('returns null for file-like assets with no data', async () => {
+    // null now means one thing only: the DID is not that kind of asset. It is no longer
+    // also how an unfetchable CID is reported -- see the next two tests.
+    it('returns null when the DID is not a file or image asset', async () => {
         const server = new FakeServer();
         const runtime = mockRuntime();
         runtime.keymaster.getImage.mockResolvedValue(null);
         runtime.keymaster.getFile.mockResolvedValue(null);
+        runtime.keymaster.resolveAsset.mockResolvedValue({ hello: 'world' });
         registerArchonTools(server, runtime as any, baseConfig);
 
         expect(expectOk(await server.tools.get('archon_get_asset_image')!.handler({ id: 'did:cid:image' }))).toBeNull();
         expect(expectOk(await server.tools.get('archon_get_asset_file')!.handler({ id: 'did:cid:file' }))).toBeNull();
+    });
+
+    it('errors when a file asset\'s bytes cannot be fetched', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        // The asset IS a file asset and small enough to inline, but the gatekeeper cannot
+        // fetch its CID: getFile hands back the file minus its data.
+        runtime.keymaster.resolveAsset.mockResolvedValue({ file: { cid: 'bafyUNPINNED', filename: 'gone.txt', type: 'text/plain', bytes: 4 } });
+        runtime.keymaster.getFile.mockResolvedValue({ filename: 'gone.txt', type: 'text/plain', cid: 'bafyUNPINNED' });
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const message = expectFail(await server.tools.get('archon_get_asset_file')!.handler({ id: 'did:cid:file' }));
+
+        // Reported as a failure rather than as "this asset has no data", and the CID is
+        // named so the failure is diagnosable.
+        expect(message).toMatch(/unavailable/i);
+        expect(message).toContain('bafyUNPINNED');
+    });
+
+    it('errors when an image asset\'s bytes cannot be fetched', async () => {
+        const server = new FakeServer();
+        const runtime = mockRuntime();
+        runtime.keymaster.getImage.mockResolvedValue({ file: { filename: 'gone.png', type: 'image/png', cid: 'bafyGONE' }, image: { width: 1, height: 1 } });
+        registerArchonTools(server, runtime as any, baseConfig);
+
+        const message = expectFail(await server.tools.get('archon_get_asset_image')!.handler({ id: 'did:cid:image' }));
+
+        expect(message).toMatch(/unavailable/i);
+        expect(message).toContain('bafyGONE');
     });
 
     it('redacts secrets from tool errors', async () => {


### PR DESCRIPTION
Closes #738.

`archon_get_asset_file` and `archon_get_asset_image` returned **`null`** when the gatekeeper couldn't fetch an asset's CID — reporting an infrastructure failure as "this asset has no data". The bytes exist; we just couldn't get them. Those aren't the same answer: `null` looks like a result, while an `isError` is what a spec-compliant client actually shows the user.

## The size-dependent bit

Worse, and what tipped this from nit to bug: #737 made the behaviour depend on **file size**. The same broken asset answered `null` below `ARCHON_MCP_INLINE_LIMIT`, and above it returned a working-looking `resource_link` that only failed when read. Now both paths report the same failure with the same message:

```
small (4 B)  : tool error -> Asset data is unavailable for did:cid:z3v8AuahBQrJ (CID: bafyUNPINNED)
large (2 MB) : link -> read error: Asset data is unavailable for did:cid:z3v8AuahBQrJ (CID: bafyUNPINNED)
```

## Why throwing is right, not just preferred

Keymaster **already throws here** — `getVaultItem` raises `Failed to retrieve data for item ... (CID: ...)` — and `resources/read` has since #734. `null` was the outlier, so this is a consistency fix rather than a taste call. The message names the CID for the same reason `getVaultItem`'s does: it's the detail that makes the failure diagnosable (unpinned? gateway down?), and it's already public in the DID document. The error helper is shared by the tools and the resource reader so one failure reads identically everywhere.

## Smaller than the issue proposed

#738 called for giving `archon_get_asset_image` a "resolve-first" restructure. Not needed: `getImage` **already** returns `null` only when the asset isn't an image asset, and returns the file *without* `data` when the fetch fails. The two cases just needed separate checks — no extra resolve. And `get_asset_file` was already structurally separated by #737, which checks `summary.cid` before fetching, so only the wrong return value was left.

## The README question, settled

#738 asked whether "the asset carries no data" is even reachable. It isn't, for a file asset with a CID: `createFile` always writes one, and a zero-byte file still yields a truthy empty `Buffer`. So that sentence documented a state that cannot occur. `null` now means exactly one thing — the DID is not a file or image asset — and the README says so.

## Testing

68 mcp-server tests pass; typecheck clean. New: both tools error (naming the CID) when bytes can't be fetched; the existing null test is renamed and tightened to assert what `null` now means. Notably, **nothing failed when I made this change** — the old behaviour was never asserted, which is part of how it survived.

Also verified through a real `McpServer`/`Client` pair that one broken asset now reports identically either side of the inline limit.

## Breaking change

Callers treating `null` as "empty asset" now see a tool error. That's the point — the failure stops being silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)