### PR TITLE
test(gatekeeper): cover the v1 routers extracted in #705

### DIFF
--- a/tests/gatekeeper/v1-api.test.ts
+++ b/tests/gatekeeper/v1-api.test.ts
@@ -63,13 +63,14 @@ function createMockGatekeeper() {
     };
 }
 
-function mount() {
+function mount(configOverrides: Record<string, unknown> = {}) {
     const gatekeeper = createMockGatekeeper();
+    const config = { ...testConfig, ...configOverrides };
     const app = express();
-    app.use(express.json({ limit: testConfig.jsonLimit }));
+    app.use(express.json({ limit: config.jsonLimit }));
     app.use('/api/v1', createV1Router({
         gatekeeper: gatekeeper as any,
-        config: testConfig,
+        config: config as any,
         logger: { error: jest.fn() } as any,
         isReady: () => true,
         getStatus: async () => ({
@@ -88,6 +89,8 @@ function mount() {
 
     return { app, gatekeeper };
 }
+
+const boom = () => jest.fn<() => Promise<never>>().mockRejectedValue(new Error('boom'));
 
 describe('/api/v1 route handlers', () => {
     it('serves health, version, status, and registry routes without bootstrapping the service', async () => {
@@ -208,5 +211,362 @@ describe('/api/v1 route handlers', () => {
         const query = await request(app).post('/api/v1/query').send({ where: { type: 'notice' } });
         expect(query.status).toBe(200);
         expect(gatekeeper.queryDocs).toHaveBeenCalledWith({ type: 'notice' });
+    });
+});
+
+describe('/api/v1 sync routes', () => {
+    const admin = (req: request.Test) => req.set('X-Archon-Admin-Key', adminKey);
+
+    it('routes batch export, import, and import-by-cids through the gatekeeper', async () => {
+        const { app, gatekeeper } = mount();
+
+        const exported = await admin(request(app).post('/api/v1/batch/export')).send({ dids: ['did:cid:abc'] });
+        expect(exported.status).toBe(200);
+        expect(exported.body).toEqual([{ did: 'did:cid:abc' }]);
+        expect(gatekeeper.exportBatch).toHaveBeenCalledWith(['did:cid:abc']);
+
+        const imported = await admin(request(app).post('/api/v1/batch/import')).send([{ did: 'did:cid:abc' }]);
+        expect(imported.status).toBe(200);
+        expect(imported.body).toMatchObject({ queued: 1, total: 1 });
+        expect(gatekeeper.importBatch).toHaveBeenCalledWith([{ did: 'did:cid:abc' }]);
+
+        const byCids = await admin(request(app).post('/api/v1/batch/import/cids'))
+            .send({ cids: ['cid-1'], metadata: { source: 'test' } });
+        expect(byCids.status).toBe(200);
+        expect(gatekeeper.importBatchByCids).toHaveBeenCalledWith(['cid-1'], { source: 'test' });
+    });
+
+    it('clears the queue and runs db maintenance routes', async () => {
+        const { app, gatekeeper } = mount();
+
+        const cleared = await admin(request(app).post('/api/v1/queue/local/clear')).send([{ type: 'create' }]);
+        expect(cleared.status).toBe(200);
+        expect(gatekeeper.clearQueue).toHaveBeenCalledWith('local', [{ type: 'create' }]);
+
+        const reset = await admin(request(app).get('/api/v1/db/reset'));
+        expect(reset.status).toBe(200);
+        expect(gatekeeper.resetDb).toHaveBeenCalled();
+
+        const verified = await admin(request(app).get('/api/v1/db/verify'));
+        expect(verified.status).toBe(200);
+        expect(verified.body).toMatchObject({ total: 1, verified: 1 });
+    });
+
+    it('refuses to reset the database in production', async () => {
+        const { app, gatekeeper } = mount();
+        const previous = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'production';
+
+        try {
+            const reset = await admin(request(app).get('/api/v1/db/reset'));
+            expect(reset.status).toBe(403);
+            expect(gatekeeper.resetDb).not.toHaveBeenCalled();
+        } finally {
+            process.env.NODE_ENV = previous;
+        }
+    });
+
+    it('reports gatekeeper failures on sync routes as 500', async () => {
+        const { app, gatekeeper } = mount();
+        for (const method of [
+            'exportBatch', 'importBatch', 'importBatchByCids', 'getQueue',
+            'clearQueue', 'listRegistries', 'resetDb', 'verifyDb', 'processEvents',
+        ] as const) {
+            (gatekeeper as any)[method] = boom();
+        }
+
+        // Build each request lazily: supertest's Test binds a server on construction,
+        // so eagerly created requests that never run would leak handles and hang Jest.
+        const calls: Array<[string, () => request.Test]> = [
+            ['batch/export', () => admin(request(app).post('/api/v1/batch/export')).send({ dids: [] })],
+            ['batch/import', () => admin(request(app).post('/api/v1/batch/import')).send([])],
+            ['batch/import/cids', () => admin(request(app).post('/api/v1/batch/import/cids')).send({ cids: [] })],
+            ['queue', () => admin(request(app).get('/api/v1/queue/local'))],
+            ['queue/clear', () => admin(request(app).post('/api/v1/queue/local/clear')).send([])],
+            ['registries', () => request(app).get('/api/v1/registries')],
+            ['db/reset', () => admin(request(app).get('/api/v1/db/reset'))],
+            ['db/verify', () => admin(request(app).get('/api/v1/db/verify'))],
+            ['events/process', () => admin(request(app).post('/api/v1/events/process'))],
+        ];
+
+        for (const [label, call] of calls) {
+            const response = await call();
+            expect([label, response.status]).toEqual([label, 500]);
+        }
+    });
+});
+
+describe('/api/v1 DID routes', () => {
+    const admin = (req: request.Test) => req.set('X-Archon-Admin-Key', adminKey);
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+    });
+
+    it('passes versionTime through and ignores an unparsable versionSequence', async () => {
+        const { app, gatekeeper } = mount();
+
+        await request(app).get('/api/v1/did/did:cid:abc?versionTime=2026-01-01T00:00:00Z&versionSequence=nope');
+        expect(gatekeeper.resolveDID).toHaveBeenCalledWith('did:cid:abc', {
+            versionTime: '2026-01-01T00:00:00Z',
+        });
+    });
+
+    it('answers 404 when the gatekeeper throws while resolving', async () => {
+        const { app, gatekeeper } = mount();
+        gatekeeper.resolveDID = boom();
+
+        const response = await request(app).get('/api/v1/did/did:cid:missing');
+        expect(response.status).toBe(404);
+        expect(response.body).toEqual({ error: 'DID not found' });
+    });
+
+    it('falls back to the universal resolver when resolution returns an error', async () => {
+        const { app, gatekeeper } = mount({ fallbackURL: 'https://resolver.test/' });
+        gatekeeper.resolveDID = jest.fn<any>().mockResolvedValue({
+            didDocument: {},
+            didResolutionMetadata: { error: 'notFound' },
+        });
+        const upstream = { didDocument: { id: 'did:cid:abc' } };
+        global.fetch = jest.fn<any>().mockResolvedValue({ ok: true, json: async () => upstream });
+
+        const response = await request(app).get('/api/v1/did/did:cid:abc');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(upstream);
+        expect(global.fetch).toHaveBeenCalledWith(
+            'https://resolver.test/1.0/identifiers/did%3Acid%3Aabc',
+            expect.objectContaining({ signal: expect.anything() }),
+        );
+    });
+
+    it('returns the original document when the universal resolver rejects or errors', async () => {
+        const errorDoc = { didDocument: {}, didResolutionMetadata: { error: 'notFound' } };
+
+        const notOk = mount({ fallbackURL: 'https://resolver.test' });
+        notOk.gatekeeper.resolveDID = jest.fn<any>().mockResolvedValue(errorDoc);
+        global.fetch = jest.fn<any>().mockResolvedValue({ ok: false });
+        const first = await request(notOk.app).get('/api/v1/did/did:cid:abc');
+        expect(first.status).toBe(200);
+        expect(first.body).toEqual(errorDoc);
+
+        const threw = mount({ fallbackURL: 'https://resolver.test' });
+        threw.gatekeeper.resolveDID = jest.fn<any>().mockResolvedValue(errorDoc);
+        global.fetch = jest.fn<any>().mockRejectedValue(new Error('network down'));
+        const second = await request(threw.app).get('/api/v1/did/did:cid:abc');
+        expect(second.status).toBe(200);
+        expect(second.body).toEqual(errorDoc);
+    });
+
+    it('sends non-create operations to updateDID', async () => {
+        const { app, gatekeeper } = mount();
+        const op = { type: 'update', registration: { registry: 'local' } };
+
+        const updated = await request(app).post('/api/v1/did').send(op);
+        expect(updated.status).toBe(200);
+        expect(gatekeeper.updateDID).toHaveBeenCalledWith(op);
+        expect(gatekeeper.createDID).not.toHaveBeenCalled();
+    });
+
+    it('rejects a generate request with no operation body', async () => {
+        const { app, gatekeeper } = mount();
+
+        // express.json() ignores a non-JSON content type, so req.body stays undefined
+        // (Express 5) and the handler's own "missing operation" guard is what answers.
+        const response = await request(app)
+            .post('/api/v1/did/generate')
+            .set('Content-Type', 'text/plain')
+            .send('');
+        expect(response.status).toBe(400);
+        expect(response.body).toEqual({ error: 'missing operation' });
+        expect(gatekeeper.generateDID).not.toHaveBeenCalled();
+    });
+
+    it('skips the universal resolver when no fallback URL is configured', async () => {
+        const { app, gatekeeper } = mount();
+        const errorDoc = { didDocument: {}, didResolutionMetadata: { error: 'notFound' } };
+        gatekeeper.resolveDID = jest.fn<any>().mockResolvedValue(errorDoc);
+        global.fetch = jest.fn<any>();
+
+        const response = await request(app).get('/api/v1/did/did:cid:abc');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(errorDoc);
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('serves a confirmed document from the confirm fallback', async () => {
+        const { app, gatekeeper } = mount({ confirmFallbackURL: 'https://confirm.test' });
+        gatekeeper.resolveDID = jest.fn<any>().mockResolvedValue({
+            didDocument: { id: 'did:cid:abc' },
+            didResolutionMetadata: {},
+            didDocumentMetadata: { confirmed: false },
+        });
+        const confirmed = { didDocument: { id: 'did:cid:abc' }, didDocumentMetadata: { confirmed: true } };
+        global.fetch = jest.fn<any>().mockResolvedValue({ ok: true, json: async () => confirmed });
+
+        const response = await request(app).get('/api/v1/did/did:cid:abc?confirm=true');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(confirmed);
+    });
+
+    it('falls through to the local document when the confirm fallback throws', async () => {
+        const { app, gatekeeper } = mount({ confirmFallbackURL: 'https://confirm.test' });
+        const local = {
+            didDocument: { id: 'did:cid:abc' },
+            didResolutionMetadata: {},
+            didDocumentMetadata: { confirmed: false },
+        };
+        gatekeeper.resolveDID = jest.fn<any>().mockResolvedValue(local);
+        global.fetch = jest.fn<any>().mockRejectedValue(new Error('fallback down'));
+
+        const response = await request(app).get('/api/v1/did/did:cid:abc?confirm=true');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(local);
+    });
+
+    it('routes DID removal, export, and import, and reports failures as 500', async () => {
+        const { app, gatekeeper } = mount();
+
+        const removed = await admin(request(app).post('/api/v1/dids/remove')).send(['did:cid:abc']);
+        expect(removed.status).toBe(200);
+        expect(gatekeeper.removeDIDs).toHaveBeenCalledWith(['did:cid:abc']);
+
+        const exported = await request(app).post('/api/v1/dids/export').send({ dids: ['did:cid:abc'] });
+        expect(exported.status).toBe(200);
+        expect(gatekeeper.exportDIDs).toHaveBeenCalledWith(['did:cid:abc']);
+
+        const imported = await admin(request(app).post('/api/v1/dids/import')).send([[{ did: 'did:cid:abc' }]]);
+        expect(imported.status).toBe(200);
+        expect(gatekeeper.importDIDs).toHaveBeenCalledWith([[{ did: 'did:cid:abc' }]]);
+
+        const failing = mount();
+        for (const method of ['createDID', 'generateDID', 'getDIDs', 'removeDIDs', 'exportDIDs', 'importDIDs'] as const) {
+            (failing.gatekeeper as any)[method] = boom();
+        }
+
+        // `/did/generate` answers 400 (not 500) on failure — its catch returns the error body.
+        const calls: Array<[string, number, () => request.Test]> = [
+            ['did', 500, () => request(failing.app).post('/api/v1/did').send({ type: 'create' })],
+            ['did/generate', 400, () => request(failing.app).post('/api/v1/did/generate').send({ type: 'create' })],
+            ['dids', 500, () => request(failing.app).post('/api/v1/dids/').send({})],
+            ['dids/remove', 500, () => admin(request(failing.app).post('/api/v1/dids/remove')).send([])],
+            ['dids/export', 500, () => request(failing.app).post('/api/v1/dids/export').send({ dids: [] })],
+            ['dids/import', 500, () => admin(request(failing.app).post('/api/v1/dids/import')).send([])],
+        ];
+
+        for (const [label, expected, call] of calls) {
+            const response = await call();
+            expect([label, response.status]).toEqual([label, expected]);
+        }
+    });
+});
+
+describe('/api/v1 block, search, health, and admin behaviour', () => {
+    const admin = (req: request.Test) => req.set('X-Archon-Admin-Key', adminKey);
+
+    it('adds a block and returns an empty result for a blank search', async () => {
+        const { app, gatekeeper } = mount();
+
+        const added = await admin(request(app).post('/api/v1/block/local')).send({ hash: 'abc', height: 8 });
+        expect(added.status).toBe(200);
+        expect(gatekeeper.addBlock).toHaveBeenCalledWith('local', { hash: 'abc', height: 8 });
+
+        const blank = await request(app).get('/api/v1/search?q=');
+        expect(blank.status).toBe(200);
+        expect(blank.body).toEqual([]);
+        expect(gatekeeper.searchDocs).not.toHaveBeenCalled();
+    });
+
+    it('reports block, search, and query failures as 500', async () => {
+        const { app, gatekeeper } = mount();
+        gatekeeper.getBlock = boom();
+        gatekeeper.addBlock = boom();
+        gatekeeper.searchDocs = boom();
+        gatekeeper.queryDocs = boom();
+
+        const calls: Array<[string, () => request.Test]> = [
+            ['block latest', () => request(app).get('/api/v1/block/local/latest')],
+            ['block by id', () => request(app).get('/api/v1/block/local/7')],
+            ['add block', () => admin(request(app).post('/api/v1/block/local')).send({})],
+            ['search', () => request(app).get('/api/v1/search?q=hello')],
+            ['query', () => request(app).post('/api/v1/query').send({ where: { type: 'notice' } })],
+        ];
+
+        for (const [label, call] of calls) {
+            const response = await call();
+            expect([label, response.status]).toEqual([label, 500]);
+        }
+    });
+
+    it('reports health route failures as 500', async () => {
+        const gatekeeper = createMockGatekeeper();
+        const app = express();
+        app.use(express.json());
+        app.use('/api/v1', createV1Router({
+            gatekeeper: gatekeeper as any,
+            config: testConfig as any,
+            logger: { error: jest.fn() } as any,
+            isReady: () => { throw new Error('not ready'); },
+            getStatus: async () => { throw new Error('no status'); },
+            didOperationsTotal: { inc: jest.fn() } as any,
+        }));
+
+        await expect(request(app).get('/api/v1/ready')).resolves.toMatchObject({ status: 500 });
+        await expect(request(app).get('/api/v1/status')).resolves.toMatchObject({ status: 500 });
+    });
+
+    it('leaves admin routes unprotected when no admin key is configured', async () => {
+        const { app, gatekeeper } = mount({ adminApiKey: '' });
+
+        const response = await request(app).get('/api/v1/queue/local');
+        expect(response.status).toBe(200);
+        expect(gatekeeper.getQueue).toHaveBeenCalledWith('local');
+    });
+});
+
+describe('/api/v1 IPFS routes', () => {
+    it('retrieves json, text, and binary payloads by cid', async () => {
+        const { app, gatekeeper } = mount();
+
+        const json = await request(app).get('/api/v1/ipfs/json/cid-json');
+        expect(json.status).toBe(200);
+        expect(json.body).toEqual({ hello: 'world' });
+        expect(gatekeeper.getJSON).toHaveBeenCalledWith('cid-json');
+
+        const text = await request(app).get('/api/v1/ipfs/text/cid-text');
+        expect(text.status).toBe(200);
+        expect(gatekeeper.getText).toHaveBeenCalledWith('cid-text');
+
+        const data = await request(app).get('/api/v1/ipfs/data/cid-data');
+        expect(data.status).toBe(200);
+        expect(gatekeeper.getData).toHaveBeenCalledWith('cid-data');
+
+        const streamed = await request(app).post('/api/v1/ipfs/stream').send(Buffer.from('bytes'));
+        expect(streamed.status).toBe(200);
+        expect(gatekeeper.addDataStream).toHaveBeenCalled();
+    });
+
+    it('reports gatekeeper failures on IPFS routes as 500', async () => {
+        const { app, gatekeeper } = mount();
+        for (const method of ['addJSON', 'getJSON', 'addText', 'getText', 'addData', 'getData', 'addDataStream'] as const) {
+            (gatekeeper as any)[method] = boom();
+        }
+        gatekeeper.getDataStream = jest.fn(() => { throw new Error('boom'); }) as any;
+
+        const calls: Array<[string, () => request.Test]> = [
+            ['post json', () => request(app).post('/api/v1/ipfs/json').send({ a: 1 })],
+            ['get json', () => request(app).get('/api/v1/ipfs/json/cid')],
+            ['post text', () => request(app).post('/api/v1/ipfs/text').set('Content-Type', 'text/plain').send('hi')],
+            ['get text', () => request(app).get('/api/v1/ipfs/text/cid')],
+            ['post data', () => request(app).post('/api/v1/ipfs/data').set('Content-Type', 'application/octet-stream').send(Buffer.from('x'))],
+            ['get data', () => request(app).get('/api/v1/ipfs/data/cid')],
+            ['post stream', () => request(app).post('/api/v1/ipfs/stream').send(Buffer.from('x'))],
+            ['get stream', () => request(app).get('/api/v1/ipfs/stream/cid')],
+        ];
+
+        for (const [label, call] of calls) {
+            const response = await call();
+            expect([label, response.status]).toEqual([label, 500]);
+        }
     });
 });


### PR DESCRIPTION
## Why

Coverage on `main` dropped **91.63% → 90.26%** on 2026-07-09, entirely at #705 (`refactor: Extract gatekeeper v1 router`). It has been flat at ~90.3% since; the 91.74% peak from 07-07 was never recovered.

No tests were lost. `jest.config.js` sets no `collectCoverageFrom`, so only files a test actually loads count. The old `gatekeeper-api.ts` (2,547 lines) was never imported by any test and so was invisible to coverage. #705 split it into eight `v1-*` routers and added `v1-api.test.ts`, which imports `createV1Router` — pulling ~300 partially-covered lines into the denominator. The 91.63% was flattering; 90.26% was the honest number for code that had never been exercised.

## What

Adds 20 tests (5 → 25 in `tests/gatekeeper/v1-api.test.ts`) covering the routes and error paths that were never hit:

- **sync**: batch export / import / import-by-cids, queue clear, db reset + verify, the production reset guard
- **did**: the `updateDID` branch, missing-operation guard, `versionTime` passthrough, 404 on resolve failure, both universal-resolver outcomes, both confirm-fallback outcomes, remove / export / import
- **ipfs**: get-by-cid for json / text / data, stream upload and download
- **block / search / health / admin**: block add, blank search, health failures, and the unprotected path when no admin key is configured
- error paths on every route

No production code is touched — one file, +363/−3.

## Result

| file | before | after |
| --- | --- | --- |
| `v1-sync-router.ts` | 35.5% | **100%** |
| `v1-did-router.ts` | 43.4% | **100%** |
| `v1-ipfs-router.ts` | 58.8% | **100%** |
| `v1-block-router.ts` | 66.7% | **100%** |
| `v1-search-router.ts` | 73.9% | **100%** |
| `v1-admin` / `v1-health` / `v1-router` | 81–88% | **100%** |

Gatekeeper server: **139 uncovered lines → 4** (the remainder is `identifiers-router.ts`, which pre-dates #705). Repo total **93.57% → 95.61%**, more than recovering the 1.37pp regression.

Full suite: 1,623 passing, eslint clean, and the file exits cleanly under `jest --runInBand` **without** `--forceExit`.

## Note for future test authors

Requests are built lazily (`() => request(app)...`) inside the assertion loops. supertest's `Test` calls `app.listen(0)` **at construction**, so eagerly building an array of requests leaks a listening server for every entry left un-awaited after a failed assertion. Because `unit-test.yml` runs Jest without `--forceExit`, that hangs CI silently instead of failing it — which is exactly what happened while writing these.

## Not included

`collectCoverageFrom` is deliberately left alone. Enabling it would newly count ~10k untested lines (`services/keymaster/server/src` alone is 8,487 lines across 23 routers that no test imports) and drop the reported figure to roughly 50–60%, swamping the per-PR signal. Better scoped per-directory as each surface gets tests — the Keymaster routers being the obvious next target, for which this file is a working template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)