### PR TITLE
release: patch point release of all @didcid packages (0.x.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26527,7 +26527,7 @@
     },
     "packages/browser-hdkey": {
       "name": "@didcid/browser-hdkey",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.3.3",
@@ -26574,10 +26574,10 @@
     },
     "packages/cipher": {
       "name": "@didcid/cipher",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@didcid/browser-hdkey": "^0.3.0",
+        "@didcid/browser-hdkey": "^0.3.1",
         "@noble/ciphers": "^0.4.1",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^1.3.3",
@@ -26627,7 +26627,7 @@
     },
     "packages/clients": {
       "name": "@didcid/clients",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.18.1",
@@ -26666,7 +26666,7 @@
     },
     "packages/common": {
       "name": "@didcid/common",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.3",
@@ -26676,13 +26676,13 @@
     },
     "packages/gatekeeper": {
       "name": "@didcid/gatekeeper",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
-        "@didcid/cipher": "^0.4.0",
-        "@didcid/clients": "^0.1.0",
-        "@didcid/common": "^0.3.0",
-        "@didcid/ipfs": "^0.3.0",
+        "@didcid/cipher": "^0.4.1",
+        "@didcid/clients": "^0.1.1",
+        "@didcid/common": "^0.3.1",
+        "@didcid/ipfs": "^0.3.1",
         "canonicalize": "^2.0.0",
         "dotenv": "^16.4.5",
         "ioredis": "^5.4.1",
@@ -26696,10 +26696,10 @@
     },
     "packages/ipfs": {
       "name": "@didcid/ipfs",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@didcid/common": "^0.3.0",
+        "@didcid/common": "^0.3.1",
         "@helia/json": "^4.0.3",
         "@helia/unixfs": "^5.0.0",
         "axios": "^1.18.1",
@@ -26715,12 +26715,12 @@
     },
     "packages/keymaster": {
       "name": "@didcid/keymaster",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
-        "@didcid/cipher": "^0.4.0",
-        "@didcid/clients": "^0.1.0",
-        "@didcid/common": "^0.3.0",
+        "@didcid/cipher": "^0.4.1",
+        "@didcid/clients": "^0.1.1",
+        "@didcid/common": "^0.3.1",
         "commander": "^11.1.0",
         "dotenv": "^16.4.5",
         "file-type": "^21.3.2",
@@ -26748,12 +26748,12 @@
     },
     "packages/mcp-server": {
       "name": "@didcid/mcp-server",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@didcid/cipher": "^0.4.0",
-        "@didcid/clients": "^0.1.0",
-        "@didcid/keymaster": "^0.6.0",
+        "@didcid/cipher": "^0.4.1",
+        "@didcid/clients": "^0.1.1",
+        "@didcid/keymaster": "^0.6.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^16.4.5",
         "zod": "^3.25.76"

--- a/packages/browser-hdkey/CHANGELOG.md
+++ b/packages/browser-hdkey/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.1](https://github.com/archetech/archon/compare/@didcid/browser-hdkey@0.1.11...@didcid/browser-hdkey@0.3.1) (2026-07-20)
+
+
+### Features
+
+* expand MCP server toward Keymaster CLI parity ([#606](https://github.com/archetech/archon/issues/606)) ([8021d44](https://github.com/archetech/archon/commit/8021d4486d28003408234c2f33993389965d1dd1))
+
+
+
+
+
 # [0.3.0](https://github.com/archetech/archon/compare/@didcid/browser-hdkey@0.2.0...@didcid/browser-hdkey@0.3.0) (2026-06-26)
 
 **Note:** Version bump only for package @didcid/browser-hdkey

--- a/packages/browser-hdkey/package.json
+++ b/packages/browser-hdkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/browser-hdkey",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Bitcoin BIP32 hierarchical deterministic keys",
   "main": "lib/hdkey.js",
   "types": "lib/hdkey.d.ts",

--- a/packages/cipher/CHANGELOG.md
+++ b/packages/cipher/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.1](https://github.com/archetech/archon/compare/@didcid/cipher@0.1.3...@didcid/cipher@0.4.1) (2026-07-20)
+
+
+### Bug Fixes
+
+* Incorrect passphrase on react-wallet ([#97](https://github.com/archetech/archon/issues/97)) ([5ce0523](https://github.com/archetech/archon/commit/5ce05238ecb2dd6e5a4a647ab0429a9cf9bdb6a4))
+
+
+### Features
+
+* Add nostr support ([#133](https://github.com/archetech/archon/issues/133)) ([3591d62](https://github.com/archetech/archon/commit/3591d6281bf29c5e98e761e7ad56a7abf78a4106)), closes [#87](https://github.com/archetech/archon/issues/87)
+* Adopt W3C JWE standard for encryption ([#90](https://github.com/archetech/archon/issues/90)) ([2321ca7](https://github.com/archetech/archon/commit/2321ca7fd6e074bac1f4b8fa7c12e58d4b45b181))
+* DIDComm Messaging v2 (Phases 0–7): TS + Python parity, transport, protocols, auto-discovery ([#633](https://github.com/archetech/archon/issues/633)) ([f53feef](https://github.com/archetech/archon/commit/f53feefc2a1e1fff1cc1ae86345dc1389de316c1)), closes [#key-1](https://github.com/archetech/archon/issues/key-1) [did#key-agreement-1](https://github.com/did/issues/key-agreement-1)
+* expand MCP server toward Keymaster CLI parity ([#606](https://github.com/archetech/archon/issues/606)) ([8021d44](https://github.com/archetech/archon/commit/8021d4486d28003408234c2f33993389965d1dd1))
+* Store imported nostr nsec in wallet ([#397](https://github.com/archetech/archon/issues/397)) ([7a0a919](https://github.com/archetech/archon/commit/7a0a919f34ba9161dce25eaa528dccf3443840a4))
+
+
+
+
+
 # [0.4.0](https://github.com/archetech/archon/compare/@didcid/cipher@0.3.0...@didcid/cipher@0.4.0) (2026-06-26)
 
 **Note:** Version bump only for package @didcid/cipher

--- a/packages/cipher/package.json
+++ b/packages/cipher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/cipher",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Archon cipher lib",
   "type": "module",
   "main": "./dist/cjs/cipher-web.cjs",
@@ -80,7 +80,7 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/browser-hdkey": "^0.3.0",
+    "@didcid/browser-hdkey": "^0.3.1",
     "@noble/ciphers": "^0.4.1",
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^1.3.3",

--- a/packages/clients/CHANGELOG.md
+++ b/packages/clients/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.1.1 (2026-07-20)
+
+
+### Bug Fixes
+
+* extract lightweight service clients ([#707](https://github.com/archetech/archon/issues/707)) ([94b1698](https://github.com/archetech/archon/commit/94b1698b6cbd633db6f5bf911aaac16c95ee4ee2))

--- a/packages/clients/package.json
+++ b/packages/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/clients",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Lightweight HTTP clients for Archon services",
   "type": "module",
   "module": "./dist/esm/index.js",
@@ -44,11 +44,21 @@
   },
   "typesVersions": {
     "*": {
-      "gatekeeper": ["./dist/types/gatekeeper-client.d.ts"],
-      "drawbridge": ["./dist/types/drawbridge-client.d.ts"],
-      "keymaster": ["./dist/types/keymaster-client.d.ts"],
-      "gatekeeper-types": ["./dist/types/gatekeeper-types.d.ts"],
-      "keymaster-types": ["./dist/types/keymaster-types.d.ts"]
+      "gatekeeper": [
+        "./dist/types/gatekeeper-client.d.ts"
+      ],
+      "drawbridge": [
+        "./dist/types/drawbridge-client.d.ts"
+      ],
+      "keymaster": [
+        "./dist/types/keymaster-client.d.ts"
+      ],
+      "gatekeeper-types": [
+        "./dist/types/gatekeeper-types.d.ts"
+      ],
+      "keymaster-types": [
+        "./dist/types/keymaster-types.d.ts"
+      ]
     }
   },
   "scripts": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.1](https://github.com/archetech/archon/compare/@didcid/common@0.1.3...@didcid/common@0.3.1) (2026-07-20)
+
+
+### Features
+
+* Add Lightning wallet support via LNbits integration ([#136](https://github.com/archetech/archon/issues/136)) ([#140](https://github.com/archetech/archon/issues/140)) ([4d99d5a](https://github.com/archetech/archon/commit/4d99d5ab8da20897e5aecf8557b271c3b1779d45))
+* expand MCP server toward Keymaster CLI parity ([#606](https://github.com/archetech/archon/issues/606)) ([8021d44](https://github.com/archetech/archon/commit/8021d4486d28003408234c2f33993389965d1dd1))
+
+
+
+
+
 # [0.3.0](https://github.com/archetech/archon/compare/@didcid/common@0.2.0...@didcid/common@0.3.0) (2026-06-26)
 
 **Note:** Version bump only for package @didcid/common

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/common",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Archon common utilities",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/gatekeeper/CHANGELOG.md
+++ b/packages/gatekeeper/CHANGELOG.md
@@ -3,6 +3,56 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.1](https://github.com/archetech/archon/compare/@didcid/gatekeeper@0.2.0...@didcid/gatekeeper@0.6.1) (2026-07-20)
+
+
+### Bug Fixes
+
+* extract lightweight service clients ([#707](https://github.com/archetech/archon/issues/707)) ([94b1698](https://github.com/archetech/archon/commit/94b1698b6cbd633db6f5bf911aaac16c95ee4ee2))
+
+
+### Features
+
+* add Filecoin storage mediator ([#555](https://github.com/archetech/archon/issues/555)) ([50e1265](https://github.com/archetech/archon/commit/50e1265f939de089f22a4d0bea9b7745ef3eb8e1))
+* Allow pin as a DID registry ([#561](https://github.com/archetech/archon/issues/561)) ([fb90d66](https://github.com/archetech/archon/commit/fb90d6664ec9cf8a56f2a207a6652c6753b23fe8))
+* DIDComm Messaging v2 (Phases 0–7): TS + Python parity, transport, protocols, auto-discovery ([#633](https://github.com/archetech/archon/issues/633)) ([f53feef](https://github.com/archetech/archon/commit/f53feefc2a1e1fff1cc1ae86345dc1389de316c1)), closes [#key-1](https://github.com/archetech/archon/issues/key-1) [did#key-agreement-1](https://github.com/did/issues/key-agreement-1)
+* expand MCP server toward Keymaster CLI parity ([#606](https://github.com/archetech/archon/issues/606)) ([8021d44](https://github.com/archetech/archon/commit/8021d4486d28003408234c2f33993389965d1dd1))
+
+
+
+# 0.8.0 (2026-05-15)
+
+
+### Bug Fixes
+
+* Better error message for missing wallet ([#53](https://github.com/archetech/archon/issues/53)) ([1a8dad0](https://github.com/archetech/archon/commit/1a8dad05a8a1eafb5d89e88224b913657d1f0530))
+* getVaultItem failed for small vault items ([#45](https://github.com/archetech/archon/issues/45)) ([a6fdd52](https://github.com/archetech/archon/commit/a6fdd5233ae2013879b28252d322e392211a59c2))
+* Show failed lightning payments ([#376](https://github.com/archetech/archon/issues/376)) ([7d3b24f](https://github.com/archetech/archon/commit/7d3b24faff2cf8a1800143079a3367f2cf1e873e))
+
+
+### Features
+
+* Add ARCHON_ADMIN_API_KEY support to CLI docker container ([#128](https://github.com/archetech/archon/issues/128)) ([#131](https://github.com/archetech/archon/issues/131)) ([8526717](https://github.com/archetech/archon/commit/8526717c50b6fb71b3812fe9cd7867051d134c53))
+* Add change-registry command to change a DID's registry ([#194](https://github.com/archetech/archon/issues/194)) ([0d258de](https://github.com/archetech/archon/commit/0d258def464394a9c49b6d07f7681c35cfda5721)), closes [#153](https://github.com/archetech/archon/issues/153)
+* Add decodeLightningInvoice to Keymaster ([#146](https://github.com/archetech/archon/issues/146)) ([2ed4139](https://github.com/archetech/archon/commit/2ed4139f3ae548b21ca509877f3b05d3ce68f1b6)), closes [#145](https://github.com/archetech/archon/issues/145)
+* Add getVersion() to KeymasterClient ([#219](https://github.com/archetech/archon/issues/219)) ([f06d89c](https://github.com/archetech/archon/commit/f06d89c8047d60c00611eef4b2a577b54ca6d6a6)), closes [#205](https://github.com/archetech/archon/issues/205)
+* Add Lightning tab to web clients ([#148](https://github.com/archetech/archon/issues/148)) ([73ed52e](https://github.com/archetech/archon/commit/73ed52ea0da92b391fa53a92ba2c671f91912bbd)), closes [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147)
+* Add Lightning wallet support via LNbits integration ([#136](https://github.com/archetech/archon/issues/136)) ([#140](https://github.com/archetech/archon/issues/140)) ([4d99d5a](https://github.com/archetech/archon/commit/4d99d5ab8da20897e5aecf8557b271c3b1779d45))
+* Add Lightning Zap tab and Publish toggle to web clients ([#161](https://github.com/archetech/archon/issues/161)) ([6357451](https://github.com/archetech/archon/commit/6357451083f464120b01348c889deb5c80bed05f)), closes [#159](https://github.com/archetech/archon/issues/159)
+* add zcash wallet and mediator services ([#517](https://github.com/archetech/archon/issues/517)) ([d898fab](https://github.com/archetech/archon/commit/d898fab47f71cdc4c718d977b007b51410da8b19))
+* Added update-credential to agent CLI ([#66](https://github.com/archetech/archon/issues/66)) ([002fce1](https://github.com/archetech/archon/commit/002fce1dcf2edb8c621eb77501cdf0abeed90484))
+* Adds CLI to keymaster package ([#39](https://github.com/archetech/archon/issues/39)) ([894ce73](https://github.com/archetech/archon/commit/894ce732f5beaca37bb90ace6b760b8e80aba3e9))
+* Adds get-property command to CLI ([#73](https://github.com/archetech/archon/issues/73)) ([310d7fe](https://github.com/archetech/archon/commit/310d7fe5d95976b8ca37ec12b7d6dc16cc52f65a))
+* Display Lightning payment history ([#164](https://github.com/archetech/archon/issues/164)) ([#165](https://github.com/archetech/archon/issues/165)) ([c8ec283](https://github.com/archetech/archon/commit/c8ec2835b0cde542c71e02fdb7fc55c3d46a81d1))
+* Lightning zap — send sats to a DID ([#155](https://github.com/archetech/archon/issues/155)) ([39d7ee3](https://github.com/archetech/archon/commit/39d7ee3242973ace494e45f636ca12fe78d911ab)), closes [#154](https://github.com/archetech/archon/issues/154)
+* move lightning payment filtering to client with full state display ([#237](https://github.com/archetech/archon/issues/237)) ([0eee4c0](https://github.com/archetech/archon/commit/0eee4c0987513d689a2a4eec3b7b088556be53b2)), closes [#236](https://github.com/archetech/archon/issues/236)
+* stream large file uploads/downloads for multi-GB video support ([#238](https://github.com/archetech/archon/issues/238)) ([eca94a0](https://github.com/archetech/archon/commit/eca94a06c041849a181a5a072728b9fe0c22bfae)), closes [#208](https://github.com/archetech/archon/issues/208)
+* Support mainnet registries ([#34](https://github.com/archetech/archon/issues/34)) ([a206c9e](https://github.com/archetech/archon/commit/a206c9e24f29fabec45f3cb239b8ba88f0525e6d))
+
+
+
+
+
 # [0.6.0](https://github.com/archetech/archon/compare/@didcid/gatekeeper@0.5.0...@didcid/gatekeeper@0.6.0) (2026-06-26)
 
 **Note:** Version bump only for package @didcid/gatekeeper

--- a/packages/gatekeeper/package.json
+++ b/packages/gatekeeper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/gatekeeper",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Archon Gatekeeper",
   "type": "module",
   "module": "./dist/esm/index.js",
@@ -114,10 +114,10 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/cipher": "^0.4.0",
-    "@didcid/clients": "^0.1.0",
-    "@didcid/common": "^0.3.0",
-    "@didcid/ipfs": "^0.3.0",
+    "@didcid/cipher": "^0.4.1",
+    "@didcid/clients": "^0.1.1",
+    "@didcid/common": "^0.3.1",
+    "@didcid/ipfs": "^0.3.1",
     "canonicalize": "^2.0.0",
     "dotenv": "^16.4.5",
     "ioredis": "^5.4.1",

--- a/packages/ipfs/CHANGELOG.md
+++ b/packages/ipfs/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.1](https://github.com/archetech/archon/compare/@didcid/ipfs@0.1.3...@didcid/ipfs@0.3.1) (2026-07-20)
+
+
+### Features
+
+* expand MCP server toward Keymaster CLI parity ([#606](https://github.com/archetech/archon/issues/606)) ([8021d44](https://github.com/archetech/archon/commit/8021d4486d28003408234c2f33993389965d1dd1))
+* stream large file uploads/downloads for multi-GB video support ([#238](https://github.com/archetech/archon/issues/238)) ([eca94a0](https://github.com/archetech/archon/commit/eca94a06c041849a181a5a072728b9fe0c22bfae)), closes [#208](https://github.com/archetech/archon/issues/208)
+
+
+
+
+
 # [0.3.0](https://github.com/archetech/archon/compare/@didcid/ipfs@0.2.0...@didcid/ipfs@0.3.0) (2026-06-26)
 
 **Note:** Version bump only for package @didcid/ipfs

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/ipfs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Archon IPFS lib",
   "type": "module",
   "module": "./dist/esm/index.js",
@@ -74,7 +74,7 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/common": "^0.3.0",
+    "@didcid/common": "^0.3.1",
     "@helia/json": "^4.0.3",
     "@helia/unixfs": "^5.0.0",
     "axios": "^1.18.1",

--- a/packages/keymaster/CHANGELOG.md
+++ b/packages/keymaster/CHANGELOG.md
@@ -3,6 +3,79 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.1](https://github.com/archetech/archon/compare/@didcid/keymaster@0.2.0...@didcid/keymaster@0.6.1) (2026-07-20)
+
+
+### Bug Fixes
+
+* Allow create-id to auto-create wallet ([#102](https://github.com/archetech/archon/issues/102)) ([#103](https://github.com/archetech/archon/issues/103)) ([bb6bc7a](https://github.com/archetech/archon/commit/bb6bc7a57d6bcfed679812b8489ab43ab9f10731)), closes [#53](https://github.com/archetech/archon/issues/53)
+* Better error message for missing wallet ([#53](https://github.com/archetech/archon/issues/53)) ([1a8dad0](https://github.com/archetech/archon/commit/1a8dad05a8a1eafb5d89e88224b913657d1f0530))
+* Check zap status in CLI ([#255](https://github.com/archetech/archon/issues/255)) ([634196a](https://github.com/archetech/archon/commit/634196a8e6a627bcf49b11a568be8a363eb18bc2))
+* extract lightweight service clients ([#707](https://github.com/archetech/archon/issues/707)) ([94b1698](https://github.com/archetech/archon/commit/94b1698b6cbd633db6f5bf911aaac16c95ee4ee2))
+* Incorrect passphrase on react-wallet ([#97](https://github.com/archetech/archon/issues/97)) ([5ce0523](https://github.com/archetech/archon/commit/5ce05238ecb2dd6e5a4a647ab0429a9cf9bdb6a4))
+* re-derive HD key when saving a different wallet than the cache ([#733](https://github.com/archetech/archon/issues/733)) ([#757](https://github.com/archetech/archon/issues/757)) ([8181fa8](https://github.com/archetech/archon/commit/8181fa8841b2c918fb905440e4291cba795048c1))
+* read DIDComm mailbox via the local gateway, not the public endpoint ([#646](https://github.com/archetech/archon/issues/646)) ([f109c41](https://github.com/archetech/archon/commit/f109c410840a5a15a43b953ea7f3bb6fd647e3f3))
+* route server Keymaster through Drawbridge for DIDComm ([#696](https://github.com/archetech/archon/issues/696)) ([41d82d3](https://github.com/archetech/archon/commit/41d82d3f8e9b7da7f703f30b987f856fc6fadfd2))
+* send binary responses for image/file API routes ([#444](https://github.com/archetech/archon/issues/444)) ([3317c72](https://github.com/archetech/archon/commit/3317c7210f041fa84097a1a9efac377cb1942b00))
+* Show failed lightning payments ([#376](https://github.com/archetech/archon/issues/376)) ([7d3b24f](https://github.com/archetech/archon/commit/7d3b24faff2cf8a1800143079a3367f2cf1e873e))
+
+
+### Features
+
+* Add ARCHON_ADMIN_API_KEY support to CLI docker container ([#128](https://github.com/archetech/archon/issues/128)) ([#131](https://github.com/archetech/archon/issues/131)) ([8526717](https://github.com/archetech/archon/commit/8526717c50b6fb71b3812fe9cd7867051d134c53))
+* Add change-passphrase command ([#111](https://github.com/archetech/archon/issues/111)) ([#112](https://github.com/archetech/archon/issues/112)) ([b6b24bb](https://github.com/archetech/archon/commit/b6b24bb6c32da91edebcf85e1212420975da70ed))
+* Add change-registry command to change a DID's registry ([#194](https://github.com/archetech/archon/issues/194)) ([0d258de](https://github.com/archetech/archon/commit/0d258def464394a9c49b6d07f7681c35cfda5721)), closes [#153](https://github.com/archetech/archon/issues/153)
+* Add CLI command to list supported registries ([#576](https://github.com/archetech/archon/issues/576)) ([e3debcf](https://github.com/archetech/archon/commit/e3debcf9b24396f9edc498e4fa9765692e001fa6))
+* Add decodeLightningInvoice to Keymaster ([#146](https://github.com/archetech/archon/issues/146)) ([2ed4139](https://github.com/archetech/archon/commit/2ed4139f3ae548b21ca509877f3b05d3ce68f1b6)), closes [#145](https://github.com/archetech/archon/issues/145)
+* Add getVersion() to KeymasterClient ([#219](https://github.com/archetech/archon/issues/219)) ([f06d89c](https://github.com/archetech/archon/commit/f06d89c8047d60c00611eef4b2a577b54ca6d6a6)), closes [#205](https://github.com/archetech/archon/issues/205)
+* Add guided Keymaster installer ([#259](https://github.com/archetech/archon/issues/259)) ([8f139d4](https://github.com/archetech/archon/commit/8f139d4280adbe6f9575ad56f516d9814f04aea0))
+* Add keymaster address CLI commands ([#378](https://github.com/archetech/archon/issues/378)) ([35dc407](https://github.com/archetech/archon/commit/35dc407f6d6c45fd0b9293f31218667d7d212f33))
+* Add Lightning tab to web clients ([#148](https://github.com/archetech/archon/issues/148)) ([73ed52e](https://github.com/archetech/archon/commit/73ed52ea0da92b391fa53a92ba2c671f91912bbd)), closes [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147) [#147](https://github.com/archetech/archon/issues/147)
+* Add Lightning wallet support via LNbits integration ([#136](https://github.com/archetech/archon/issues/136)) ([#140](https://github.com/archetech/archon/issues/140)) ([4d99d5a](https://github.com/archetech/archon/commit/4d99d5ab8da20897e5aecf8557b271c3b1779d45))
+* Add nostr support ([#133](https://github.com/archetech/archon/issues/133)) ([3591d62](https://github.com/archetech/archon/commit/3591d6281bf29c5e98e761e7ad56a7abf78a4106)), closes [#87](https://github.com/archetech/archon/issues/87)
+* Add remote dmail name resolution ([#251](https://github.com/archetech/archon/issues/251)) ([157b0b0](https://github.com/archetech/archon/commit/157b0b036cf933d4385fa13007967fcc9e170f78))
+* Added update-credential to agent CLI ([#66](https://github.com/archetech/archon/issues/66)) ([002fce1](https://github.com/archetech/archon/commit/002fce1dcf2edb8c621eb77501cdf0abeed90484))
+* Adds dmail commands to agent CLI ([#67](https://github.com/archetech/archon/issues/67)) ([c5648b3](https://github.com/archetech/archon/commit/c5648b32b9c468e7dd2ead8225cbfc8ba28f929b))
+* Adds get-property command to CLI ([#73](https://github.com/archetech/archon/issues/73)) ([310d7fe](https://github.com/archetech/archon/commit/310d7fe5d95976b8ca37ec12b7d6dc16cc52f65a))
+* Adds view-credential command ([#96](https://github.com/archetech/archon/issues/96)) ([560a472](https://github.com/archetech/archon/commit/560a4727679a2b0e7154e26aef6ff3370b616d6c))
+* Adopt W3C JWE standard for encryption ([#90](https://github.com/archetech/archon/issues/90)) ([2321ca7](https://github.com/archetech/archon/commit/2321ca7fd6e074bac1f4b8fa7c12e58d4b45b181))
+* Allow any URI as credentialSubject.id per W3C VC Data Model v2 ([#92](https://github.com/archetech/archon/issues/92)) ([80d9f29](https://github.com/archetech/archon/commit/80d9f29a9653a93c19356c499512682794d270ce))
+* DIDComm Messaging v2 (Phases 0–7): TS + Python parity, transport, protocols, auto-discovery ([#633](https://github.com/archetech/archon/issues/633)) ([f53feef](https://github.com/archetech/archon/commit/f53feefc2a1e1fff1cc1ae86345dc1389de316c1)), closes [#key-1](https://github.com/archetech/archon/issues/key-1) [did#key-agreement-1](https://github.com/did/issues/key-agreement-1)
+* DIDComm Phase 8 — route all sends through the service (Tor egress) ([#643](https://github.com/archetech/archon/issues/643)) ([7110f42](https://github.com/archetech/archon/commit/7110f4210d5c8bae85a02d99ec2d72497072b42e)), closes [#644](https://github.com/archetech/archon/issues/644)
+* Display Lightning payment history ([#164](https://github.com/archetech/archon/issues/164)) ([#165](https://github.com/archetech/archon/issues/165)) ([c8ec283](https://github.com/archetech/archon/commit/c8ec2835b0cde542c71e02fdb7fc55c3d46a81d1))
+* expand MCP server toward Keymaster CLI parity ([#606](https://github.com/archetech/archon/issues/606)) ([8021d44](https://github.com/archetech/archon/commit/8021d4486d28003408234c2f33993389965d1dd1))
+* Lightning zap — send sats to a DID ([#155](https://github.com/archetech/archon/issues/155)) ([39d7ee3](https://github.com/archetech/archon/commit/39d7ee3242973ace494e45f636ca12fe78d911ab)), closes [#154](https://github.com/archetech/archon/issues/154)
+* node capability manifest + client gating for optional services (Option C) ([#648](https://github.com/archetech/archon/issues/648)) ([1cec3d1](https://github.com/archetech/archon/commit/1cec3d1fc57e3327ff94a66c2afb435366cba3d4))
+* Publish addresses with optional Herald email service ([#491](https://github.com/archetech/archon/issues/491)) ([11938bd](https://github.com/archetech/archon/commit/11938bdfc12f3edad201f21b5fb16c26328de02d))
+* Refactor polls to use vault-based architecture ([#88](https://github.com/archetech/archon/issues/88)) ([#100](https://github.com/archetech/archon/issues/100)) ([8fa9eef](https://github.com/archetech/archon/commit/8fa9eef5230daf853c6f29194b72bbbec5de041a)), closes [#1](https://github.com/archetech/archon/issues/1) [#7](https://github.com/archetech/archon/issues/7) [#8](https://github.com/archetech/archon/issues/8) [#6](https://github.com/archetech/archon/issues/6) [#5](https://github.com/archetech/archon/issues/5) [#9](https://github.com/archetech/archon/issues/9)
+* Rename user-facing URL labels to Node URL ([#260](https://github.com/archetech/archon/issues/260)) ([5b5082c](https://github.com/archetech/archon/commit/5b5082cf5360edf29973e80b9e37a6190cace57a))
+* Store imported nostr nsec in wallet ([#397](https://github.com/archetech/archon/issues/397)) ([7a0a919](https://github.com/archetech/archon/commit/7a0a919f34ba9161dce25eaa528dccf3443840a4))
+* stream large file uploads/downloads for multi-GB video support ([#238](https://github.com/archetech/archon/issues/238)) ([eca94a0](https://github.com/archetech/archon/commit/eca94a06c041849a181a5a072728b9fe0c22bfae)), closes [#208](https://github.com/archetech/archon/issues/208)
+* Support LUD-16 Lightning Addresses in zapLightning ([#168](https://github.com/archetech/archon/issues/168)) ([f81457e](https://github.com/archetech/archon/commit/f81457e058c1ed99b54dafa463c48353a95d99b0)), closes [#160](https://github.com/archetech/archon/issues/160) [#160](https://github.com/archetech/archon/issues/160)
+* Update identity views across client apps ([#379](https://github.com/archetech/archon/issues/379)) ([4944281](https://github.com/archetech/archon/commit/49442810dd08a0b6e36221fbc93ccb0d89ca9f13))
+* V2 groups — promote name, add version field ([#109](https://github.com/archetech/archon/issues/109)) ([#132](https://github.com/archetech/archon/issues/132)) ([f04855d](https://github.com/archetech/archon/commit/f04855dac48a9a040c10143305029fb2d9c4c9ee))
+
+
+
+# 0.2.0 (2026-02-04)
+
+
+### Bug Fixes
+
+* Fix for duplicate credential types ([#37](https://github.com/archetech/archon/issues/37)) ([9613c46](https://github.com/archetech/archon/commit/9613c469a69b8c610df12bd64bea264a7cb6f8a9))
+* getVaultItem failed for small vault items ([#45](https://github.com/archetech/archon/issues/45)) ([a6fdd52](https://github.com/archetech/archon/commit/a6fdd5233ae2013879b28252d322e392211a59c2))
+
+
+### Features
+
+* Added import schema pack ([#29](https://github.com/archetech/archon/issues/29)) ([4af8acf](https://github.com/archetech/archon/commit/4af8acf4e9c15b36319f65f6a5b59a0c2c4bf2df))
+* Adds CLI to keymaster package ([#39](https://github.com/archetech/archon/issues/39)) ([894ce73](https://github.com/archetech/archon/commit/894ce732f5beaca37bb90ace6b760b8e80aba3e9))
+* Improve DTG credential support ([#48](https://github.com/archetech/archon/issues/48)) ([fb7e245](https://github.com/archetech/archon/commit/fb7e24538d93f36a310a36040e1608052969aba6))
+
+
+
+
+
 # [0.6.0](https://github.com/archetech/archon/compare/@didcid/keymaster@0.5.0...@didcid/keymaster@0.6.0) (2026-06-26)
 
 **Note:** Version bump only for package @didcid/keymaster

--- a/packages/keymaster/package.json
+++ b/packages/keymaster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/keymaster",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Archon Keymaster",
   "type": "module",
   "module": "./dist/esm/index.js",
@@ -141,9 +141,9 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/cipher": "^0.4.0",
-    "@didcid/clients": "^0.1.0",
-    "@didcid/common": "^0.3.0",
+    "@didcid/cipher": "^0.4.1",
+    "@didcid/clients": "^0.1.1",
+    "@didcid/common": "^0.3.1",
     "commander": "^11.1.0",
     "dotenv": "^16.4.5",
     "file-type": "^21.3.2",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -3,6 +3,50 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.3.1 (2026-07-20)
+
+
+### Bug Fixes
+
+* extract lightweight service clients ([#707](https://github.com/archetech/archon/issues/707)) ([94b1698](https://github.com/archetech/archon/commit/94b1698b6cbd633db6f5bf911aaac16c95ee4ee2))
+* report unfetchable asset bytes as an error, not as null ([#738](https://github.com/archetech/archon/issues/738)) ([#739](https://github.com/archetech/archon/issues/739)) ([0fd3cfc](https://github.com/archetech/archon/commit/0fd3cfcb961c0057800c547407a63bd11ba534cd)), closes [#734](https://github.com/archetech/archon/issues/734) [#737](https://github.com/archetech/archon/issues/737)
+* return asset image/file tools as MCP content blocks ([#721](https://github.com/archetech/archon/issues/721)) ([#724](https://github.com/archetech/archon/issues/724)) ([3d6189a](https://github.com/archetech/archon/commit/3d6189a9b2448b6b49ee126490a8f1999a74bdeb))
+* return MCP-spec tool results (isError, structuredContent) ([#719](https://github.com/archetech/archon/issues/719)) ([8242c99](https://github.com/archetech/archon/commit/8242c99c34386b7e1cb825a17b62b396d592e7ca)), closes [#691](https://github.com/archetech/archon/issues/691)
+
+
+### Features
+
+* add Archon MCP server ([#605](https://github.com/archetech/archon/issues/605)) ([7cb9b34](https://github.com/archetech/archon/commit/7cb9b340c4ea5fa9bc353f680f06ef05a38c49d5))
+* author real input schemas for structured-object tools ([#727](https://github.com/archetech/archon/issues/727)) ([#732](https://github.com/archetech/archon/issues/732)) ([2ac744b](https://github.com/archetech/archon/commit/2ac744b91ad174219e5102087785d7043557f97d)), closes [#728](https://github.com/archetech/archon/issues/728)
+* DIDComm Messaging v2 (Phases 0–7): TS + Python parity, transport, protocols, auto-discovery ([#633](https://github.com/archetech/archon/issues/633)) ([f53feef](https://github.com/archetech/archon/commit/f53feefc2a1e1fff1cc1ae86345dc1389de316c1)), closes [#key-1](https://github.com/archetech/archon/issues/key-1) [did#key-agreement-1](https://github.com/did/issues/key-agreement-1)
+* expand MCP server toward Keymaster CLI parity ([#606](https://github.com/archetech/archon/issues/606)) ([8021d44](https://github.com/archetech/archon/commit/8021d4486d28003408234c2f33993389965d1dd1))
+* implement the MCP resources capability ([#725](https://github.com/archetech/archon/issues/725)) ([#734](https://github.com/archetech/archon/issues/734)) ([1ba5d0d](https://github.com/archetech/archon/commit/1ba5d0dd8345f75b8f9ca231f217c63d744bba4d)), closes [#721](https://github.com/archetech/archon/issues/721)
+* link large file assets instead of inlining base64 ([#735](https://github.com/archetech/archon/issues/735)) ([#737](https://github.com/archetech/archon/issues/737)) ([affdc35](https://github.com/archetech/archon/commit/affdc3554b9c172e61d1b64e5e4cb37510a760c9)), closes [#725](https://github.com/archetech/archon/issues/725) [#734](https://github.com/archetech/archon/issues/734)
+* return vault items and dmail attachments as resource blocks ([#726](https://github.com/archetech/archon/issues/726)) ([#736](https://github.com/archetech/archon/issues/736)) ([44fad35](https://github.com/archetech/archon/commit/44fad354bc3d0176b8054b601597c38fbc7bad93)), closes [#725](https://github.com/archetech/archon/issues/725)
+* type MCP tool handlers and declare selective output schemas ([#720](https://github.com/archetech/archon/issues/720)) ([#728](https://github.com/archetech/archon/issues/728)) ([c52586f](https://github.com/archetech/archon/commit/c52586f25a24d01b2faf9e49752bf01799b1fded)), closes [#727](https://github.com/archetech/archon/issues/727) [#724](https://github.com/archetech/archon/issues/724)
+
+
+### BREAKING CHANGES
+
+* MCP tool results no longer use the `{ ok, result }` /
+`{ ok, error }` envelope. Failures set `isError: true` with the message as text;
+successes return the payload as JSON text plus `structuredContent` for objects.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+
+* fix: gate structuredContent on the serialized payload
+
+A JS object can serialize to a JSON scalar -- a Date, or anything with a
+toJSON() returning a non-object -- so testing the raw result let a string
+through as structuredContent, which MCP requires to be a JSON object. Gate on
+the parsed payload instead, so the object guarantee holds by construction.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+
+
+
+
+
 # [0.3.0](https://github.com/archetech/archon/compare/@didcid/mcp-server@0.2.0...@didcid/mcp-server@0.3.0) (2026-06-26)
 
 **Note:** Version bump only for package @didcid/mcp-server

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/mcp-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Archon MCP server",
   "type": "module",
   "main": "./dist/index.js",
@@ -35,9 +35,9 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@didcid/cipher": "^0.4.0",
-    "@didcid/clients": "^0.1.0",
-    "@didcid/keymaster": "^0.6.0",
+    "@didcid/cipher": "^0.4.1",
+    "@didcid/clients": "^0.1.1",
+    "@didcid/keymaster": "^0.6.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^16.4.5",
     "zod": "^3.25.76"


### PR DESCRIPTION
Back-merges the lerna version bumps + CHANGELOGs from the `release/2026-07-20` point release into `main`.

## Published (to npm `latest`)

| Package | Version |
|---|---|
| @didcid/keymaster | 0.6.1 |
| @didcid/gatekeeper | 0.6.1 |
| @didcid/cipher | 0.4.1 |
| @didcid/common | 0.3.1 |
| @didcid/ipfs | 0.3.1 |
| @didcid/mcp-server | 0.3.1 |
| @didcid/browser-hdkey | 0.3.1 |
| @didcid/clients | 0.1.1 |

Published via the "Publish to NPM" workflow (run 29784120282, `package=all`, `version=patch`) on the release branch, so the version-bump commit never touched `main` directly. Tags `@didcid/*@0.x.1` are pushed. Install verified: `@didcid/keymaster@0.6.1` resolves `@didcid/cipher@0.4.1` + `@didcid/common@0.3.1`.

This PR only brings the generated `package.json` / `CHANGELOG.md` / `package-lock.json` changes back to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)