### PR TITLE
test: resolve @didcid/cipher/didcomm to source, not the built dist

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,6 +20,7 @@ const config = {
         '^@didcid/clients/gatekeeper-types$': '<rootDir>/packages/clients/src/gatekeeper-types.ts',
         '^@didcid/clients/keymaster-types$': '<rootDir>/packages/clients/src/keymaster-types.ts',
         '^@didcid/cipher/node$': '<rootDir>/packages/cipher/src/cipher-node.ts',
+        '^@didcid/cipher/didcomm$': '<rootDir>/packages/cipher/src/didcomm.ts',
         '^@didcid/cipher/types': '<rootDir>/packages/cipher/src/types.ts',
         '^@didcid/common/errors$': '<rootDir>/packages/common/src/errors.ts',
         '^@didcid/common/utils$': '<rootDir>/packages/common/src/utils.ts',


### PR DESCRIPTION
## Problem

`jest.config.js` maps `@didcid/cipher/node`, `/types` and `/passphrase` to TypeScript source, but had **no entry for `/didcomm`**. So the import at `packages/keymaster/src/keymaster.ts:97` resolved through package exports to the compiled `packages/cipher/dist/esm/didcomm.js`.

Consequences:

- The DIDComm logic was **measured twice** — `dist/esm/didcomm.js` at 83.6% (213 lines) *and* `src/didcomm.ts` at 96.4% — inflating the denominator with build output.
- Coverage annotations pointed at generated JS instead of source anyone can act on.
- Local `npm test` exercised whatever was last compiled rather than the working tree.

To be precise about the blast radius: **CI was not running stale code.** `unit-test.yml` runs `npm run build` before `npm test`, so CI always compiled fresh. This is primarily a measurement-hygiene fix, not a correctness emergency — the stale-code exposure was limited to local runs that skip the build.

## Change

One line — a `moduleNameMapper` entry pointing `@didcid/cipher/didcomm` at `packages/cipher/src/didcomm.ts`, matching the existing pattern for its siblings.

`jest.config.didcomm-e2e.js` and `jest.config.cli.js` both spread the base config, so they inherit it.

## Verified before switching

- `src` and `dist` export **identical symbol sets** (15 exports, diffed).
- No commit has touched `packages/cipher/src/didcomm.ts` since the `dist` was built, so the two are in sync.
- `dist/` is gitignored — it is pure build output, not a checked-in artifact.
- The two relative imports in the source (`./concat-kdf.js`, `./types.js`) were already handled by existing mappers.

## Result

| | before | after |
| --- | --- | --- |
| measured lines | 7,607 | **7,394** (build output gone) |
| files measured | 86 | 85 |
| `src/didcomm.ts` | 96.4% | **97.4%** |
| repo total | 96.19% | **96.58%** |

`packages/cipher/dist/**` no longer appears in `lcov.info` at all. `src/didcomm.ts` coverage improves because the tests that were exercising `dist` now exercise source.

Suite: 1,640 passing, plus the isolated DIDComm relay e2e (7 passing). eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)