### PR TITLE
keymaster: ephemeral assets follow a `local` default registry

### DIFF
--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -206,7 +206,12 @@ export default class Keymaster implements KeymasterInterface {
         this.didcommServiceURL = options.didcommServiceURL;
 
         this.defaultRegistry = options.defaultRegistry || 'hyperswarm';
-        this.ephemeralRegistry = 'hyperswarm';
+        // Ephemeral assets (challenges, responses, credential-request notices) follow a `local`
+        // default registry so a fully-local deployment can author them. Otherwise the controller
+        // consistency check bars a `local`-registered identity from a `hyperswarm` ephemeral op,
+        // making challenges/credentials impossible on a local-only node. Non-local defaults are
+        // unchanged (`hyperswarm`).
+        this.ephemeralRegistry = this.defaultRegistry === 'local' ? 'local' : 'hyperswarm';
         this.maxAliasLength = options.maxAliasLength || 32;
         this.maxDataLength = 8 * 1024; // 8 KB max data to store in a JSON object
     }

--- a/tests/keymaster/challenge.test.ts
+++ b/tests/keymaster/challenge.test.ts
@@ -49,6 +49,22 @@ describe('createChallenge', () => {
         expect(ttl < 60 * 60 * 1000).toBe(true);
     });
 
+    it('should let a local-default identity create a challenge (ephemeral follows a local default)', async () => {
+        // A fully-local deployment must be able to author ephemeral docs. Previously
+        // ephemeralRegistry was hardcoded 'hyperswarm', so the controller consistency
+        // check rejected a `local` identity authoring a `hyperswarm` ephemeral op.
+        const localKeymaster = new Keymaster({
+            gatekeeper, wallet: new WalletJsonMemory(), cipher,
+            passphrase: 'passphrase', defaultRegistry: 'local',
+        });
+        const alice = await localKeymaster.createId('Alice');
+        const did = await localKeymaster.createChallenge();
+        const doc = await localKeymaster.resolveDID(did);
+
+        expect(doc.didDocument!.controller).toBe(alice);
+        expect(doc.didDocumentData).toStrictEqual({ challenge: {} });
+    });
+
     it('should create an empty challenge with specified expiry', async () => {
         const alice = await keymaster.createId('Alice');
         const validUntil = '2025-01-01';


### PR DESCRIPTION
## Summary
`ephemeralRegistry` is hardcoded to `hyperswarm`, so a `Keymaster` whose `defaultRegistry` is `local` still creates ephemeral assets (challenges, responses, credential-request notices) on `hyperswarm`. The gatekeeper's controller-consistency check then rejects a `local`-registered identity authoring a non-`local` operation:

```
Invalid operation: non-local registry=hyperswarm
```

As a result, **challenges and credentials are impossible on a fully-local (offline / single-node) deployment** — a `local` identity can never author the ephemeral doc they depend on.

## Change
One line — make `ephemeralRegistry` follow the default registry when it is `local`:

```ts
this.ephemeralRegistry = this.defaultRegistry === 'local' ? 'local' : 'hyperswarm';
```

Non-local defaults (`hyperswarm`, chains) are unchanged.

## Why this is sufficient
When the ephemeral asset is `local`, the controller (also `local`) and the asset registries match, so the existing controller-consistency check passes on its own — no change to that check is needed.

## Test
Adds a case to `tests/keymaster/challenge.test.ts`: a `local`-default identity can create a challenge. Verified it **fails without** the change (`non-local registry=hyperswarm`) and **passes with** it; the existing challenge tests are unaffected.
