### PR TITLE
ci: add build_test_images rollup status for branch protection

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -77,3 +77,23 @@ jobs:
         with:
           name: E2E Artifacts (${{ matrix.gatekeeper }}, ${{ matrix.keymaster }})
           path: e2e-results.xml
+
+  # Single stable status that rolls up every build_test_images matrix leg, so
+  # branch protection can require one check instead of the fragile per-leg
+  # matrix names. `if: always()` is required: without it this job is skipped
+  # when a leg fails, and a skipped required check would stall the PR instead
+  # of failing it.
+  build_test_images_result:
+    name: build_test_images result
+    if: always()
+    needs: build_test_images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all matrix legs passed
+        run: |
+          result="${{ needs.build_test_images.result }}"
+          if [ "$result" != "success" ]; then
+            echo "build_test_images did not succeed (result: $result)"
+            exit 1
+          fi
+          echo "All build_test_images legs passed"


### PR DESCRIPTION
## What

Adds a single rollup job, `build_test_images result`, to `docker-build-test.yml`. It `needs:` the `build_test_images` matrix and passes only when every leg succeeds.

## Why

The `build_test_images` matrix produces per-leg check names like `build_test_images (rust gatekeeper, python keymaster)`. These names change whenever the matrix changes, so requiring them in branch protection is fragile — editing the matrix silently orphans a required check and can permanently block merges.

This rollup gives **one stable required-check name** to select in branch protection instead of the ~4 dynamic matrix names. The other PR-triggered suites (`lockfile-consistency`, `dependency-review`, `test_python_sdk`, `test_python_keymaster`) are already single stable names.

## Note on `if: always()`

The rollup uses `if: always()` deliberately. Without it, the job is *skipped* when a matrix leg fails — and a skipped required check stalls a PR ("waiting for status") rather than blocking it. With `always()` + the explicit `result` check, a failed leg produces a real red required check.

## Follow-up (manual, admin-only)

Once merged and run on a PR, `build_test_images result` will appear in the branch-protection status-check picker. Add it there alongside the four stable checks above, and remove the currently-required `report-build-status` (that check is the GitHub Pages deploy status and never runs on PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)