### PR TITLE
fix: re-derive HD key when saving a different wallet than the cache (#733)

### DIFF
--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -351,6 +351,10 @@ export default class Keymaster implements KeymasterInterface {
         wallet.seed.mnemonicEnc = mnemonicEnc;
         this.passphrase = newPassphrase;
         this._walletCache = wallet;
+        // Rotation re-encrypts the same mnemonic, so the cached HD key is still
+        // valid; repoint its identity to the new mnemonicEnc so the re-encrypt
+        // below reuses the cache instead of re-deriving.
+        this._hdkeyCacheKey = this.hdkeyCacheKey(wallet.seed);
 
         const encrypted = await this.encryptWalletForStorage(wallet);
         const ok = await this.db.saveWallet(encrypted, true);

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -206,6 +206,9 @@ export default class Keymaster implements KeymasterInterface {
     private _nodeCapabilities?: Record<string, boolean> | null;
     private _walletCache?: WalletFile;
     private _hdkeyCache?: any;
+    // Identity of the wallet whose seed `_hdkeyCache` was derived from, so a
+    // save of a *different* wallet re-derives instead of reusing a stale key.
+    private _hdkeyCacheKey?: string;
 
     constructor(options: KeymasterOptions) {
         if (!options || !options.gatekeeper || !options.gatekeeper.createDID) {
@@ -315,6 +318,9 @@ export default class Keymaster implements KeymasterInterface {
             counter: 0,
             ids: {}
         };
+        // _hdkeyCache was just set from this mnemonic; record its identity so
+        // the save below reuses it instead of re-deriving.
+        this._hdkeyCacheKey = this.hdkeyCacheKey(wallet.seed);
 
         const ok = await this.saveWallet(wallet, overwrite)
         if (!ok) {
@@ -5500,13 +5506,25 @@ export default class Keymaster implements KeymasterInterface {
         } catch { }
     }
 
+    // The passphrase-encrypted mnemonic uniquely identifies the wallet whose
+    // seed a cached HD key belongs to. Used to detect when the cache is stale
+    // for the wallet currently being encrypted (e.g. restoring one wallet into
+    // an instance warmed by another) so we re-derive rather than encrypt under
+    // the wrong key and brick the stored wallet.
+    private hdkeyCacheKey(seed: Seed): string | undefined {
+        const enc = seed.mnemonicEnc;
+        return enc ? `${enc.salt}.${enc.iv}.${enc.data}` : undefined;
+    }
+
     private async getHDKeyFromCacheOrMnemonic(wallet: WalletFile) {
-        if (this._hdkeyCache) {
+        const cacheKey = this.hdkeyCacheKey(wallet.seed);
+        if (this._hdkeyCache && cacheKey !== undefined && this._hdkeyCacheKey === cacheKey) {
             return this._hdkeyCache;
         }
 
         const mnemonic = await this.getMnemonicForDerivation(wallet);
         this._hdkeyCache = this.cipher.generateHDKey(mnemonic);
+        this._hdkeyCacheKey = cacheKey;
         return this._hdkeyCache;
     }
 
@@ -5538,6 +5556,7 @@ export default class Keymaster implements KeymasterInterface {
         }
 
         this._hdkeyCache = this.cipher.generateHDKey(mnemonic);
+        this._hdkeyCacheKey = this.hdkeyCacheKey(stored.seed);
         const { publicJwk, privateJwk } = this.cipher.generateJwk(this._hdkeyCache.privateKey!);
 
         const plaintext = this.cipher.decryptMessage(privateJwk, stored.enc, publicJwk);

--- a/python/keymaster/src/keymaster/core.py
+++ b/python/keymaster/src/keymaster/core.py
@@ -130,6 +130,9 @@ class Keymaster:
         self.max_data_length = 8 * 1024
         self._wallet_cache: dict[str, Any] | None = None
         self._root_cache = None
+        # Identity of the wallet whose seed `_root_cache` was derived from, so a
+        # save of a *different* wallet re-derives instead of reusing a stale key.
+        self._root_cache_key: str | None = None
         self._lock = asyncio.Lock()
         # Node capability manifest (<nodeURL>/api/v1/capabilities), fetched once and
         # memoized. _UNFETCHED until first read; None = node has no manifest (older
@@ -195,6 +198,9 @@ class Keymaster:
             "ids": {},
             "aliases": {},
         }
+        # _root_cache was just set from this mnemonic; record its identity so
+        # the save below reuses it instead of re-deriving.
+        self._root_cache_key = self._root_cache_identity(wallet["seed"])
         ok = await self.save_wallet(wallet, overwrite=overwrite)
         if not ok:
             raise KeymasterError("save wallet failed")
@@ -210,6 +216,7 @@ class Keymaster:
         except InvalidTag as exc:
             raise KeymasterError("Incorrect passphrase.") from exc
         self._root_cache = hd_root_from_mnemonic(mnemonic)
+        self._root_cache_key = self._root_cache_identity(seed)
         root_pair = await self.hd_key_pair()
         try:
             plaintext = decrypt_message(root_pair["privateJwk"], stored["enc"])
@@ -238,6 +245,7 @@ class Keymaster:
 
         self.passphrase = new_passphrase
         self._root_cache = hd_root_from_mnemonic(mnemonic)
+        self._root_cache_key = self._root_cache_identity(wallet["seed"])
         self._wallet_cache = wallet
 
         encrypted = await self.encrypt_wallet_for_storage(wallet)
@@ -249,13 +257,38 @@ class Keymaster:
     async def export_encrypted_wallet(self) -> dict[str, Any]:
         return await self.encrypt_wallet_for_storage(await self.load_wallet())
 
+    @staticmethod
+    def _root_cache_identity(seed: dict[str, Any]) -> str | None:
+        # The passphrase-encrypted mnemonic uniquely identifies the wallet whose
+        # seed a cached root belongs to. Comparing it detects when the cache is
+        # stale for the wallet currently being encrypted (e.g. restoring one
+        # wallet into an instance warmed by another) so we re-derive rather than
+        # encrypt under the wrong key and brick the stored wallet.
+        enc = (seed or {}).get("mnemonicEnc")
+        if not enc:
+            return None
+        return f"{enc['salt']}.{enc['iv']}.{enc['data']}"
+
     async def _root_node(self, wallet: dict[str, Any] | None = None):
+        # When a wallet is supplied, re-derive if the cache belongs to a
+        # different wallet (the #733 fix). When it is not, keep the original
+        # early-return on a warm cache: callers inside decrypt_wallet reach here
+        # while load_wallet is mid-flight, so we must not re-enter load_wallet.
+        if wallet is not None:
+            cache_key = self._root_cache_identity(wallet.get("seed", {}))
+            if self._root_cache is not None and cache_key is not None and self._root_cache_key == cache_key:
+                return self._root_cache
+            mnemonic = decrypt_with_passphrase(wallet["seed"]["mnemonicEnc"], self.passphrase)
+            self._root_cache = hd_root_from_mnemonic(mnemonic)
+            self._root_cache_key = cache_key
+            return self._root_cache
+
         if self._root_cache is not None:
             return self._root_cache
-        if wallet is None:
-            wallet = await self.load_wallet()
+        wallet = await self.load_wallet()
         mnemonic = decrypt_with_passphrase(wallet["seed"]["mnemonicEnc"], self.passphrase)
         self._root_cache = hd_root_from_mnemonic(mnemonic)
+        self._root_cache_key = self._root_cache_identity(wallet.get("seed", {}))
         return self._root_cache
 
     async def hd_key_pair(self, wallet: dict[str, Any] | None = None) -> dict[str, dict[str, str]]:

--- a/python/keymaster/tests/test_wallet.py
+++ b/python/keymaster/tests/test_wallet.py
@@ -65,6 +65,37 @@ def test_save_wallet_rejects_unsupported_version(testbed):
         run(testbed.keymaster.save_wallet({"version": 0, "seed": {"mnemonicEnc": {}}, "ids": {}}))
 
 
+def test_save_wallet_restore_into_warm_instance_does_not_corrupt(testbed):
+    # Regression for #733: restoring the unencrypted WalletFile form into an
+    # instance whose root-key cache was warmed by a different wallet used to
+    # encrypt the restored metadata under the wrong key, bricking the stored
+    # wallet while save_wallet still returned True.
+
+    # Warm instance A's root-key cache with wallet A.
+    run(testbed.keymaster.create_id("Alice"))
+    run(testbed.keymaster.load_wallet())
+
+    # Build an independent wallet B and take its decrypted WalletFile form.
+    other = make_testbed()
+    run(other.keymaster.create_id("Bob"))
+    wallet_b = run(other.keymaster.load_wallet())
+    assert "enc" not in wallet_b
+
+    # Restore B into the warmed instance A.
+    assert run(testbed.keymaster.save_wallet(wallet_b, overwrite=True)) is True
+
+    # A fresh instance over the same store must read B back intact.
+    fresh = Keymaster(
+        gatekeeper=testbed.gatekeeper,
+        wallet_store=testbed.wallet_store,
+        passphrase="passphrase",
+    )
+    restored = run(fresh.load_wallet())
+    assert "Bob" in restored["ids"]
+    assert "Alice" not in restored["ids"]
+    assert restored == wallet_b
+
+
 def test_new_wallet_rejects_invalid_mnemonic(testbed):
     with pytest.raises(KeymasterError, match="Invalid parameter: mnemonic"):
         run(testbed.keymaster.new_wallet("not a valid mnemonic", overwrite=True))

--- a/tests/keymaster/wallet.test.ts
+++ b/tests/keymaster/wallet.test.ts
@@ -290,6 +290,36 @@ describe('saveWallet', () => {
         expect(ok).toBe(true);
     });
 
+    // Regression for #733: restoring the unencrypted WalletFile form (as the
+    // MCP surface hands out from create/show) into an instance whose HD-key
+    // cache was already warmed by a *different* wallet used to encrypt the
+    // restored metadata under the wrong key, bricking the stored wallet while
+    // saveWallet still returned true.
+    it('should not corrupt when restoring a different wallet into a warm instance', async () => {
+        // Warm instance A's HD-key cache with wallet A.
+        await keymaster.createId('Alice');
+        await keymaster.loadWallet();
+
+        // Build an independent wallet B and take its decrypted WalletFile form.
+        const walletBStore = new WalletJsonMemory();
+        const keymasterB = new Keymaster({ gatekeeper, wallet: walletBStore, cipher, passphrase: PASSPHRASE });
+        await keymasterB.createId('Bob');
+        const walletB = await keymasterB.loadWallet();
+        expect('enc' in walletB).toBe(false);
+
+        // Restore B into the warmed instance A.
+        const ok = await keymaster.saveWallet(walletB, true);
+        expect(ok).toBe(true);
+
+        // A fresh instance over the same storage must read B back intact,
+        // not throw or surface wallet A's contents.
+        const fresh = new Keymaster({ gatekeeper, wallet, cipher, passphrase: PASSPHRASE });
+        const restored = await fresh.loadWallet();
+        expect(restored.ids['Bob']).toBeDefined();
+        expect(restored.ids['Alice']).toBeUndefined();
+        expect(restored).toStrictEqual(walletB);
+    });
+
     it('should throw on incorrect passphrase', async () => {
         const wallet = new WalletJsonMemory();
         const keymaster = new Keymaster({ gatekeeper, wallet, cipher, passphrase: 'incorrect' });


### PR DESCRIPTION
Fixes #733.

## The bug

Restoring the unencrypted `WalletFile` form — the form the MCP surface hands out from `archon_create_wallet` / `archon_show_wallet` / `archon_new_wallet` — into a **long-lived instance** (MCP server, keymaster REST service) whose HD-key cache was warmed by a *different* wallet silently corrupts the stored wallet, while `saveWallet` still returns `true`.

The metadata gets encrypted under the **previous** wallet's HD key, but the **incoming** wallet's `seed.mnemonicEnc` is stored. On next load the key derived from that mnemonic can't decrypt `enc` → the wallet is bricked.

## Root cause

The HD-key cache (`_hdkeyCache` / `_root_cache`) carried no record of which wallet's seed it was derived from, so `getHDKeyFromCacheOrMnemonic` / `_root_node` returned a stale key for the wallet being encrypted. The **encrypted**-restore path is unaffected (it refreshes the cache before re-encrypting); only the decrypted `WalletFile` path, which skips that refresh, was exposed. The **CLI is safe** — one command per process, cold cache — which is why this never surfaced there.

Reachable via the obvious MCP round trip: `create_wallet` → keep the result → hand it back to `restore_wallet_file` on the same session.

## Fix

Key the cache to the passphrase-encrypted mnemonic (`salt.iv.data`) it was derived from. The cache is now reused only when the wallet being encrypted matches; otherwise it re-derives.

- Normal same-wallet saves (the idiomatic `load → mutate → save`) keep the cache warm — **no extra KDF**.
- The KDF is paid only when the wallet identity actually changes, which is the correct behaviour.

Why not the alternatives (evaluated on the issue): deriving unconditionally in `encryptWalletForStorage` defeats the hot-path cache; rejecting the `WalletFile` form breaks `newWallet`, the documented MCP schema, and the ~32 `load→mutate→save` tests — it's a first-class API path, not misuse.

## Parity

Applied symmetrically to the **JS core** (`packages/keymaster`) and the **Python keymaster port** (`python/keymaster`) — same bug, same fix — since both back the REST/MCP surfaces.

## Tests

Adds a regression test in each language: warm an instance with wallet A, restore wallet B's decrypted form, assert a fresh instance reads B back intact (Bob present, Alice absent). Both **fail without the fix** (verified — read-back throws a decryption error) and pass with it.

- JS: `tests/keymaster/wallet.test.ts` — full suite green (56)
- Python: `python/keymaster/tests/test_wallet.py` — suite green (40)
- eslint clean on changed TS

🤖 Generated with [Claude Code](https://claude.com/claude-code)