### PR TITLE
test(keymaster): cover the server routers extracted in #706

### DIFF
--- a/tests/keymaster/server-routers.test.ts
+++ b/tests/keymaster/server-routers.test.ts
@@ -1,0 +1,487 @@
+import { jest } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+
+import { createAddressRouter } from '../../services/keymaster/server/src/keymaster-address-router';
+import { createAgentRouter } from '../../services/keymaster/server/src/keymaster-agent-router';
+import { createAssetRouter } from '../../services/keymaster/server/src/keymaster-asset-router';
+import { createChallengeRouter } from '../../services/keymaster/server/src/keymaster-challenge-router';
+import { createCoreRouter } from '../../services/keymaster/server/src/keymaster-core-router';
+import { createCredentialRouter } from '../../services/keymaster/server/src/keymaster-credential-router';
+import { createDidCommRouter } from '../../services/keymaster/server/src/keymaster-didcomm-router';
+import { createDmailRouter } from '../../services/keymaster/server/src/keymaster-dmail-router';
+import { createFileRouter } from '../../services/keymaster/server/src/keymaster-file-router';
+import { createGroupRouter } from '../../services/keymaster/server/src/keymaster-group-router';
+import { createIdentityRouter } from '../../services/keymaster/server/src/keymaster-identity-router';
+import { createImageRouter } from '../../services/keymaster/server/src/keymaster-image-router';
+import { createKeyRouter } from '../../services/keymaster/server/src/keymaster-key-router';
+import { createLightningRouter } from '../../services/keymaster/server/src/keymaster-lightning-router';
+import { createNostrRouter } from '../../services/keymaster/server/src/keymaster-nostr-router';
+import { createNoticeRouter } from '../../services/keymaster/server/src/keymaster-notice-router';
+import { createPollRouter } from '../../services/keymaster/server/src/keymaster-poll-router';
+import { createPublicRouter } from '../../services/keymaster/server/src/keymaster-public-router';
+import { createResponseRouter } from '../../services/keymaster/server/src/keymaster-response-router';
+import { createSchemaRouter } from '../../services/keymaster/server/src/keymaster-schema-router';
+import { createSchemaTemplateRouter } from '../../services/keymaster/server/src/keymaster-schema-template-router';
+import { createVaultRouter } from '../../services/keymaster/server/src/keymaster-vault-router';
+import { createRequireAdminKey } from '../../services/keymaster/server/src/keymaster-admin';
+import defaultConfig from '../../services/keymaster/server/src/config';
+
+type Method = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+const adminKey = 'test-admin-key';
+
+const baseConfig = {
+    ...defaultConfig,
+    adminApiKey: adminKey,
+    keymasterPassphrase: '',
+};
+
+// Every Keymaster method is a jest.fn created on first access, so the routers can
+// call anything without the test having to enumerate ~150 method names. `mode`
+// flips the whole surface between resolving and rejecting.
+function createMockKeymaster(mode: { reject: boolean }) {
+    const methods = new Map<string, any>();
+    return new Proxy({} as any, {
+        get(_target, prop: string) {
+            if (!methods.has(prop)) {
+                methods.set(prop, jest.fn(() => mode.reject
+                    ? Promise.reject(new Error(`boom:${prop}`))
+                    : Promise.resolve({ ok: true, name: prop })));
+            }
+            return methods.get(prop);
+        },
+        has: () => true,
+    });
+}
+
+function mount(configOverrides: Record<string, unknown> = {}) {
+    const mode = { reject: false };
+    const keymaster = createMockKeymaster(mode);
+    const gatekeeper = createMockKeymaster(mode);
+    const config = { ...baseConfig, ...configOverrides };
+
+    const options = {
+        getKeymaster: () => keymaster,
+        getGatekeeper: () => gatekeeper,
+        config: config as any,
+        walletOperationsTotal: { inc: jest.fn() } as any,
+        didNotFound: { error: 'DID not found' },
+        isReady: () => true,
+        getServiceVersion: () => '9.9.9',
+        serviceCommit: 'abc1234',
+    };
+
+    const app = express();
+    app.use(express.json());
+    for (const create of [
+        createPublicRouter, createCoreRouter, createIdentityRouter, createAddressRouter,
+        createDidCommRouter, createNostrRouter, createLightningRouter, createChallengeRouter,
+        createResponseRouter, createGroupRouter, createSchemaRouter, createSchemaTemplateRouter,
+        createAgentRouter, createCredentialRouter, createKeyRouter, createAssetRouter,
+        createPollRouter, createImageRouter, createFileRouter, createVaultRouter,
+        createDmailRouter, createNoticeRouter,
+    ]) {
+        app.use(create(options as any));
+    }
+
+    return { app, keymaster, gatekeeper, mode };
+}
+
+function send(app: express.Express, method: Method, path: string) {
+    const agent = request(app);
+    const call = method === 'GET' ? agent.get(path)
+        : method === 'POST' ? agent.post(path)
+            : method === 'PUT' ? agent.put(path)
+                : agent.delete(path);
+    // Express 5 leaves req.body undefined without a parsed body, which would make
+    // handlers that destructure it throw before reaching the code under test.
+    return method === 'GET' ? call : call.send({});
+}
+
+// [method, path, status the handler's catch block returns]
+const ROUTES: Array<[Method, string, number]> = [
+    // address
+    ['GET', '/addresses', 500],
+    ['GET', '/addresses/example.com', 400],
+    ['POST', '/addresses/import', 400],
+    ['GET', '/addresses/check/addr1', 400],
+    ['POST', '/addresses', 400],
+    ['POST', '/addresses/publish', 400],
+    ['DELETE', '/addresses/publish', 400],
+    ['DELETE', '/addresses/addr1', 400],
+    // agent
+    ['POST', '/agents/test-id/test', 400],
+    // asset
+    ['POST', '/assets', 500],
+    ['GET', '/assets', 500],
+    ['GET', '/assets/test-id', 404],
+    ['PUT', '/assets/test-id', 500],
+    ['POST', '/assets/test-id/transfer', 500],
+    ['POST', '/assets/test-id/clone', 500],
+    // challenge
+    ['GET', '/challenge', 500],
+    ['POST', '/challenge', 400],
+    // core
+    ['GET', '/registries', 500],
+    ['GET', '/wallet', 500],
+    ['PUT', '/wallet', 500],
+    ['POST', '/wallet/new', 500],
+    ['POST', '/wallet/backup', 500],
+    ['POST', '/wallet/recover', 500],
+    ['POST', '/wallet/check', 500],
+    ['POST', '/wallet/fix', 500],
+    ['GET', '/wallet/mnemonic', 500],
+    ['POST', '/wallet/passphrase', 500],
+    ['GET', '/export/wallet/encrypted', 500],
+    // credential
+    ['POST', '/credentials/bind', 400],
+    ['GET', '/credentials/held', 500],
+    ['POST', '/credentials/held', 400],
+    ['GET', '/credentials/held/didcid1:abc', 500],
+    ['DELETE', '/credentials/held/didcid1:abc', 400],
+    ['POST', '/credentials/held/didcid1:abc/publish', 400],
+    ['POST', '/credentials/held/didcid1:abc/unpublish', 400],
+    ['GET', '/credentials/issued', 500],
+    ['POST', '/credentials/issued', 400],
+    ['GET', '/credentials/issued/didcid1:abc', 500],
+    ['POST', '/credentials/issued/didcid1:abc/send', 500],
+    ['POST', '/credentials/issued/didcid1:abc', 400],
+    ['DELETE', '/credentials/issued/didcid1:abc', 400],
+    // didcomm
+    ['POST', '/didcomm/publish', 400],
+    ['DELETE', '/didcomm/publish', 400],
+    ['POST', '/didcomm/pack', 400],
+    ['POST', '/didcomm/unpack', 400],
+    ['POST', '/didcomm/send', 400],
+    ['POST', '/didcomm/receive', 400],
+    ['POST', '/didcomm/mediate', 400],
+    // dmail
+    ['GET', '/dmail', 500],
+    ['POST', '/dmail', 500],
+    ['POST', '/dmail/import', 500],
+    ['GET', '/dmail/test-id', 404],
+    ['PUT', '/dmail/test-id', 500],
+    ['DELETE', '/dmail/test-id', 500],
+    ['POST', '/dmail/test-id/send', 500],
+    ['POST', '/dmail/test-id/file', 500],
+    ['GET', '/dmail/test-id/attachments', 404],
+    ['POST', '/dmail/test-id/attachments', 500],
+    ['DELETE', '/dmail/test-id/attachments/item', 404],
+    ['GET', '/dmail/test-id/attachments/item', 404],
+    // file
+    ['POST', '/files', 500],
+    ['PUT', '/files/test-id', 500],
+    ['GET', '/files/test-id', 404],
+    ['POST', '/files/test-id/test', 400],
+    ['GET', '/ipfs/data/cid1', 404],
+    // group
+    ['GET', '/groups', 500],
+    ['POST', '/groups', 500],
+    ['GET', '/groups/item', 404],
+    ['POST', '/groups/item/add', 500],
+    ['POST', '/groups/item/remove', 500],
+    ['POST', '/groups/item/test', 400],
+    // identity
+    ['GET', '/did/test-id', 404],
+    ['DELETE', '/did/test-id', 500],
+    ['PUT', '/did/test-id', 500],
+    ['GET', '/ids/current', 500],
+    ['PUT', '/ids/current', 400],
+    ['GET', '/ids', 500],
+    ['POST', '/ids', 500],
+    ['GET', '/ids/test-id', 404],
+    ['DELETE', '/ids/test-id', 400],
+    ['POST', '/ids/test-id/rename', 400],
+    ['POST', '/ids/test-id/change-registry', 400],
+    ['POST', '/ids/test-id/backup', 400],
+    ['POST', '/ids/test-id/recover', 500],
+    ['GET', '/aliases', 500],
+    ['POST', '/aliases', 500],
+    ['GET', '/aliases/ally', 404],
+    ['DELETE', '/aliases/ally', 400],
+    // image
+    ['POST', '/images', 500],
+    ['PUT', '/images/test-id', 500],
+    ['GET', '/images/test-id', 404],
+    ['POST', '/images/test-id/test', 400],
+    // key
+    ['POST', '/keys/rotate', 500],
+    ['POST', '/keys/encrypt/message', 500],
+    ['POST', '/keys/decrypt/message', 500],
+    ['POST', '/keys/encrypt/json', 500],
+    ['POST', '/keys/decrypt/json', 500],
+    ['POST', '/keys/sign', 500],
+    ['POST', '/keys/verify', 500],
+    // lightning
+    ['POST', '/lightning', 400],
+    ['DELETE', '/lightning', 400],
+    ['POST', '/lightning/balance', 400],
+    ['POST', '/lightning/invoice', 400],
+    ['POST', '/lightning/pay', 400],
+    ['POST', '/lightning/payment', 400],
+    ['POST', '/lightning/decode', 400],
+    ['POST', '/lightning/publish', 400],
+    ['POST', '/lightning/unpublish', 400],
+    ['POST', '/lightning/zap', 400],
+    ['POST', '/lightning/payments', 400],
+    // nostr
+    ['POST', '/nostr', 400],
+    ['DELETE', '/nostr', 400],
+    ['POST', '/nostr/import', 400],
+    ['POST', '/nostr/nsec', 400],
+    ['POST', '/nostr/sign', 400],
+    // notice
+    ['POST', '/notices', 500],
+    ['PUT', '/notices/test-id', 500],
+    ['POST', '/notices/refresh', 500],
+    // poll
+    ['GET', '/templates/poll', 500],
+    ['GET', '/polls', 500],
+    ['POST', '/polls', 500],
+    ['POST', '/polls/ballot/send', 500],
+    ['GET', '/polls/ballot/didcid1:abc', 500],
+    ['GET', '/polls/poll-1', 500],
+    ['GET', '/polls/poll-1/test', 500],
+    ['GET', '/polls/poll-1/view', 500],
+    ['POST', '/polls/poll-1/send', 500],
+    ['POST', '/polls/poll-1/vote', 500],
+    ['PUT', '/polls/update', 500],
+    ['POST', '/polls/poll-1/publish', 500],
+    ['POST', '/polls/poll-1/unpublish', 500],
+    ['POST', '/polls/poll-1/voters', 500],
+    ['DELETE', '/polls/poll-1/voters/did:cid:voter', 500],
+    ['GET', '/polls/poll-1/voters', 500],
+    // public — /ready and /version are covered separately; they never call Keymaster
+    // response
+    ['POST', '/response', 400],
+    ['POST', '/response/verify', 400],
+    // schema
+    ['GET', '/schemas', 500],
+    ['POST', '/schemas', 500],
+    ['GET', '/schemas/test-id', 404],
+    ['PUT', '/schemas/test-id', 500],
+    ['POST', '/schemas/test-id/test', 400],
+    // schema-template
+    ['POST', '/schemas/test-id/template', 500],
+    // vault
+    ['POST', '/vaults', 500],
+    ['GET', '/vaults/test-id', 404],
+    ['POST', '/vaults/test-id/test', 404],
+    ['POST', '/vaults/test-id/members', 404],
+    ['DELETE', '/vaults/test-id/members/did:cid:member', 404],
+    ['GET', '/vaults/test-id/members', 404],
+    ['POST', '/vaults/test-id/items', 500],
+    ['DELETE', '/vaults/test-id/items/item', 404],
+    ['GET', '/vaults/test-id/items', 404],
+    ['GET', '/vaults/test-id/items/item', 404],
+];
+
+describe('keymaster server routers', () => {
+    it('mounts every route and reaches its handler', async () => {
+        const { app } = mount();
+        const notFound: string[] = [];
+
+        for (const [method, path] of ROUTES) {
+            const response = await send(app, method, path);
+            if (response.status === 404 && typeof response.text === 'string'
+                && response.text.includes('Cannot')) {
+                notFound.push(`${method} ${path}`);
+            }
+        }
+
+        expect(notFound).toEqual([]);
+    });
+
+    it('maps a failing Keymaster to each route documented error status', async () => {
+        const { app, mode } = mount();
+        mode.reject = true;
+        const mismatches: string[] = [];
+
+        for (const [method, path, expected] of ROUTES) {
+            const response = await send(app, method, path);
+            if (response.status !== expected) {
+                mismatches.push(`${method} ${path} -> ${response.status}, expected ${expected}`);
+            }
+        }
+
+        expect(mismatches).toEqual([]);
+    });
+});
+
+describe('keymaster binary asset downloads', () => {
+    const octet = 'application/octet-stream';
+
+    it('streams image bytes with metadata headers when octet-stream is requested', async () => {
+        const { app, keymaster } = mount();
+        keymaster.getImage.mockResolvedValue({
+            file: { data: Buffer.from('png-bytes'), type: 'image/png', bytes: 9 },
+            image: { width: 1, height: 2 },
+        });
+
+        const binary = await request(app).get('/images/test-id').set('Accept', octet);
+        expect(binary.status).toBe(200);
+        expect(binary.headers['content-type']).toContain(octet);
+        expect(JSON.parse(binary.headers['x-metadata'])).toEqual({
+            file: { type: 'image/png', bytes: 9 },
+            image: { width: 1, height: 2 },
+        });
+
+        // The default (JSON) branch returns the whole asset instead.
+        const json = await request(app).get('/images/test-id');
+        expect(json.status).toBe(200);
+        expect(json.body.image).toEqual({ width: 1, height: 2 });
+    });
+
+    it('answers 404 for an image with no byte payload', async () => {
+        const { app, keymaster } = mount();
+        keymaster.getImage.mockResolvedValue({ image: { width: 1 } });
+
+        const response = await request(app).get('/images/test-id').set('Accept', octet);
+        expect(response.status).toBe(404);
+        expect(response.body).toEqual({ error: 'Image not found' });
+    });
+
+    it('streams file bytes with metadata headers when octet-stream is requested', async () => {
+        const { app, keymaster } = mount();
+        keymaster.getFile.mockResolvedValue({
+            data: Buffer.from('raw-bytes'),
+            type: 'text/plain',
+            bytes: 9,
+        });
+
+        const binary = await request(app).get('/files/test-id').set('Accept', octet);
+        expect(binary.status).toBe(200);
+        expect(JSON.parse(binary.headers['x-metadata'])).toEqual({ type: 'text/plain', bytes: 9 });
+
+        const json = await request(app).get('/files/test-id');
+        expect(json.status).toBe(200);
+        expect(json.body.file.type).toBe('text/plain');
+    });
+
+    it('answers 404 for a file with no byte payload', async () => {
+        const { app, keymaster } = mount();
+        keymaster.getFile.mockResolvedValue({ type: 'text/plain' });
+
+        const response = await request(app).get('/files/test-id').set('Accept', octet);
+        expect(response.status).toBe(404);
+        expect(response.body).toEqual({ error: 'File not found' });
+    });
+});
+
+describe('keymaster key signing', () => {
+    it('parses the request contents before adding a proof', async () => {
+        const { app, keymaster } = mount();
+        keymaster.addProof.mockResolvedValue({ proof: 'sig' });
+
+        const response = await request(app)
+            .post('/keys/sign')
+            .send({ contents: JSON.stringify({ hello: 'world' }) });
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ signed: { proof: 'sig' } });
+        expect(keymaster.addProof).toHaveBeenCalledWith({ hello: 'world' });
+    });
+
+    it('reports unparsable contents as 500', async () => {
+        const { app } = mount();
+
+        const response = await request(app).post('/keys/sign').send({ contents: 'not-json' });
+        expect(response.status).toBe(500);
+    });
+});
+
+describe('keymaster identity recovery', () => {
+    it('answers 404 only when recovery fails with a DID-not-found error', async () => {
+        const { app, keymaster } = mount();
+
+        keymaster.recoverId.mockRejectedValue({ error: 'DID not found' });
+        const missing = await request(app).post('/ids/test-id/recover').send({});
+        expect(missing.status).toBe(404);
+
+        keymaster.recoverId.mockRejectedValue(new Error('something else'));
+        const other = await request(app).post('/ids/test-id/recover').send({});
+        expect(other.status).toBe(500);
+
+        keymaster.recoverId.mockResolvedValue('did:cid:recovered');
+        const ok = await request(app).post('/ids/test-id/recover').send({});
+        expect(ok.status).toBe(200);
+        expect(ok.body).toEqual({ recovered: 'did:cid:recovered' });
+    });
+});
+
+describe('keymaster public router', () => {
+    it('reports the service version and commit', async () => {
+        const { app } = mount();
+
+        const response = await request(app).get('/version');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ version: '9.9.9', commit: 'abc1234' });
+    });
+
+    it('returns the admin key directly when no passphrase is configured', async () => {
+        const { app } = mount();
+
+        const response = await request(app).post('/login').send({});
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ adminApiKey: adminKey });
+    });
+
+    it('requires a matching passphrase when one is configured', async () => {
+        const { app } = mount({ keymasterPassphrase: 's3cret' });
+
+        const wrong = await request(app).post('/login').send({ passphrase: 'nope' });
+        expect(wrong.status).toBe(401);
+        expect(wrong.body).toEqual({ error: 'Incorrect passphrase' });
+
+        const right = await request(app).post('/login').send({ passphrase: 's3cret' });
+        expect(right.status).toBe(200);
+        expect(right.body).toEqual({ adminApiKey: adminKey });
+    });
+
+    it('reports readiness from the injected probe', async () => {
+        const { app } = mount();
+
+        const response = await request(app).get('/ready');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ ready: true });
+    });
+
+    it('reports a failing readiness probe as 500', async () => {
+        const app = express();
+        app.use(express.json());
+        app.use(createPublicRouter({
+            config: baseConfig as any,
+            isReady: () => { throw new Error('probe failed'); },
+            getServiceVersion: () => '9.9.9',
+            serviceCommit: 'abc1234',
+        } as any));
+
+        const response = await request(app).get('/ready');
+        expect(response.status).toBe(500);
+    });
+});
+
+describe('keymaster admin key middleware', () => {
+    function run(config: Record<string, unknown>, header?: string | string[]) {
+        const app = express();
+        app.use(express.json());
+        app.get('/protected', createRequireAdminKey({ ...baseConfig, ...config } as any), (_req, res) => {
+            res.json({ ok: true });
+        });
+        const call = request(app).get('/protected');
+        return header === undefined ? call : call.set('X-Archon-Admin-Key', header as string);
+    }
+
+    it('passes through when no admin key is configured', async () => {
+        await expect(run({ adminApiKey: '' })).resolves.toMatchObject({ status: 200 });
+    });
+
+    it('rejects a missing or wrong key', async () => {
+        await expect(run({})).resolves.toMatchObject({ status: 401 });
+        await expect(run({}, 'wrong')).resolves.toMatchObject({ status: 401 });
+    });
+
+    it('accepts the configured key', async () => {
+        await expect(run({}, adminKey)).resolves.toMatchObject({ status: 200 });
+    });
+});


### PR DESCRIPTION
## Why

Follow-up to #814. That PR fixed the visible coverage regression from #705; this one closes the much larger hole it exposed.

#706 split `keymaster-api.ts` into 22 routers — but **no test imported any of them**. Because `jest.config.js` sets no `collectCoverageFrom`, only files a test actually loads enter the denominator, so ~8,500 lines were simultaneously uncovered *and* uncounted. The split registered a **0.00 delta** on Coveralls, and no change to the entire Keymaster HTTP surface could ever have surfaced as a regression.

## Approach

Mount every router against a mocked Keymaster and drive all 155 routes.

Rather than hand-write ~150 route specs, the mock is a `Proxy` that manufactures a `jest.fn` on first property access, so the test never has to enumerate Keymaster's method surface, and one flag flips the whole thing between resolving and rejecting. Two table-driven tests then assert:

1. every route reaches its handler (rather than 404ing from a bad mount), and
2. every route maps a failing Keymaster to **its own** documented status — 52 routes answer 400, 22 answer 404, 79 answer 500.

**The route table was generated by parsing each handler's catch block, not transcribed by hand.** 153 of 155 entries were correct on the first run, and both mismatches were defects in my generated table rather than in the code:

- `/ids/:id/recover` has two statuses — 404 only for a `DIDNotFound`-shaped error, 500 otherwise. The extractor took the first. It now has a dedicated test covering all three outcomes.
- `/ready` never calls Keymaster, so it cannot fail when Keymaster fails. Removed from the table; covered by the public-router tests.

Targeted tests cover what a uniform table cannot reach: the `Accept: application/octet-stream` branches in the image and file routers (byte streaming with `X-Metadata`, and the 404-when-no-payload guard), `/keys/sign` parsing its request contents, `/login` passphrase handling, `/version`, a throwing readiness probe, and the admin-key middleware.

## Result

`services/keymaster/server/src`: **0 files instrumented → 24, all at 100%** (1000/1000 lines).

| | before | after |
| --- | --- | --- |
| repo total | 95.61% | **96.19%** |
| instrumented lines | 6,607 | 7,607 |
| keymaster server | not measured | **100%** |

Note the total **rose while adding 1,000 lines to the denominator** — the inverse of what #705 did. Suite: 1,640 passing, eslint clean, exits cleanly under `jest --runInBand` without `--forceExit`.

Test-only; no production code touched.

## Suggested follow-ups

- **`@didcid/cipher/didcomm` has no `moduleNameMapper` entry**, so it resolves through package exports to the built `packages/cipher/dist/esm/didcomm.js` instead of source. The DIDComm logic is counted twice (dist 83.6%, src 96.4%) and tests exercise whatever was last built. That's a correctness issue, not just a metric one — kept out of this PR because it changes what the whole suite runs against.
- **`collectCoverageFrom` scoped to `services/keymaster/server/**`** is now worth adding, since the directory is at 100% rather than 0%. Scoping it per-directory as each surface gets tests keeps the number meaningful; enabling it repo-wide today would still drop the figure to ~50-60% and swamp the per-PR signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)