### PR TITLE
test: derive expected image byte counts from the source buffer

### DIFF
--- a/tests/keymaster/image.test.ts
+++ b/tests/keymaster/image.test.ts
@@ -56,7 +56,7 @@ describe('createImage', () => {
             file: {
                 cid,
                 filename: 'image',
-                bytes: 392,
+                bytes: mockImage.length,
                 type: 'image/png',
             },
             image: {
@@ -110,7 +110,7 @@ describe('updateImage', () => {
             file: {
                 cid,
                 filename: 'image',
-                bytes: 522,
+                bytes: mockImage2.length,
                 type: 'image/jpg',
             },
             image: {
@@ -146,7 +146,7 @@ describe('updateImage', () => {
             file: {
                 cid,
                 filename: 'image',
-                bytes: 779,
+                bytes: mockImage.length,
                 type: 'image/png',
             },
             image: {
@@ -198,7 +198,7 @@ describe('getImage', () => {
 
         expect(image).not.toBeNull();
         expect(image!.file.type).toStrictEqual('image/png');
-        expect(image!.file.bytes).toStrictEqual(392);
+        expect(image!.file.bytes).toStrictEqual(mockImage.length);
         expect(image!.file.data).toStrictEqual(mockImage);
         expect(image!.image.width).toStrictEqual(100);
         expect(image!.image.height).toStrictEqual(100);


### PR DESCRIPTION
Unblocks #773 (bump sharp 0.33.5 → 0.35.0), which currently fails three tests in `tests/keymaster/image.test.ts`.

## Cause

The tests generate an image with sharp and then assert a **hardcoded** encoded size:

```js
const mockImage = await sharp({ create: { width: 100, height: 100, ... } }).png().toBuffer();
...
const expected = { file: { cid, filename: 'image', bytes: 392, type: 'image/png' } };
```

sharp 0.35.x bundles a newer libvips that encodes the same 100×100 PNG as 414 bytes instead of 392, so the assertion breaks — nothing about the behaviour under test changed.

Note the expected `cid` was already derived from the same buffer at test time, which is why only `bytes` drifted.

## Fix

`bytes` now derives from the same buffer as `cid` (`mockImage.length`). The assertion stays exact — it still catches a real regression where the stored size doesn't match the input — but no longer encodes a specific encoder version's output.

## Verification

Ran `tests/keymaster/image.test.ts` against both sharp versions:

| sharp | before | after |
|---|---|---|
| 0.33.5 (current) | 13 pass | 13 pass |
| 0.35.3 | 3 fail, 10 pass | 13 pass |

The three failures under 0.35.3 match those reported on #773 exactly.

Worth noting #773 targets 0.35.0 while 0.35.3 is current; taking the newer one may be preferable once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)