### PR TITLE
gatekeeper: exportBatch includes DIDs promoted off `local`

### DIFF
--- a/docs/services/gatekeeper/README.md
+++ b/docs/services/gatekeeper/README.md
@@ -92,7 +92,7 @@ unhandled paths.
 | `POST` | `/api/v1/dids/remove` | yes | Body: array of DIDs. Returns boolean. |
 | `POST` | `/api/v1/dids/export` | no | Body: `{ "dids": string[] | undefined }`. Returns `GatekeeperEvent[][]` (one inner array per DID). |
 | `POST` | `/api/v1/dids/import` | yes | Body: `GatekeeperEvent[][]`. Flattens into a batch and queues for processing. Returns `ImportBatchResult`. |
-| `POST` | `/api/v1/batch/export` | yes | Body: `{ "dids": string[] | undefined }`. Returns a single sorted `GatekeeperEvent[]` of all non-`local` events for the chosen DIDs. |
+| `POST` | `/api/v1/batch/export` | yes | Body: `{ "dids": string[] | undefined }`. Returns a single `GatekeeperEvent[]`, sorted by `proof.created`, holding the full history of every chosen DID that is gossip-eligible. Eligibility is per DID, not per event, and an eligible DID exports its `local` operations too — see [§8.7](#87-batch-export-eligibility). |
 | `POST` | `/api/v1/batch/import` | yes | Body: `GatekeeperEvent[]`. Returns `ImportBatchResult`. Empty arrays MUST be rejected with HTTP 500 `Error: Invalid parameter: batch`. |
 | `POST` | `/api/v1/batch/import/cids` | yes | Body: `{ "cids": string[], "metadata": BatchMetadata }`. Hydrates each CID via the operation store or IPFS, then imports. Empty `cids` MUST 500 with `Error: Invalid parameter: cids`; missing `metadata.registry`/`time`/`ordinal` MUST 500 with `Error: Invalid parameter: metadata`. |
 | `GET` | `/api/v1/queue/:registry` | yes | Returns queued outbound `Operation[]` for the registry. |
@@ -812,6 +812,44 @@ operation.type ∈ { create, update, delete }
 `compare_ordinals(a, b)` is element-wise lexicographic over `Vec<u64>`:
 shorter is "less than" prefix-equal longer (matches the TS behavior).
 `None` ordinals compare as equal to anything.
+
+### 8.7 Batch export eligibility
+
+`POST /api/v1/batch/export` is the outbound counterpart of import: it
+selects which DIDs are eligible to be gossiped to peers (the Hyperswarm
+mediator's `shareDb` is the primary caller). `POST /api/v1/dids/export`
+performs no such filtering and returns every requested DID.
+
+Eligibility is decided **per DID, not per event**:
+
+> A DID is exportable if **any** of its operations carries a non-`local`
+> registry.
+
+Read the registry from whichever field the operation shape provides:
+
+| Operation | Registry field |
+| --- | --- |
+| `create` | `operation.registration.registry` |
+| `update` | `operation.doc.didDocumentRegistration.registry` |
+
+A missing or empty registry MUST NOT qualify a DID for export.
+
+Checking only the create operation is **insufficient**. A DID created
+`local` and later promoted (via `change-registry`, an `update` that
+rewrites `didDocumentRegistration.registry`) still has a `local` create
+op, so a create-only test excludes the DID entirely and the promotion
+never reaches peers — the origin reports it as confirmed on the new
+registry while every other node returns `notFound`.
+
+An eligible DID MUST export its **full** operation history, including any
+`local` operations. Peers need the create op to replay the DID from its
+first version; exporting only the non-`local` operations leaves them
+unable to reconstruct it. This does not re-publish the `local` operation,
+because outbound queueing ([§10.4](#104-outbound-queue)) early-returns on
+`local` — only the promoting update drives further distribution.
+
+The response is a single flat `GatekeeperEvent[]`, sorted ascending by
+`operation.proof.created`.
 
 ---
 

--- a/packages/gatekeeper/src/gatekeeper.ts
+++ b/packages/gatekeeper/src/gatekeeper.ts
@@ -1380,14 +1380,20 @@ export default class Gatekeeper implements GatekeeperInterface {
 
     async exportBatch(dids?: string[]): Promise<GatekeeperEvent[]> {
         const allDIDs = await this.exportDIDs(dids);
-        const nonlocalDIDs = allDIDs.filter(events => {
-            if (events.length > 0) {
-                const create = events[0];
-                const registry = create.operation?.registration?.registry;
-                return registry && registry !== 'local'
-            }
-            return false;
-        });
+        // Export a DID if ANY of its operations is non-local, not only the create op. A DID created
+        // `local` and later promoted (e.g. via change-registry) has a `local` create op but a
+        // non-local update; keying only on the create op left it un-exportable, so the promotion
+        // never reached peers. `.flat()` below still carries the create op along, so a peer receives
+        // the full history and reconstructs the DID.
+        const nonlocalDIDs = allDIDs.filter(events =>
+            events.some(event => {
+                // create ops carry the registry at `operation.registration.registry`; update ops
+                // (including a change-registry promotion) carry it at `doc.didDocumentRegistration.registry`.
+                const registry = event.operation?.registration?.registry
+                    ?? event.operation?.doc?.didDocumentRegistration?.registry;
+                return registry && registry !== 'local';
+            })
+        );
 
         const events = nonlocalDIDs.flat();
         return events.sort((a, b) => new Date(a.operation.proof?.created ?? 0).getTime() - new Date(b.operation.proof?.created ?? 0).getTime());

--- a/rust/services/gatekeeper/src/api.rs
+++ b/rust/services/gatekeeper/src/api.rs
@@ -516,16 +516,32 @@ pub(crate) async fn export_batch(
     let mut events = Vec::new();
     for did in dids {
         let did_events = store.get_events(&did);
-        if let Some(create) = did_events.first() {
-            let registry = create
+        // Export a DID if ANY of its operations is non-local, not only the create op. A DID
+        // created `local` and later promoted (e.g. via change-registry) has a `local` create op
+        // but a non-local update; keying only on the create op left it un-exportable, so the
+        // promotion never reached peers. The whole history is extended below, so a peer receives
+        // the `local` create op too and can reconstruct the DID.
+        let exportable = did_events.iter().any(|event| {
+            // create ops carry the registry at `registration.registry`; update ops (including a
+            // change-registry promotion) carry it at `doc.didDocumentRegistration.registry`.
+            let registry = event
                 .operation
                 .get("registration")
                 .and_then(|value| value.get("registry"))
                 .and_then(Value::as_str)
-                .unwrap_or("");
-            if registry != "local" {
-                events.extend(did_events);
-            }
+                .or_else(|| {
+                    event
+                        .operation
+                        .get("doc")
+                        .and_then(|value| value.get("didDocumentRegistration"))
+                        .and_then(|value| value.get("registry"))
+                        .and_then(Value::as_str)
+                });
+            matches!(registry, Some(registry) if !registry.is_empty() && registry != "local")
+        });
+
+        if exportable {
+            events.extend(did_events);
         }
     }
 

--- a/rust/services/gatekeeper/tests/sync_behaviors.rs
+++ b/rust/services/gatekeeper/tests/sync_behaviors.rs
@@ -683,3 +683,52 @@ async fn sync_processing_handles_large_linear_update_chain_without_pending() -> 
 
     Ok(())
 }
+
+#[tokio::test]
+async fn sync_export_batch_includes_dids_promoted_off_local() -> Result<()> {
+    let service = spawn_json().await?;
+
+    let agent_did = create_did(
+        &service,
+        create_agent_operation(7, "2026-04-11T12:00:00Z", "local"),
+    )
+    .await?;
+
+    // a local DID is not gossip-eligible
+    let batch = admin_post(&service, "batch/export", json!({ "dids": [&agent_did] })).await?;
+    assert_eq!(batch.as_array().unwrap().len(), 0);
+
+    // promote local -> hyperswarm via an update op
+    let mut doc = resolve_did(&service, &agent_did).await?;
+    let previd = doc["didDocumentMetadata"]["versionId"]
+        .as_str()
+        .map(ToString::to_string);
+    doc["didDocumentRegistration"]["registry"] = json!("hyperswarm");
+    let response = service
+        .client
+        .post(format!("{}/did", service.base_url))
+        .json(&create_update_operation(
+            7,
+            &agent_did,
+            previd.as_deref(),
+            "2026-04-11T12:01:00Z",
+            doc,
+        ))
+        .send()
+        .await?;
+    assert!(response.status().is_success(), "promotion should succeed");
+
+    // now gossip-eligible, and the local create op comes along so a peer can reconstruct the DID
+    let batch = admin_post(&service, "batch/export", json!({ "dids": [&agent_did] })).await?;
+    let events = batch.as_array().unwrap();
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["operation"]["type"], "create");
+    assert_eq!(events[0]["operation"]["registration"]["registry"], "local");
+    assert_eq!(events[1]["operation"]["type"], "update");
+    assert_eq!(
+        events[1]["operation"]["doc"]["didDocumentRegistration"]["registry"],
+        "hyperswarm"
+    );
+
+    Ok(())
+}

--- a/tests/gatekeeper/sync.test.ts
+++ b/tests/gatekeeper/sync.test.ts
@@ -227,6 +227,27 @@ describe('exportBatch', () => {
         expect(exports[1].operation).toStrictEqual(updateOp);
     });
 
+    it('should export a DID promoted from local, carrying its create op', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await helper.createAgentOp(keypair, { version: 1, registry: 'local' });
+        const did = await gatekeeper.createDID(agentOp);
+
+        // a local DID is not exportable
+        expect((await gatekeeper.exportBatch([did])).length).toBe(0);
+
+        // promote local -> hyperswarm via an update op
+        const doc = await gatekeeper.resolveDID(did);
+        doc.didDocumentRegistration!.registry = 'hyperswarm';
+        const updateOp = await helper.createUpdateOp(keypair, did, doc);
+        await gatekeeper.updateDID(updateOp);
+
+        // now exportable, and the local create op comes along so the peer can reconstruct the DID
+        const exports = await gatekeeper.exportBatch([did]);
+        expect(exports.length).toBe(2);
+        expect(exports[0].operation).toStrictEqual(agentOp);
+        expect(exports[1].operation).toStrictEqual(updateOp);
+    });
+
     // eslint-disable-next-line
     it('should return empty array on an invalid DID', async () => {
         const exports = await gatekeeper.exportBatch(['mockDID']);

--- a/tests/gatekeeper/sync.test.ts
+++ b/tests/gatekeeper/sync.test.ts
@@ -248,6 +248,32 @@ describe('exportBatch', () => {
         expect(exports[1].operation).toStrictEqual(updateOp);
     });
 
+    it('should let a peer reconstruct a DID promoted from local', async () => {
+        // The reported symptom is that peers return notFound, so assert the whole round trip:
+        // exporting the ops is necessary but does not prove a peer can import and replay them.
+        const peerDb = new DbJsonMemory('peer');
+        const peer = new Gatekeeper({ db: peerDb, ipfs, console: mockConsole, registries: ['local', 'hyperswarm', 'BTC:signet'] });
+        await peer.resetDb();
+
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await helper.createAgentOp(keypair, { version: 1, registry: 'local' });
+        const did = await gatekeeper.createDID(agentOp);
+
+        const doc = await gatekeeper.resolveDID(did);
+        doc.didDocumentRegistration!.registry = 'hyperswarm';
+        await gatekeeper.updateDID(await helper.createUpdateOp(keypair, did, doc));
+
+        const batch = await gatekeeper.exportBatch([did]);
+        expect(await peer.importBatch(batch)).toMatchObject({ queued: 2, rejected: 0 });
+        expect(await peer.processEvents()).toMatchObject({ added: 2, rejected: 0 });
+
+        // the promotion arrived, and the local create op replayed to rebuild the DID
+        const peerDoc = await peer.resolveDID(did);
+        expect(peerDoc.didDocumentRegistration!.registry).toBe('hyperswarm');
+        expect(peerDoc.didDocumentMetadata!.versionSequence).toBe('2');
+        expect(peerDoc.didDocumentMetadata!.confirmed).toBe(true);
+    });
+
     // eslint-disable-next-line
     it('should return empty array on an invalid DID', async () => {
         const exports = await gatekeeper.exportBatch(['mockDID']);


### PR DESCRIPTION
## Problem

A DID created on the `local` registry and later promoted with `change-registry`
(e.g. `local → hyperswarm`) applies the promotion **on the origin node only**. The
promoted DID never reaches peers, so it is `notFound` on every other node in the
swarm — even though the origin reports it as confirmed on `hyperswarm`.

`change-registry` succeeds and `resolveDID` on the origin reports the new registry,
so the DID *looks* promoted. It silently isn't federated.

### Root cause

`exportBatch` (which the hyperswarm mediator's `shareDb` uses to hand DIDs to peers)
decides gossip-eligibility from the **create op's** registry alone:

```ts
const create = events[0];
const registry = create.operation?.registration?.registry;
return registry && registry !== 'local';
```

For a promoted DID the create op is still `local`, so the whole DID — including the
promoting update — is excluded from every export. The promotion has nowhere to go.

## Reproduction (Archon-native, over public hyperswarm)

Plain Keymaster CLI against a stock node (`flaxlap`, gatekeeper `0.11.0` / `28ddd48`,
registries include `local` + `hyperswarm`), resolving on the public node
`archon.technology` (`0.11.0` / `4cd4a45`), which is hyperswarm-synced with the origin.

```
$ create-id repro-local -r local
DID = did:cid:bagaaiera7cdtjljwjx52bkphc5s26try7u7gweo4ti7vmh37zvwoyriqwkda

# before migrate — local, so correctly absent on the public node
flaxlap (origin)          : OK  registry=local        versionSequence=1  confirmed=true
archon.technology (public): error=notFound

$ change-registry <did> hyperswarm      →  OK

# after migrate — origin applies + confirms the promotion...
flaxlap (origin)          : OK  registry=hyperswarm   versionSequence=2  confirmed=true
# ...but the public node never receives it:
archon.technology (public): error=notFound   (t+15s, +30s, +45s, +60s)     ← the bug
```

**Control** — same node, same swarm, same registry endpoint; only the create op's
registry differs:

```
$ create-id repro-hyperswarm-control -r hyperswarm     # born on hyperswarm, not migrated
flaxlap (origin)          : OK  registry=hyperswarm
archon.technology (public): OK  registry=hyperswarm    (t+15s)              ← sync works
```

A born-`hyperswarm` DID syncs in ~15s; a `local`-then-migrated DID never does. The only
variable is the create op's registry — which is exactly what `exportBatch` keys off.

## Fix

Keep a DID for export if **any** of its ops is non-`local`, checking both op shapes —
a create op carries the registry at `operation.registration.registry`, an update op
(the promoting one) at `operation.doc.didDocumentRegistration.registry`:

```ts
const nonlocalDIDs = allDIDs.filter(events =>
    events.some(event => {
        const registry = event.operation?.registration?.registry
            ?? event.operation?.doc?.didDocumentRegistration?.registry;
        return registry && registry !== 'local';
    })
);
```

`exportBatch` already emits the DID's full history (`.flat()`), so the `local` create op
propagates alongside the promoting update and a peer can reconstruct the DID. The create
op stays `local` on import (`queueOperation` early-returns for `local`), so it is not
re-distributed — only the promotion drives further gossip.

## Test

`tests/gatekeeper/sync.test.ts` — a `local`-created, then-promoted DID exports its
create + update ops. Fails without the change (exports `0`); passes with it (exports `2`).
Existing `exportBatch` tests unaffected (73/73 pass).

---
Related: #798 (ephemeral registry follows a `local` default) — both make `local` a
first-class registry rather than a half-citizen.
