### PR TITLE
keymaster: keep a local agent's assets on the local registry

### DIFF
--- a/docs/services/keymaster/README.md
+++ b/docs/services/keymaster/README.md
@@ -546,11 +546,15 @@ An asset's registry is chosen in this order:
 2. The **ephemeral registry** (`hyperswarm`) for short-lived assets the
    Keymaster creates on the caller's behalf — challenges, challenge
    responses, credential offers, poll and ballot notices, and dmail
-   notices. Ephemeral assets are never anchored to a chain registry, and
-   are excluded from `IDInfo.owned[]` because they are garbage-collected
-   at `validUntil`.
+   notices. Keymaster never *selects* a chain registry for these, but the
+   choice is only a default: a caller who supplies `registry` overrides it
+   per (1).
 3. Otherwise the wallet's default registry (`ARCHON_DEFAULT_REGISTRY`,
    `hyperswarm` when unset).
+
+Any asset carrying `validUntil` — every ephemeral asset, plus any the
+caller marks that way — is omitted from `IDInfo.owned[]`, since it will be
+garbage-collected when it expires.
 
 Implementations MUST then apply this invariant:
 

--- a/docs/services/keymaster/README.md
+++ b/docs/services/keymaster/README.md
@@ -517,7 +517,7 @@ the DID document carries the asset payload.
 
 ```jsonc
 {
-  "registry": "local" | "hyperswarm" | "BTC:..." | undefined,  // defaults to wallet defaultRegistry
+  "registry": "local" | "hyperswarm" | "BTC:..." | undefined,  // see 7.2 Registry selection
   "controller": "<DID>" | undefined,                            // defaults to current ID
   "validUntil": "<RFC 3339>" | undefined,                       // ephemeral expiry
   "alias": string | undefined                                   // also add this alias
@@ -537,6 +537,55 @@ this wallet — transfers to external DIDs leave the local list shrunk).
 
 `wallet.check` and `wallet.fix` rebuild this bookkeeping by walking every
 DID in `owned` and verifying it still resolves with the right controller.
+
+### 7.2 Registry selection
+
+An asset's registry is chosen in this order:
+
+1. `CreateAssetOptions.registry`, when the caller supplies one.
+2. The **ephemeral registry** (`hyperswarm`) for short-lived assets the
+   Keymaster creates on the caller's behalf — challenges, challenge
+   responses, credential offers, poll and ballot notices, and dmail
+   notices. Ephemeral assets are never anchored to a chain registry, and
+   are excluded from `IDInfo.owned[]` because they are garbage-collected
+   at `validUntil`.
+3. Otherwise the wallet's default registry (`ARCHON_DEFAULT_REGISTRY`,
+   `hyperswarm` when unset).
+
+Implementations MUST then apply this invariant:
+
+> If the controlling agent is registered on the `local` registry, the
+> asset operation MUST also be `local`.
+
+The check is one-directional — a non-`local` agent may own assets on any
+registry, including `local` — and applies to asset **creation** only;
+Gatekeeper does not re-check the controller's registry on `update` or
+`delete`. It exists because Gatekeeper refuses an asset `create` whose
+controller resolves to a `local` registration when the operation itself is
+not `local` (`Invalid operation: non-local registry=<registry>`; see
+Gatekeeper spec [§7.1](../gatekeeper/README.md#71-create), step 4).
+Without it, a local-only deployment cannot author challenges or
+credentials at all, since its agents can never author the ephemeral assets
+those flows depend on.
+
+Implementations MUST enforce this **before signing**, by downgrading the
+registry to `local` — including when the caller asked for something else,
+because Gatekeeper would refuse that operation outright. Gatekeeper MUST
+NOT rewrite the registry itself: `registration.registry` is covered by the
+operation proof and by the CID the DID is derived from, so mutating it
+server-side would both invalidate the signature and change the DID.
+
+Resolve the controller with `confirm: true`, as Gatekeeper does, so a
+pending `change-registry` update cannot let a mismatch through.
+
+Because the controlling agent's registry is what matters — not the
+wallet-wide default — this MUST be evaluated per operation against the
+agent that signs it. Deriving it from the default registry alone is
+insufficient: it misses a `local` agent under a non-`local` default, and
+wrongly downgrades a non-`local` agent under a `local` default.
+
+Challenges additionally default to a `validUntil` one hour in the future
+when the caller does not supply one.
 
 ---
 

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -230,12 +230,9 @@ export default class Keymaster implements KeymasterInterface {
         this.cipher = options.cipher;
 
         this.defaultRegistry = options.defaultRegistry || 'hyperswarm';
-        // Ephemeral assets (challenges, responses, credential-request notices) follow a `local`
-        // default registry so a fully-local deployment can author them. Otherwise the controller
-        // consistency check bars a `local`-registered identity from a `hyperswarm` ephemeral op,
-        // making challenges/credentials impossible on a local-only node. Non-local defaults are
-        // unchanged (`hyperswarm`).
-        this.ephemeralRegistry = this.defaultRegistry === 'local' ? 'local' : 'hyperswarm';
+        // Ephemeral assets stay off-chain; `createAsset` downgrades them to `local` when the
+        // controlling agent is local.
+        this.ephemeralRegistry = 'hyperswarm';
         this.maxAliasLength = options.maxAliasLength || 32;
         this.maxDataLength = 8 * 1024; // 8 KB max data to store in a JSON object
     }
@@ -855,6 +852,17 @@ export default class Keymaster implements KeymasterInterface {
         }
 
         const id = await this.fetchIdInfo(controller);
+
+        // Gatekeeper rejects an asset operation whose controller is registered `local` unless the
+        // operation is `local` too, so a local agent's assets are downgraded to `local` rather
+        // than submitted and refused. Resolve confirmed, as Gatekeeper does, so a pending
+        // change-registry doesn't let a mismatch through.
+        const controllerDoc = await this.resolveDID(id.did, { confirm: true });
+
+        if (controllerDoc.didDocumentRegistration?.registry === 'local') {
+            registry = 'local';
+        }
+
         const block = await this.gatekeeper.getBlock(registry);
         const blockid = block?.hash;
 

--- a/python/keymaster/src/keymaster/core.py
+++ b/python/keymaster/src/keymaster/core.py
@@ -125,6 +125,8 @@ class Keymaster:
         self.wallet_store = wallet_store
         self.passphrase = passphrase
         self.default_registry = default_registry or "hyperswarm"
+        # Ephemeral assets stay off-chain; `create_asset` downgrades them to `local` when the
+        # controlling agent is local.
         self.ephemeral_registry = ephemeral_registry
         self.max_alias_length = max_alias_length
         self.max_data_length = 8 * 1024
@@ -1854,6 +1856,16 @@ class Keymaster:
         valid_until = options.get("validUntil")
         alias = options.get("alias")
         id_info = await self.fetch_id_info(controller)
+
+        # Gatekeeper rejects an asset operation whose controller is registered `local` unless the
+        # operation is `local` too, so a local agent's assets are downgraded to `local` rather
+        # than submitted and refused. Resolve confirmed, as Gatekeeper does, so a pending
+        # change-registry doesn't let a mismatch through.
+        controller_doc = await self.resolve_did(id_info["did"], {"confirm": True})
+
+        if (controller_doc.get("didDocumentRegistration") or {}).get("registry") == "local":
+            registry = "local"
+
         block = await self.gatekeeper.get_block(registry)
         payload = {
             "type": "create",
@@ -2745,7 +2757,13 @@ class Keymaster:
         return groups
 
     async def create_challenge(self, challenge: dict[str, Any] | None = None, options: dict[str, Any] | None = None) -> str:
-        return await self.create_asset({"challenge": challenge or {}}, options or {})
+        options = dict(options or {})
+        options.setdefault("registry", self.ephemeral_registry)
+        if "validUntil" not in options:
+            expires = __import__("datetime").datetime.utcnow() + __import__("datetime").timedelta(hours=1)
+            options["validUntil"] = expires.isoformat() + "Z"
+
+        return await self.create_asset({"challenge": challenge or {}}, options)
 
     def is_managed_did(self, value: str) -> bool:
         return isinstance(value, str) and value.startswith("did:")

--- a/python/keymaster/tests/test_schema_group_challenge.py
+++ b/python/keymaster/tests/test_schema_group_challenge.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import pytest
 
-from keymaster import KeymasterError, UnknownIDError
+from keymaster import Keymaster, KeymasterError, UnknownIDError
 
-from .helpers import MOCK_SCHEMA, run
+from .helpers import MOCK_SCHEMA, FakeGatekeeper, FakeWalletStore, run
 
 
 def test_schema_lifecycle_and_template(testbed):
@@ -137,6 +137,57 @@ def test_create_and_verify_challenge_response(testbed):
     assert verified["match"] is True
     assert verified["requested"] == 0
     assert verified["responder"] == alice
+
+
+def _keymaster(**kwargs):
+    return Keymaster(
+        gatekeeper=FakeGatekeeper(),
+        wallet_store=FakeWalletStore(),
+        passphrase="passphrase",
+        **kwargs,
+    )
+
+
+def _registry_of(km, did):
+    return run(km.resolve_did(did)).get("didDocumentRegistration", {}).get("registry")
+
+
+def test_local_agent_assets_are_local_whatever_the_default():
+    # Gatekeeper rejects an asset op from a `local` controller on any other registry, so a local
+    # agent's assets must be local — including the ephemeral ones, and regardless of the
+    # instance-wide default.
+    km = _keymaster(default_registry="hyperswarm")
+    run(km.create_id("Alice", {"registry": "local"}))
+
+    assert _registry_of(km, run(km.create_asset({"key": "value"}))) == "local"
+    assert _registry_of(km, run(km.create_challenge())) == "local"
+
+
+def test_non_local_agent_assets_are_not_downgraded_by_a_local_default():
+    # The mirror case: the default is `local` but the agent is not, so nothing is downgraded and
+    # ephemeral assets still land somewhere that propagates.
+    km = _keymaster(default_registry="local")
+    run(km.create_id("Alice", {"registry": "hyperswarm"}))
+
+    assert _registry_of(km, run(km.create_challenge())) == "hyperswarm"
+
+
+def test_local_agent_downgrades_an_explicit_non_local_registry():
+    # Gatekeeper would refuse the operation outright, so the request is unsatisfiable rather than
+    # merely unusual; downgrading keeps a local-only node working.
+    km = _keymaster(default_registry="hyperswarm")
+    run(km.create_id("Alice", {"registry": "local"}))
+    did = run(km.create_asset({"key": "value"}, {"registry": "hyperswarm"}))
+
+    assert _registry_of(km, did) == "local"
+
+
+def test_create_challenge_sets_an_expiry():
+    km = _keymaster()
+    run(km.create_id("Alice"))
+    doc = run(km.resolve_did(run(km.create_challenge())))
+
+    assert doc["didDocumentRegistration"]["validUntil"] is not None
 
 
 def test_verify_response_rejects_non_response_asset(testbed):

--- a/tests/keymaster/challenge.test.ts
+++ b/tests/keymaster/challenge.test.ts
@@ -49,20 +49,41 @@ describe('createChallenge', () => {
         expect(ttl < 60 * 60 * 1000).toBe(true);
     });
 
-    it('should let a local-default identity create a challenge (ephemeral follows a local default)', async () => {
-        // A fully-local deployment must be able to author ephemeral docs. Previously
-        // ephemeralRegistry was hardcoded 'hyperswarm', so the controller consistency
-        // check rejected a `local` identity authoring a `hyperswarm` ephemeral op.
+    it('should keep a local agent\'s assets local whatever the default registry', async () => {
+        // Gatekeeper rejects an asset op from a `local` controller on any other registry, so a
+        // local agent's assets must be local — including ephemeral ones, and regardless of the
+        // instance-wide default.
+        const alice = await keymaster.createId('Alice', { registry: 'local' });
+        const did = await keymaster.createChallenge();
+        const doc = await keymaster.resolveDID(did);
+
+        expect(doc.didDocument!.controller).toBe(alice);
+        expect(doc.didDocumentRegistration!.registry).toBe('local');
+        expect(doc.didDocumentData).toStrictEqual({ challenge: {} });
+    });
+
+    it('should not downgrade a non-local agent when the default registry is local', async () => {
+        // The mirror case: the default is `local` but the agent is not, so the challenge still
+        // lands somewhere that propagates to a remote verifier.
         const localKeymaster = new Keymaster({
             gatekeeper, wallet: new WalletJsonMemory(), cipher,
             passphrase: 'passphrase', defaultRegistry: 'local',
         });
-        const alice = await localKeymaster.createId('Alice');
+        await localKeymaster.createId('Alice', { registry: 'hyperswarm' });
         const did = await localKeymaster.createChallenge();
         const doc = await localKeymaster.resolveDID(did);
 
-        expect(doc.didDocument!.controller).toBe(alice);
-        expect(doc.didDocumentData).toStrictEqual({ challenge: {} });
+        expect(doc.didDocumentRegistration!.registry).toBe('hyperswarm');
+    });
+
+    it('should downgrade an explicit non-local registry for a local agent', async () => {
+        // Gatekeeper would refuse the operation outright, so the request is unsatisfiable rather
+        // than merely unusual; downgrading keeps a local-only node working.
+        await keymaster.createId('Alice', { registry: 'local' });
+        const did = await keymaster.createAsset({ key: 'value' }, { registry: 'hyperswarm' });
+        const doc = await keymaster.resolveDID(did);
+
+        expect(doc.didDocumentRegistration!.registry).toBe('local');
     });
 
     it('should create an empty challenge with specified expiry', async () => {


### PR DESCRIPTION
Supersedes the approach in #798 and brings Python to parity.

## The problem with keying off `defaultRegistry`

#798 made `ephemeralRegistry` follow a `local` `defaultRegistry`. But Gatekeeper's rule is about the **controlling agent's** registry, not the wallet-wide default, and the two diverge in both directions. Verified on `main`:

| Setup | Before this PR |
| --- | --- |
| `local` default, `local` agent | works (what #798 fixed) |
| **non-`local` default, `local` agent** | still fails: `Invalid operation: non-local registry=hyperswarm` |
| **`local` default, `hyperswarm` agent** | challenge silently created on `local` — validates, but never reaches a remote verifier |

The second row is the original bug, unfixed. The third is a regression #798 introduced, and it's silent, which is worse than the loud failure it replaced.

## The fix

Enforce the invariant once, at the chokepoint every asset already passes through:

> If the controlling agent is registered `local`, the asset operation must be `local`.

`createAsset` resolves the controlling agent — with `confirm: true`, as Gatekeeper does, so a pending `change-registry` can't slip a mismatch through — and downgrades the operation to `local` when that agent is local.

This covers all six ephemeral call sites (`sendCredential`, `createChallenge`, `createResponse`, `sendPoll`, `sendBallot`, `sendDmail`), any direct `createAsset` caller, and any ephemeral site added later. `ephemeralRegistry` goes back to a constant — the derivation from #798 is no longer needed in either language.

Scoped to `create` only: Gatekeeper re-checks the controller's registry in [§7.1](docs/services/gatekeeper/README.md) step 4 but not on `update`/`delete`, so `updateAsset` needs no guard.

### Why downgrade rather than reject

Gatekeeper would refuse the operation outright, so a non-`local` registry on a `local` agent is unsatisfiable rather than merely unusual — rejecting would just move the same failure earlier. Downgrading keeps a local-only node working, which is the entire point.

### Why Gatekeeper can't do this itself

It has the controller doc in hand, so it's a fair question. But `registration.registry` is inside the operation proof *and* inside the CID the DID is derived from (`generateDID(operation)`). Rewriting it server-side would invalidate the signature and change the DID; rewrite-then-verify fails the signature check, verify-then-rewrite stores an operation that can never be re-verified by `verify-db`, a peer importing the batch, or any replay. Operations are self-certifying — only the signer can legitimately change the registry.

## Python parity

Mirrors the same logic in `create_asset`, and fixes `create_challenge`, which was a bare passthrough:

```python
async def create_challenge(self, challenge=None, options=None) -> str:
    return await self.create_asset({"challenge": challenge or {}}, options or {})
```

It set neither the ephemeral registry nor the one-hour `validUntil` that TypeScript's `createChallenge` sets — so **Python challenges never expired**. That's an independent divergence this PR closes.

Still divergent and *not* addressed here: Python's `create_challenge` performs none of TypeScript's input validation (`challenge` must be a non-array object, `challenge.credentials` must be an array). Worth a follow-up.

## Spec

New **7.2 Registry selection** in the Keymaster spec: the selection order, the invariant as a MUST, that it's enforced before signing and never by Gatekeeper, the `confirm: true` requirement, why deriving from the default registry is insufficient, and the one-hour challenge expiry. The Gatekeeper spec already documented the enforcement rule in §7.1, so it's cross-referenced rather than duplicated.

## Tests

Three cases per language covering all three rows of the table above, plus a Python test pinning the challenge expiry.

- TypeScript `tests/keymaster`: **963 passed**, 1 skipped
- Python `python/keymaster`: **169 passed**
- `tsc --noEmit` and `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)