### PR TITLE
security: bump form-data and tar overrides in mediators

### DIFF
--- a/services/mediators/ethereum/package-lock.json
+++ b/services/mediators/ethereum/package-lock.json
@@ -886,15 +886,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
@@ -1025,9 +1025,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/services/mediators/ethereum/package.json
+++ b/services/mediators/ethereum/package.json
@@ -22,9 +22,9 @@
     "sqlite3": "^6.0.1"
   },
   "overrides": {
-    "form-data": "2.5.5",
+    "form-data": "2.5.6",
     "qs": "6.15.1",
-    "tar": "^7.5.1",
+    "tar": "^7.5.16",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/services/mediators/satoshi-wallet/package-lock.json
+++ b/services/mediators/satoshi-wallet/package-lock.json
@@ -1447,9 +1447,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2514,15 +2514,15 @@
       }
     },
     "node_modules/request/node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },

--- a/services/mediators/satoshi-wallet/package.json
+++ b/services/mediators/satoshi-wallet/package.json
@@ -41,7 +41,7 @@
       "lodash": "4.18.1"
     },
     "request": {
-      "form-data": "2.5.5",
+      "form-data": "2.5.6",
       "qs": "6.14.2",
       "tough-cookie": "4.1.4"
     }

--- a/services/mediators/solana/package-lock.json
+++ b/services/mediators/solana/package-lock.json
@@ -1137,15 +1137,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
@@ -1276,9 +1276,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/services/mediators/solana/package.json
+++ b/services/mediators/solana/package.json
@@ -23,12 +23,12 @@
     "sqlite3": "^6.0.1"
   },
   "overrides": {
-    "form-data": "2.5.5",
+    "form-data": "2.5.6",
     "jayson": {
       "uuid": "^11.1.1"
     },
     "qs": "6.15.1",
-    "tar": "^7.5.1",
+    "tar": "^7.5.16",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/services/mediators/zcash/package-lock.json
+++ b/services/mediators/zcash/package-lock.json
@@ -966,15 +966,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
@@ -1136,9 +1136,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },

--- a/services/mediators/zcash/package.json
+++ b/services/mediators/zcash/package.json
@@ -23,9 +23,9 @@
     "sqlite3": "^6.0.1"
   },
   "overrides": {
-    "form-data": "2.5.5",
+    "form-data": "2.5.6",
     "qs": "6.15.1",
-    "tar": "^7.5.1"
+    "tar": "^7.5.16"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",


### PR DESCRIPTION
`form-data` and `tar` are transitive deps in the blockchain mediators, already pinned via each package's `overrides` block. This bumps those pins to patched versions.

## Changes

| Mediator | form-data | tar |
|---|---|---|
| solana | 2.5.5 → **2.5.6** | ^7.5.1 → **^7.5.16** |
| ethereum | 2.5.5 → **2.5.6** | ^7.5.1 → **^7.5.16** |
| zcash | 2.5.5 → **2.5.6** | ^7.5.1 → **^7.5.16** |
| satoshi-wallet | 2.5.5 → **2.5.6** (under `request` override) | — |

Resolved: form-data 2.5.6, tar 7.5.16 in all lockfiles. (satoshi-wallet's other `form-data@4.0.5` copy was already patched.)

## Advisories cleared

- **GHSA-hmw2-7cc7-3qxx (High)** — CRLF injection in form-data via unescaped multipart field names/filenames
- **node-tar cluster (High)** — GHSA-34x7-hfp2-rc4v, GHSA-83g3-92jg-28cx, GHSA-9ppj-qmqm-q256, GHSA-8qq5-rm4j-mr97, GHSA-r6q2-hw4h-h46w, GHSA-qffp-2rhf-9h96 (path traversal / symlink / hardlink escapes)
- **GHSA-vmf3-w455-68vh (Moderate)** — PAX size-override parser differential

Override-only change; lockfiles regenerated with `npm install --package-lock-only`.

> Note: these override blocks still pin `qs` to 6.15.1 (mediators) / 6.14.2 (satoshi-wallet), which remain exposed to the moderate GHSA-q8mj-m7cp-5q26 (patched 6.15.2). Left out to keep this PR scoped to form-data/tar; can follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)