### PR TITLE
docs(mcp): add DIDComm tools to the CLI mapping table

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -441,3 +441,10 @@ Pay a Lightning invoice:
 | `remove-dmail-attachment` | `archon_remove_dmail_attachment` |
 | `get-dmail-attachment` | `archon_get_dmail_attachment` |
 | `list-dmail-attachments` | `archon_list_dmail_attachments` |
+| `pack-didcomm` | `archon_pack_didcomm` |
+| `unpack-didcomm` | `archon_unpack_didcomm` |
+| `send-didcomm` | `archon_send_didcomm` |
+| `receive-didcomm` | `archon_receive_didcomm` |
+| `mediate-didcomm` | `archon_mediate_didcomm` |
+| `publish-didcomm` | `archon_publish_didcomm` |
+| `unpublish-didcomm` | `archon_unpublish_didcomm` |


### PR DESCRIPTION
The MCP server README's Keymaster CLI mapping claims to map *"every Keymaster CLI command to one MCP tool"*, but the 7 DIDComm tools were missing — the whole DIDComm v2 surface (merged in #633) was undocumented.

Adds them to the mapping table:

| CLI command | MCP tool |
| --- | --- |
| `pack-didcomm` | `archon_pack_didcomm` |
| `unpack-didcomm` | `archon_unpack_didcomm` |
| `send-didcomm` | `archon_send_didcomm` |
| `receive-didcomm` | `archon_receive_didcomm` |
| `mediate-didcomm` | `archon_mediate_didcomm` |
| `publish-didcomm` | `archon_publish_didcomm` |
| `unpublish-didcomm` | `archon_unpublish_didcomm` |

Verified the table now covers all 145 registered tools (`tools.ts`), with no stale entries. Rest of the README (env vars, tool-result/resources/structured-input semantics, inline-limit default) checks out against the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)