### PR TITLE
security: override @xmldom/xmldom to 0.8.13 in react-wallet

### DIFF
--- a/apps/react-wallet/package-lock.json
+++ b/apps/react-wallet/package-lock.json
@@ -1988,9 +1988,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2008,9 +2005,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2028,9 +2022,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2048,9 +2039,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2068,9 +2056,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2088,9 +2073,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2475,10 +2457,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
-      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
-      "deprecated": "this version is no longer supported, please update to at least 0.8.*",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6009,16 +5990,6 @@
       },
       "engines": {
         "node": ">=10.4.0"
-      }
-    },
-    "node_modules/plist/node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/postcss": {

--- a/apps/react-wallet/package.json
+++ b/apps/react-wallet/package.json
@@ -41,5 +41,8 @@
     "esbuild": "^0.28.1",
     "typescript": "^5.9.3",
     "vite": "^8.1.5"
+  },
+  "overrides": {
+    "@xmldom/xmldom": "^0.8.13"
   }
 }


### PR DESCRIPTION
`@xmldom/xmldom` is a transitive dep of the Capacitor/Trapeze native-project build tooling in react-wallet, pulled in two copies both below the 0.8.13 fix line:

- `@trapezedev/project` (`^0.7.5`) and `mergexml` (`^0.7.0`) → **0.7.13**
- `plist` (`^0.8.8`) → **0.8.11**

Adds a top-level `overrides` entry forcing `@xmldom/xmldom` to `^0.8.13`, which collapses both to a single patched **0.8.13**.

## Advisories cleared

- GHSA-wh4c-j3r5-mjhp — XML injection via unsafe CDATA serialization
- GHSA-f6ww-3ggp-fr8h — injection via unvalidated DocumentType serialization
- GHSA-j759-j44w-7fr8 — node injection via unvalidated comment serialization
- GHSA-x6wf-f3px-wcqx — node injection via unvalidated processing-instruction serialization

## Risk

Build-time native-project tooling only (used by `cap sync`/asset generation) — not bundled into the shipped wallet. The 0.7→0.8 xmldom API is compatible for these consumers. Lockfile regenerated with `npm install --package-lock-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)