### PR TITLE
refactor(herald): extract the routes so index.ts can be tested

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "lerna": "^9.0.3",
         "macaroons.js": "^0.3.8",
         "mock-fs": "^5.2.0",
+        "multer": "^2.2.0",
         "nock": "^14.0.0",
         "supertest": "^7.2.2",
         "swagger-jsdoc": "^6.2.8",
@@ -9198,6 +9199,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
@@ -10396,6 +10404,18 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/byte-size": {
       "version": "8.1.1",
@@ -20027,6 +20047,50 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
@@ -24640,6 +24704,15 @@
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-stream-types": "^2.0.1"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/strict-event-emitter": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lerna": "^9.0.3",
     "macaroons.js": "^0.3.8",
     "mock-fs": "^5.2.0",
+    "multer": "^2.2.0",
     "nock": "^14.0.0",
     "supertest": "^7.2.2",
     "swagger-jsdoc": "^6.2.8",

--- a/services/herald/server/src/config.ts
+++ b/services/herald/server/src/config.ts
@@ -1,0 +1,29 @@
+// Environment-derived configuration, shared by index.ts and routes.ts.
+// Extracted from index.ts so the route module can be imported without pulling in
+// the server bootstrap (app creation, session setup, listen).
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export const HOST_PORT = Number(process.env.ARCHON_HERALD_PORT) || 4230;
+export const DRAWBRIDGE_PORT = Number(process.env.ARCHON_DRAWBRIDGE_PORT) || 4222;
+export const DRAWBRIDGE_PUBLIC_HOST = process.env.ARCHON_DRAWBRIDGE_PUBLIC_HOST || `http://localhost:${DRAWBRIDGE_PORT}`;
+export const GATEKEEPER_URL = process.env.ARCHON_GATEKEEPER_URL || 'http://localhost:4224';
+export const WALLET_URL = process.env.ARCHON_HERALD_WALLET_URL || 'https://wallet.archon.technology';
+export const HERALD_DATABASE_TYPE = process.env.ARCHON_HERALD_DB || 'json';
+export const DATA_DIR = process.env.ARCHON_HERALD_DATA_DIR || '/app/server/data';
+export const IPFS_API_URL = process.env.ARCHON_HERALD_IPFS_API_URL || 'http://localhost:5001/api/v0';
+export const SERVICE_NAME = process.env.ARCHON_HERALD_NAME || 'name-service';
+export const PUBLIC_URL = `${DRAWBRIDGE_PUBLIC_HOST.replace(/\/$/, '')}/names`;
+export const SERVICE_DOMAIN = process.env.ARCHON_HERALD_DOMAIN || '';
+export const SESSION_SECRET = process.env.ARCHON_HERALD_SESSION_SECRET;
+export const IPNS_KEY_NAME = process.env.ARCHON_HERALD_IPNS_KEY_NAME || SERVICE_NAME;
+export const DEFAULT_MEMBERSHIP_SCHEMA_DID = 'did:cid:bagaaieravnv5onsflewvrz6urhwfjixfnwq7bgc3ejhlrj2nekx75ddhdupq';
+export const MEMBERSHIP_SCHEMA_DID = process.env.ARCHON_HERALD_MEMBERSHIP_SCHEMA_DID || DEFAULT_MEMBERSHIP_SCHEMA_DID;
+export const TOR_PROXY = process.env.ARCHON_HERALD_TOR_PROXY || '';
+export const ADMIN_API_KEY = process.env.ARCHON_ADMIN_API_KEY || process.env.ARCHON_HERALD_ADMIN_API_KEY || '';
+export const SENDGRID_API_KEY = process.env.ARCHON_HERALD_SENDGRID_API_KEY || '';
+export const SENDGRID_FROM_EMAIL = process.env.ARCHON_HERALD_SENDGRID_FROM_EMAIL || `dmail@${SERVICE_DOMAIN}`;
+export const SENDGRID_PARSE_DOMAIN = process.env.ARCHON_HERALD_SENDGRID_PARSE_DOMAIN || `parse.${SERVICE_DOMAIN}`;
+export const OWNER_DID = process.env.ARCHON_HERALD_OWNER_DID || '';
+export const WEBHOOK_SECRET = process.env.ARCHON_HERALD_WEBHOOK_SECRET || '';

--- a/services/herald/server/src/index.ts
+++ b/services/herald/server/src/index.ts
@@ -1,56 +1,50 @@
-import express, {
-    Request,
-    Response,
-    NextFunction
-} from 'express';
+import express from 'express';
 import session from 'express-session';
 import morgan from 'morgan';
 import path from 'path';
 import dotenv from 'dotenv';
-import cors from 'cors';
-import { socksDispatcher } from 'fetch-socks';
 
 import CipherNode from '@didcid/cipher/node';
 import GatekeeperClient from '@didcid/clients/gatekeeper';
 import Keymaster from '@didcid/keymaster';
 import KeymasterClient from '@didcid/clients/keymaster';
 import WalletJson from '@didcid/keymaster/wallet/json';
-import { DatabaseInterface, User } from './db/interfaces.js';
+import { DatabaseInterface } from './db/interfaces.js';
 import { DbJson } from './db/json.js';
 import { DbRedis } from './db/redis.js';
 import { DbSqlite } from './db/sqlite.js';
-import { createOAuthRoutes } from './oauth/index.js';
 import { EmailBridge } from './email-bridge.js';
 import { SendGridEmailService } from './email/sendgrid.js';
-import multer from 'multer';
+import { createHeraldRoutes, type HeraldContext } from './routes.js';
+import {
+    ADMIN_API_KEY,
+    DATA_DIR,
+    GATEKEEPER_URL,
+    HERALD_DATABASE_TYPE,
+    HOST_PORT,
+    IPFS_API_URL,
+    IPNS_KEY_NAME,
+    SENDGRID_API_KEY,
+    SENDGRID_FROM_EMAIL,
+    SENDGRID_PARSE_DOMAIN,
+    SERVICE_DOMAIN,
+    OWNER_DID,
+    SERVICE_NAME,
+    SESSION_SECRET,
+    WALLET_URL,
+} from './config.js';
 
-let keymaster: Keymaster | KeymasterClient;
-let db: DatabaseInterface;
-let emailBridge: EmailBridge | null = null;
+// Shared mutable state, populated by the bootstrap below and read lazily by the
+// routes (which are registered before any of it exists).
+const ctx: HeraldContext = {
+    keymaster: undefined as unknown as Keymaster | KeymasterClient,
+    db: undefined as unknown as DatabaseInterface,
+    emailBridge: null,
+    serviceDID: '',
+};
 
 dotenv.config();
 
-const HOST_PORT = Number(process.env.ARCHON_HERALD_PORT) || 4230;
-const DRAWBRIDGE_PORT = Number(process.env.ARCHON_DRAWBRIDGE_PORT) || 4222;
-const DRAWBRIDGE_PUBLIC_HOST = process.env.ARCHON_DRAWBRIDGE_PUBLIC_HOST || `http://localhost:${DRAWBRIDGE_PORT}`;
-const GATEKEEPER_URL = process.env.ARCHON_GATEKEEPER_URL || 'http://localhost:4224';
-const WALLET_URL = process.env.ARCHON_HERALD_WALLET_URL || 'https://wallet.archon.technology';
-const HERALD_DATABASE_TYPE = process.env.ARCHON_HERALD_DB || 'json';
-const DATA_DIR = process.env.ARCHON_HERALD_DATA_DIR || '/app/server/data';
-const IPFS_API_URL = process.env.ARCHON_HERALD_IPFS_API_URL || 'http://localhost:5001/api/v0';
-const SERVICE_NAME = process.env.ARCHON_HERALD_NAME || 'name-service';
-const PUBLIC_URL = `${DRAWBRIDGE_PUBLIC_HOST.replace(/\/$/, '')}/names`;
-const SERVICE_DOMAIN = process.env.ARCHON_HERALD_DOMAIN || '';
-const SESSION_SECRET = process.env.ARCHON_HERALD_SESSION_SECRET;
-const IPNS_KEY_NAME = process.env.ARCHON_HERALD_IPNS_KEY_NAME || SERVICE_NAME;
-const DEFAULT_MEMBERSHIP_SCHEMA_DID = 'did:cid:bagaaieravnv5onsflewvrz6urhwfjixfnwq7bgc3ejhlrj2nekx75ddhdupq';
-const MEMBERSHIP_SCHEMA_DID = process.env.ARCHON_HERALD_MEMBERSHIP_SCHEMA_DID || DEFAULT_MEMBERSHIP_SCHEMA_DID;
-const TOR_PROXY = process.env.ARCHON_HERALD_TOR_PROXY || '';
-const ADMIN_API_KEY = process.env.ARCHON_ADMIN_API_KEY || process.env.ARCHON_HERALD_ADMIN_API_KEY || '';
-const SENDGRID_API_KEY = process.env.ARCHON_HERALD_SENDGRID_API_KEY || '';
-const SENDGRID_FROM_EMAIL = process.env.ARCHON_HERALD_SENDGRID_FROM_EMAIL || `dmail@${SERVICE_DOMAIN}`;
-const SENDGRID_PARSE_DOMAIN = process.env.ARCHON_HERALD_SENDGRID_PARSE_DOMAIN || `parse.${SERVICE_DOMAIN}`;
-const WEBHOOK_SECRET = process.env.ARCHON_HERALD_WEBHOOK_SECRET || '';
 const SESSION_SECRET_PLACEHOLDERS = new Set(['change-me', 'change-me-to-a-random-string']);
 
 if (!SESSION_SECRET) {
@@ -62,12 +56,6 @@ if (SESSION_SECRET_PLACEHOLDERS.has(SESSION_SECRET)) {
 }
 
 const app = express();
-const logins: Record<string, {
-    response: string;
-    challenge: string;
-    did: string;
-    verify: any;
-}> = {};
 
 app.use(morgan('dev'));
 app.use(express.json());
@@ -85,32 +73,33 @@ app.use(session({
     }
 }));
 
-let serviceDID = '';
-const OWNER_DID = process.env.ARCHON_HERALD_OWNER_DID || '';
+const { router: heraldRouter, startDmailPollLoop } = createHeraldRoutes(ctx);
+app.use(heraldRouter);
+
 
 async function initServiceIdentity(): Promise<void> {
-    const currentId = await keymaster.getCurrentId();
+    const currentId = await ctx.keymaster.getCurrentId();
 
     try {
-        const docs = await keymaster.resolveDID(SERVICE_NAME);
+        const docs = await ctx.keymaster.resolveDID(SERVICE_NAME);
         if (!docs.didDocument?.id) {
             throw new Error('No DID found');
         }
-        serviceDID = docs.didDocument.id;
-        console.log(`${SERVICE_NAME}: ${serviceDID}`);
+        ctx.serviceDID = docs.didDocument.id;
+        console.log(`${SERVICE_NAME}: ${ctx.serviceDID}`);
     }
     catch (error) {
         console.log(`Creating ID ${SERVICE_NAME}`);
-        serviceDID = await keymaster.createId(SERVICE_NAME);
+        ctx.serviceDID = await ctx.keymaster.createId(SERVICE_NAME);
     }
 
-    await keymaster.setCurrentId(SERVICE_NAME);
+    await ctx.keymaster.setCurrentId(SERVICE_NAME);
 
     // Publish the service name as a DID property so it's discoverable
-    const docs = await keymaster.resolveDID(SERVICE_NAME);
+    const docs = await ctx.keymaster.resolveDID(SERVICE_NAME);
     const currentName = (docs.didDocumentData as any)?.name;
     if (currentName !== SERVICE_NAME) {
-        await keymaster.mergeData(SERVICE_NAME, { name: SERVICE_NAME });
+        await ctx.keymaster.mergeData(SERVICE_NAME, { name: SERVICE_NAME });
         console.log(`Published name property: ${SERVICE_NAME}`);
     }
 
@@ -121,7 +110,7 @@ async function initServiceIdentity(): Promise<void> {
     }
 
     if (currentId) {
-        await keymaster.setCurrentId(currentId);
+        await ctx.keymaster.setCurrentId(currentId);
     }
 }
 
@@ -153,1271 +142,18 @@ async function ensureIpnsKeyExists(): Promise<void> {
     console.log(`Created IPNS key ${genResult.Name}: ${genResult.Id}`);
 }
 
-function validateName(name: any): { ok: boolean; trimmedName?: string; message?: string } {
-    if (!name || typeof name !== 'string') {
-        return { ok: false, message: 'Name is required' };
-    }
-    const trimmedName = name.trim().toLowerCase();
-    if (trimmedName.length < 3 || trimmedName.length > 32) {
-        return { ok: false, message: 'Name must be 3-32 characters' };
-    }
-    if (!/^[a-z0-9_-]+$/.test(trimmedName)) {
-        return { ok: false, message: 'Name can only contain letters, numbers, hyphens, and underscores' };
-    }
-    return { ok: true, trimmedName };
-}
-
-async function checkNameAvailability(trimmedName: string, excludeDid?: string): Promise<boolean> {
-    const existingDid = await db.findDidByName(trimmedName);
-    return !existingDid || existingDid === excludeDid;
-}
-
-async function issueOrUpdateCredential(did: string, user: any, trimmedName: string): Promise<void> {
-    if (!MEMBERSHIP_SCHEMA_DID) {
-        console.warn(`Skipping credential issuance for ${trimmedName}: ARCHON_HERALD_MEMBERSHIP_SCHEMA_DID is not set`);
-        return;
-    }
-
-    await keymaster.setCurrentId(SERVICE_NAME);
-
-    if (user.credentialDid) {
-        const vc: any = await keymaster.getCredential(user.credentialDid);
-        if (!vc) throw new Error('Failed to fetch existing credential');
-        vc.credentialSubject.name = `${trimmedName}@${SERVICE_DOMAIN}`;
-        vc.validFrom = new Date().toISOString();
-        const updated = await keymaster.updateCredential(user.credentialDid, vc);
-        if (!updated) throw new Error('Failed to update credential');
-        user.credentialIssuedAt = new Date().toISOString();
-        console.log(`Updated credential ${user.credentialDid} for ${trimmedName}`);
-    } else {
-        const boundCredential = await keymaster.bindCredential(did, {
-            schema: MEMBERSHIP_SCHEMA_DID,
-            validFrom: new Date().toISOString(),
-            claims: { name: `${trimmedName}@${SERVICE_DOMAIN}` }
-        });
-        const credentialDid = await keymaster.issueCredential(boundCredential);
-        user.credentialDid = credentialDid;
-        user.credentialIssuedAt = new Date().toISOString();
-        console.log(`Issued new credential ${credentialDid} for ${trimmedName}`);
-    }
-}
-
-async function revokeCredential(user: any, name: string): Promise<void> {
-    if (user.credentialDid) {
-        try {
-            await keymaster.setCurrentId(SERVICE_NAME);
-            await keymaster.revokeCredential(user.credentialDid);
-            console.log(`Revoked credential ${user.credentialDid} for ${name}`);
-        } catch (err) {
-            console.log(`Failed to revoke credential: ${err}`);
-        }
-        delete user.credentialDid;
-        delete user.credentialIssuedAt;
-    }
-}
-
-async function verifyBearerToken(req: Request): Promise<string | null> {
-    const authHeader = req.headers.authorization;
-    if (!authHeader?.startsWith('Bearer ')) return null;
-    const response = authHeader.slice(7);
-    if (!response) return null;
-    const verify = await keymaster.verifyResponse(response, { retries: 10 });
-    if (!verify.match || !verify.responder) return null;
-    return verify.responder;
-}
-
-async function ensureUser(did: string): Promise<User> {
-    const now = new Date().toISOString();
-    const existingUser = await db.getUser(did);
-    if (existingUser) {
-        return existingUser;
-    }
-    const user = { firstLogin: now, lastLogin: now, logins: 1 };
-    await db.setUser(did, user);
-    return user;
-}
-
-async function findNameDid(name: string): Promise<string | null> {
-    return db.findDidByName(name);
-}
-
-async function listUsers(): Promise<Record<string, User>> {
-    return db.listUsers();
-}
-
-function buildRegistry(users: Record<string, User>): { version: number; updated: string; names: Record<string, string> } {
-    const names: Record<string, string> = {};
-
-    for (const [did, user] of Object.entries(users)) {
-        if (user.name) {
-            names[user.name] = did;
-        }
-    }
-
-    return {
-        version: 1,
-        updated: new Date().toISOString(),
-        names,
-    };
-}
-
-async function resolveLightningEndpoint(name: string): Promise<{ did: string; endpoint: string } | null> {
-    const did = await findNameDid(name);
-    if (!did) return null;
-
-    const didDoc: any = await keymaster.resolveDID(did);
-    if (!didDoc?.didDocument?.service) return null;
-
-    const lightning = didDoc.didDocument.service.find(
-        (s: any) => s.type === 'Lightning' || s.id?.endsWith('#lightning')
-    );
-    if (!lightning?.serviceEndpoint) return null;
-
-    return { did, endpoint: lightning.serviceEndpoint };
-}
-
-async function resolveAvatarImage(name: string): Promise<{
-    did: string;
-    avatarDid: string;
-    file: {
-        data: Buffer;
-        type: string;
-        filename?: string;
-        bytes?: number;
-    };
-} | null> {
-    const did = await findNameDid(name);
-    if (!did) return null;
-
-    const memberDoc: any = await keymaster.resolveDID(did);
-    const avatarDid = typeof memberDoc?.didDocumentData?.avatar === 'string'
-        ? memberDoc.didDocumentData.avatar.trim()
-        : '';
-
-    if (!avatarDid) return null;
-
-    const image = await keymaster.getImage(avatarDid);
-    const data = image?.file?.data ?? null;
-
-    if (!data || !Buffer.isBuffer(data) || !image?.file?.type || !image.image) {
-        return null;
-    }
-
-    return {
-        did,
-        avatarDid,
-        file: {
-            ...image.file,
-            data,
-        },
-    };
-}
-
-function getSafeAvatarContentType(contentType: string): string {
-    const normalizedType = contentType.trim().toLowerCase();
-    const allowedAvatarContentTypes = new Set([
-        'image/avif',
-        'image/gif',
-        'image/jpeg',
-        'image/jpg',
-        'image/png',
-        'image/webp',
-    ]);
-
-    return allowedAvatarContentTypes.has(normalizedType)
-        ? normalizedType
-        : 'application/octet-stream';
-}
-
-function isAuthenticated(req: Request, res: Response, next: NextFunction): void {
-    if (!req.session.user && req.session.challenge) {
-        const challengeData = logins[req.session.challenge];
-        if (challengeData) {
-            req.session.user = { did: challengeData.did };
-        }
-    }
-
-    if (req.session.user) {
-        return next();
-    }
-    res.status(401).send('You need to log in first');
-}
-
-function isOwner(req: Request, res: Response, next: NextFunction): void {
-    isAuthenticated(req, res, () => {
-        const userDid = req.session.user?.did;
-        if (userDid === OWNER_DID) {
-            return next();
-        }
-        res.status(403).send('Owner access required');
-    });
-}
-
-async function loginUser(response: string): Promise<any> {
-    const verify = await keymaster.verifyResponse(response, { retries: 10 });
-
-    if (verify.match) {
-        const challenge = verify.challenge;
-        const did = verify.responder!;
-        const now = new Date().toISOString();
-        const user = await db.getUser(did);
-
-        if (user) {
-            user.lastLogin = now;
-            user.logins = (user.logins || 0) + 1;
-            await db.setUser(did, user);
-        } else {
-            await db.setUser(did, {
-                firstLogin: now,
-                lastLogin: now,
-                logins: 1,
-            });
-        }
-
-        logins[challenge] = {
-            response,
-            challenge,
-            did,
-            verify,
-        };
-    }
-
-    return verify;
-}
-
-const corsOptions = {
-    origin: true,
-    methods: ['GET', 'POST', 'PUT', 'DELETE'],
-    credentials: true,
-    optionsSuccessStatus: 200
-};
-
-app.use(cors(corsOptions));
-
-app.options('/api/{*path}', cors(corsOptions));
-app.options('/.well-known/{*path}', cors(corsOptions));
-
-// Helper function for OAuth
-async function getMemberByDID(did: string): Promise<any> {
-    const user = await db.getUser(did);
-    if (user) {
-        return {
-            ...user,
-            did,
-            handle: user.name
-        };
-    }
-    return null;
-}
-
-// Mount OAuth routes (keymaster accessed lazily)
-const oauthRouter = createOAuthRoutes(() => keymaster, getMemberByDID);
-app.use('/oauth', oauthRouter);
-console.log('OAuth routes mounted at /oauth');
-
-// OIDC Discovery at root level (required by spec)
-app.get('/.well-known/openid-configuration', (_req: Request, res: Response) => {
-    const issuer = PUBLIC_URL;
-    res.json({
-        issuer,
-        authorization_endpoint: `${issuer}/oauth/authorize`,
-        token_endpoint: `${issuer}/oauth/token`,
-        userinfo_endpoint: `${issuer}/oauth/userinfo`,
-        response_types_supported: ['code'],
-        subject_types_supported: ['public'],
-        id_token_signing_alg_values_supported: ['ES256'],
-        scopes_supported: ['openid', 'profile'],
-        claims_supported: ['sub', 'name', 'preferred_username', 'picture']
-    });
-});
-
-app.get('/api/version', async (_: Request, res: Response) => {
-    try {
-        res.json(1);
-    } catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-app.get('/api/config', (_: Request, res: Response) => {
-    res.json({
-        serviceName: SERVICE_NAME,
-        serviceDID,
-        ...(SENDGRID_API_KEY ? { relayAgent: serviceDID } : {}),
-        serviceDomain: SERVICE_DOMAIN,
-        publicUrl: PUBLIC_URL,
-        walletUrl: WALLET_URL,
-    });
-});
-
-app.get('/api/challenge', async (req: Request, res: Response) => {
-    try {
-        const challenge = await keymaster.createChallenge({
-            // @ts-ignore
-            callback: `${PUBLIC_URL}/api/login`
-        });
-        req.session.challenge = challenge;
-        const challengeURL = `${WALLET_URL}?challenge=${challenge}`;
-
-        const doc = await keymaster.resolveDID(challenge);
-        console.log(JSON.stringify(doc, null, 4));
-        res.json({ challenge, challengeURL });
-    } catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-// Email bridge: inbound email webhook (SendGrid Inbound Parse)
-const inboundEmailUpload = multer();
-app.post('/api/inbound-email', inboundEmailUpload.none(), async (req: Request, res: Response) => {
-    try {
-        if (!emailBridge?.isConfigured()) {
-            res.status(404).json({ error: 'Email bridge not configured' });
-            return;
-        }
-
-        // Verify webhook authenticity via query parameter token
-        if (WEBHOOK_SECRET && req.query.secret !== WEBHOOK_SECRET) {
-            console.warn('Inbound email webhook rejected: invalid or missing secret');
-            res.status(401).json({ error: 'Unauthorized' });
-            return;
-        }
-
-        const email = emailBridge.parseInboundEmail(req.body);
-        if (!email) {
-            console.warn('Inbound email missing required fields');
-            res.status(400).json({ error: 'Missing from or to fields' });
-            return;
-        }
-
-        const spamScore = parseFloat(email.spam_score || '0');
-        if (spamScore > 5) {
-            console.warn(`Inbound email rejected: spam score ${spamScore} from ${email.from}`);
-            res.status(200).json({ ok: true, action: 'spam-rejected' });
-            return;
-        }
-
-        const token = emailBridge.extractReplyToken(email.to);
-        if (token) {
-            const tokenData = await emailBridge.lookupToken(token);
-            if (!tokenData) {
-                console.warn(`Inbound email with expired/unknown token from ${email.from}`);
-                res.status(200).json({ ok: true, action: 'token-expired' });
-                return;
-            }
-
-            // Reply to an outbound email: create dmail to original sender
-            const replyFromEmail = emailBridge.extractEmailAddress(email.from) || email.from;
-            await keymaster.setCurrentId(SERVICE_NAME);
-            const dmailMessage = {
-                to: [tokenData.senderDid],
-                cc: [] as string[],
-                subject: `[email from ${replyFromEmail}] ${email.subject}`,
-                body: email.text || '(no text content)',
-                reference: tokenData.originalDmailDid,
-            };
-            const dmailDid = await keymaster.createDmail(dmailMessage, { registry: 'hyperswarm' });
-            const noticeDid = await keymaster.sendDmail(dmailDid);
-
-            await emailBridge.storeEmailMapping(dmailDid, replyFromEmail, tokenData.senderDid);
-            console.log(`Inbound email from ${email.from} → dmail ${dmailDid} to ${tokenData.senderDid} (notice: ${noticeDid})`);
-            res.status(200).json({ ok: true, action: 'delivered', dmailDid });
-            return;
-        }
-
-        // No reply token — try to resolve recipient as a Herald name
-        const recipientName = emailBridge.extractRecipientName(email.to);
-        if (!recipientName) {
-            console.warn(`Inbound email with no recognizable recipient from ${email.from} to ${email.to}`);
-            res.status(200).json({ ok: true, action: 'no-recipient-ignored' });
-            return;
-        }
-
-        const recipientDid = await db.findDidByName(recipientName);
-        if (!recipientDid) {
-            console.warn(`Inbound email to unknown Herald name "${recipientName}" from ${email.from}`);
-            res.status(200).json({ ok: true, action: 'unknown-name-ignored' });
-            return;
-        }
-
-        // Unsolicited inbound: create dmail from Herald to the named recipient
-        const senderEmail = emailBridge.extractEmailAddress(email.from) || email.from;
-        await keymaster.setCurrentId(SERVICE_NAME);
-        const dmailMessage = {
-            to: [recipientDid],
-            cc: [] as string[],
-            subject: `[email from ${senderEmail}] ${email.subject}`,
-            body: email.text || '(no text content)',
-        };
-        const dmailDid = await keymaster.createDmail(dmailMessage, { registry: 'hyperswarm' });
-        const noticeDid = await keymaster.sendDmail(dmailDid);
-
-        await emailBridge.storeEmailMapping(dmailDid, senderEmail, recipientDid);
-        console.log(`Inbound email from ${email.from} → dmail ${dmailDid} to ${recipientName} (${recipientDid}) (notice: ${noticeDid})`);
-        res.status(200).json({ ok: true, action: 'delivered', dmailDid });
-    } catch (error) {
-        console.error('Error processing inbound email:', error);
-        res.status(200).json({ ok: true, action: 'error' });
-    }
-});
-
-// Email bridge: send email (authenticated)
-app.post('/api/send-email', async (req: Request, res: Response) => {
-    try {
-        if (!emailBridge?.isConfigured()) {
-            res.status(404).json({ error: 'Email bridge not configured' });
-            return;
-        }
-
-        const senderDid = await verifyBearerToken(req);
-        if (!senderDid) {
-            res.status(401).json({ error: 'Authentication required' });
-            return;
-        }
-
-        const user = await db.getUser(senderDid);
-        if (!user?.name) {
-            res.status(403).json({ error: 'Herald name required to send email' });
-            return;
-        }
-
-        const { to, subject, body, dmailDid } = req.body;
-        if (!to || !subject || !body || !dmailDid) {
-            res.status(400).json({ error: 'Missing required fields: to, subject, body, dmailDid' });
-            return;
-        }
-
-        const result = await emailBridge.sendEmail({
-            to,
-            subject,
-            body,
-            senderName: user.name,
-            senderDid,
-            dmailDid,
-        });
-
-        console.log(`Email sent by ${user.name} (${senderDid}) to ${to}`);
-        res.json({ ok: true, token: result.token });
-    } catch (error) {
-        console.error('Error sending email:', error);
-        res.status(500).json({ error: 'Failed to send email' });
-    }
-});
-
-app.get('/api/login', cors(corsOptions), async (req: Request, res: Response) => {
-    try {
-        const { response } = req.query;
-        if (typeof response !== 'string') {
-            res.status(400).json({ error: 'Missing or invalid response param' });
-            return;
-        }
-        const verify = await loginUser(response);
-        if (!verify.challenge) {
-            res.json({ authenticated: false });
-            return;
-        }
-        req.session.user = {
-            did: verify.responder
-        };
-        res.json({ authenticated: verify.match });
-    } catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-app.post('/api/login', cors(corsOptions), async (req: Request, res: Response) => {
-    try {
-        const { response } = req.body;
-        const verify = await loginUser(response);
-        if (!verify.challenge) {
-            res.json({ authenticated: false });
-            return;
-        }
-        req.session.user = {
-            did: verify.responder
-        };
-        res.json({ authenticated: verify.match });
-    } catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-app.post('/api/logout', async (req: Request, res: Response) => {
-    try {
-        req.session.destroy(err => {
-            if (err) {
-                console.log(err);
-            }
-        });
-        res.json({ ok: true });
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-app.get('/api/check-auth', async (req: Request, res: Response) => {
-    try {
-        if (!req.session.user && req.session.challenge) {
-            const challengeData = logins[req.session.challenge];
-            if (challengeData) {
-                req.session.user = { did: challengeData.did };
-            }
-        }
-
-        const isAuthenticated = !!req.session.user;
-        const userDID = isAuthenticated ? req.session.user?.did : null;
-        let profile: any = null;
-
-        if (isAuthenticated && userDID) {
-            profile = await db.getUser(userDID);
-        }
-
-        const auth = {
-            isAuthenticated,
-            userDID,
-            isOwner: isAuthenticated && userDID === OWNER_DID,
-            profile,
-        };
-
-        res.json(auth);
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-app.get('/api/users', isAuthenticated, async (_: Request, res: Response) => {
-    try {
-        const users = Object.keys(await listUsers());
-        res.json(users);
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-app.get('/api/admin', isOwner, async (_: Request, res: Response) => {
-    try {
-        res.json({ users: await listUsers() });
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-// Publish registry to IPFS and update IPNS
-app.post('/api/admin/publish', isOwner, async (_: Request, res: Response) => {
-    try {
-        // Build registry from DB
-        const registry = buildRegistry(await listUsers());
-
-        const registryJson = JSON.stringify(registry, null, 2);
-
-        // Add to IPFS
-        const formData = new FormData();
-        formData.append('file', new Blob([registryJson], { type: 'application/json' }), 'registry.json');
-
-        const addResponse = await fetch(`${IPFS_API_URL}/add?pin=true`, {
-            method: 'POST',
-            body: formData
-        });
-
-        if (!addResponse.ok) {
-            throw new Error(`IPFS add failed: ${addResponse.statusText}`);
-        }
-
-        const addResult = await addResponse.json();
-        const cid = addResult.Hash;
-
-        console.log(`Registry added to IPFS: ${cid}`);
-
-        // Publish to IPNS
-        const publishResponse = await fetch(
-            `${IPFS_API_URL}/name/publish?arg=/ipfs/${cid}&key=${IPNS_KEY_NAME}`,
-            { method: 'POST' }
-        );
-
-        if (!publishResponse.ok) {
-            throw new Error(`IPNS publish failed: ${publishResponse.statusText}`);
-        }
-
-        const publishResult = await publishResponse.json();
-
-        console.log(`Registry published to IPNS: ${publishResult.Name}`);
-
-        res.json({
-            ok: true,
-            cid,
-            ipns: publishResult.Name,
-            registry
-        });
-    }
-    catch (error: any) {
-        console.log(error);
-        res.status(500).json({ ok: false, error: error.message || String(error) });
-    }
-});
-
-app.get('/api/profile/:did', isAuthenticated, async (req: Request, res: Response) => {
-    try {
-        const did = req.params.did as string;
-        const user = await db.getUser(did);
-        if (!user) {
-            res.status(404).send('Not found');
-            return;
-        }
-
-        const profile: User = { ...user };
-
-        profile.did = did;
-        profile.isUser = (req.session?.user?.did === did);
-
-        res.json(profile);
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-app.get('/api/profile/:did/name', isAuthenticated, async (req: Request, res: Response) => {
-    try {
-        const did = req.params.did as string;
-        const user = await db.getUser(did);
-        if (!user) {
-            res.status(404).send('Not found');
-            return;
-        }
-
-        res.json({ name: user.name });
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-app.put('/api/profile/:did/name', isAuthenticated, async (req: Request, res: Response) => {
-    try {
-        const did = req.params.did as string;
-
-        if (!req.session.user || req.session.user.did !== did) {
-            res.status(403).json({ message: 'Forbidden' });
-            return;
-        }
-
-        const validation = validateName(req.body.name);
-        if (!validation.ok) {
-            res.status(400).json({ ok: false, message: validation.message });
-            return;
-        }
-        const trimmedName = validation.trimmedName!;
-
-        const user = await db.getUser(did);
-        if (!user) {
-            res.status(404).send('Not found');
-            return;
-        }
-
-        if (!(await checkNameAvailability(trimmedName, did))) {
-            res.status(409).json({ ok: false, message: 'Name already taken' });
-            return;
-        }
-
-        user.name = trimmedName;
-        await issueOrUpdateCredential(did, user, trimmedName);
-        await db.setUser(did, user);
-
-        res.json({ ok: true, message: `name set to ${trimmedName}` });
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-// Delete name and revoke credential (session-based)
-app.delete('/api/profile/:did/name', isAuthenticated, async (req: Request, res: Response) => {
-    try {
-        const did = req.params.did as string;
-
-        if (!req.session.user || req.session.user.did !== did) {
-            res.status(403).json({ message: 'Forbidden' });
-            return;
-        }
-
-        const user = await db.getUser(did);
-        if (!user) {
-            res.status(404).send('Not found');
-            return;
-        }
-
-        const deletedName = user.name;
-
-        await revokeCredential(user, deletedName || '');
-        delete user.name;
-        await db.setUser(did, user);
-
-        res.json({ ok: true, message: `name '${deletedName}' deleted and credential revoked` });
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-// Stateless name claim (Bearer token auth)
-app.put('/api/name', async (req: Request, res: Response) => {
-    try {
-        const did = await verifyBearerToken(req);
-        if (!did) {
-            res.status(401).json({ ok: false, message: 'Valid Bearer token (response DID) required' });
-            return;
-        }
-
-        const validation = validateName(req.body.name);
-        if (!validation.ok) {
-            res.status(400).json({ ok: false, message: validation.message });
-            return;
-        }
-        const trimmedName = validation.trimmedName!;
-
-        const user = await ensureUser(did);
-
-        if (!(await checkNameAvailability(trimmedName, did))) {
-            res.status(409).json({ ok: false, message: 'Name already taken' });
-            return;
-        }
-
-        user.name = trimmedName;
-        await issueOrUpdateCredential(did, user, trimmedName);
-        await db.setUser(did, user);
-
-        let credential = null;
-        if (user.credentialDid) {
-            credential = await keymaster.getCredential(user.credentialDid);
-        }
-
-        res.json({
-            ok: true,
-            name: trimmedName,
-            did,
-            credentialDid: user.credentialDid,
-            credentialIssuedAt: user.credentialIssuedAt,
-            credential,
-        });
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-// Stateless name delete (Bearer token auth)
-app.delete('/api/name', async (req: Request, res: Response) => {
-    try {
-        const did = await verifyBearerToken(req);
-        if (!did) {
-            res.status(401).json({ ok: false, message: 'Valid Bearer token (response DID) required' });
-            return;
-        }
-
-        const user = await db.getUser(did);
-        if (!user) {
-            res.status(404).json({ ok: false, message: 'User not found' });
-            return;
-        }
-
-        const deletedName = user.name;
-
-        if (!deletedName) {
-            res.status(404).json({ ok: false, message: 'No name to delete' });
-            return;
-        }
-
-        await revokeCredential(user, deletedName);
-        delete user.name;
-        await db.setUser(did, user);
-
-        res.json({ ok: true, message: `name '${deletedName}' deleted and credential revoked` });
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-// Export name registry for IPNS publication
-app.get('/api/registry', async (_: Request, res: Response) => {
-    try {
-        res.json(buildRegistry(await listUsers()));
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-// Resolve a name to a DID
-app.get('/api/name/:name', async (req: Request, res: Response) => {
-    try {
-        const name = (req.params.name as string).trim().toLowerCase();
-        const did = await findNameDid(name);
-        if (did) {
-            res.json({ name, did });
-            return;
-        }
-
-        res.status(404).json({ error: 'Name not found' });
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-// Public directory.json - same as /api/registry for IPNS compatibility
-app.get('/directory.json', async (_: Request, res: Response) => {
-    try {
-        res.json(buildRegistry(await listUsers()));
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-// Resolve a member name to their DID document
-// Public API endpoint for member lookup
-app.get('/api/member/:name', async (req: Request, res: Response) => {
-    try {
-        const name = (req.params.name as string).trim().toLowerCase();
-        const memberDid = await findNameDid(name);
-        if (!memberDid) {
-            res.status(404).json({ error: 'Name not found', name });
-            return;
-        }
-
-        // Fetch DID document from gatekeeper
-        const didDoc = await keymaster.resolveDID(memberDid);
-
-        res.json(didDoc);
-    }
-    catch (error: any) {
-        console.log(error);
-        res.status(500).json({ error: error.message || String(error) });
-    }
-});
-
-// Resolve a member name to their avatar image
-app.get('/api/name/:name/avatar', async (req: Request, res: Response) => {
-    try {
-        const name = (req.params.name as string).trim().toLowerCase();
-        const avatar = await resolveAvatarImage(name);
-
-        if (!avatar) {
-            res.status(404).json({ error: 'Avatar not found', name });
-            return;
-        }
-
-        res.set('X-Content-Type-Options', 'nosniff');
-        res.set('Content-Type', getSafeAvatarContentType(avatar.file.type));
-        res.set('Content-Length', String(avatar.file.data.length));
-        if (avatar.file.filename) {
-            res.set('Content-Disposition', `inline; filename="${encodeURIComponent(avatar.file.filename)}"`);
-        }
-
-        res.send(avatar.file.data);
-    }
-    catch (error: any) {
-        console.log(error);
-        res.status(500).json({ error: error.message || String(error) });
-    }
-});
-
-
-// Admin: Delete a user
-app.delete('/api/admin/user/:did', isOwner, async (req: Request, res: Response) => {
-    try {
-        const did = decodeURIComponent(req.params.did as string);
-        const user = await db.getUser(did);
-        if (!user) {
-            res.status(404).json({ error: 'User not found' });
-            return;
-        }
-
-        // Don't allow deleting the owner
-        if (did === OWNER_DID) {
-            res.status(403).json({ error: 'Cannot delete the owner account' });
-            return;
-        }
-
-        const userName = user.name || did;
-        await db.deleteUser(did);
-
-        console.log(`Deleted user ${userName} (${did})`);
-        res.json({ ok: true, message: `User ${userName} deleted` });
-    }
-    catch (error: any) {
-        console.log(error);
-        res.status(500).json({ error: error.message || String(error) });
-    }
-});
-
-// Get member's credential
-app.get('/api/credential', isAuthenticated, async (req: Request, res: Response) => {
-    try {
-        const userDid = req.session.user?.did;
-        if (!userDid) {
-            res.status(401).json({ error: 'Not authenticated' });
-            return;
-        }
-
-        const user = await db.getUser(userDid);
-
-        if (!user) {
-            res.status(404).json({ error: 'User not found' });
-            return;
-        }
-
-        if (!user.credentialDid) {
-            res.json({
-                hasCredential: false,
-                name: user.name || null,
-                message: 'No credential issued yet'
-            });
-            return;
-        }
-
-        // Fetch the credential
-        const credential = await keymaster.getCredential(user.credentialDid);
-
-        res.json({
-            hasCredential: true,
-            credentialDid: user.credentialDid,
-            credentialIssuedAt: user.credentialIssuedAt,
-            credential
-        });
-    }
-    catch (error: any) {
-        console.log(error);
-        const errorMsg = error?.message || error?.error || (typeof error === 'string' ? error : JSON.stringify(error));
-        res.status(500).json({ error: errorMsg });
-    }
-});
-
-
-// LUD16 Lightning Address support
-const LN_MIN_SENDABLE = 1000;        // 1 sat in msats
-const LN_MAX_SENDABLE = 100000000000; // 100k sats in msats
-
-app.get('/.well-known/lnurlp/:name', async (req: Request, res: Response) => {
-    try {
-        const name = (req.params.name as string).trim().toLowerCase();
-        const result = await resolveLightningEndpoint(name);
-
-        if (!result) {
-            res.json({ status: 'ERROR', reason: 'No Lightning service found for this name' });
-            return;
-        }
-
-        const metadata = JSON.stringify([
-            ['text/plain', `Payment to ${name}@${SERVICE_DOMAIN}`],
-            ['text/identifier', `${name}@${SERVICE_DOMAIN}`]
-        ]);
-
-        res.json({
-            tag: 'payRequest',
-            callback: `${PUBLIC_URL}/api/lnurlp/${name}/callback`,
-            minSendable: LN_MIN_SENDABLE,
-            maxSendable: LN_MAX_SENDABLE,
-            metadata,
-        });
-    }
-    catch (error: any) {
-        console.log(error);
-        res.json({ status: 'ERROR', reason: error.message || 'Internal error' });
-    }
-});
-
-app.get('/api/lnurlp/:name/callback', async (req: Request, res: Response) => {
-    try {
-        const name = (req.params.name as string).trim().toLowerCase();
-        const amount = parseInt(req.query.amount as string, 10);
-
-        if (!amount || amount < LN_MIN_SENDABLE || amount > LN_MAX_SENDABLE) {
-            res.json({ status: 'ERROR', reason: `Amount must be between ${LN_MIN_SENDABLE} and ${LN_MAX_SENDABLE} msats` });
-            return;
-        }
-
-        const result = await resolveLightningEndpoint(name);
-        if (!result) {
-            res.json({ status: 'ERROR', reason: 'No Lightning service found for this name' });
-            return;
-        }
-
-        // LUD16 amount is in millisatoshis, convert to satoshis for Lightning endpoint
-        const amountSats = Math.floor(amount / 1000);
-        const invoiceUrl = `${result.endpoint}?amount=${amountSats}`;
-        const fetchOptions: any = {};
-
-        if (result.endpoint.includes('.onion') && TOR_PROXY) {
-            const [host, port] = TOR_PROXY.split(':');
-            fetchOptions.dispatcher = socksDispatcher({
-                type: 5,
-                host: host || 'localhost',
-                port: parseInt(port || '9050'),
-            });
-        }
-
-        const response = await fetch(invoiceUrl, fetchOptions);
-        if (!response.ok) {
-            res.json({ status: 'ERROR', reason: 'Lightning service returned an error' });
-            return;
-        }
-
-        const data: any = await response.json();
-
-        // Normalize to LUD06 format (pr + routes)
-        res.json({
-            pr: data.pr || data.paymentRequest,
-            routes: data.routes || [],
-        });
-    }
-    catch (error: any) {
-        console.log(error);
-        res.json({ status: 'ERROR', reason: error.message || 'Internal error' });
-    }
-});
-
-// ── Well-Known Endpoints (Issue #4) ─────────────────────────────────
-
-// GET /.well-known/names — list/directory of registered names
-app.get('/.well-known/names', async (_: Request, res: Response) => {
-    try {
-        res.json(buildRegistry(await listUsers()));
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-// GET /.well-known/names/:name — resolve a name to a DID
-app.get('/.well-known/names/:name', async (req: Request, res: Response) => {
-    try {
-        const name = (req.params.name as string).trim().toLowerCase();
-        const did = await findNameDid(name);
-
-        if (!did) {
-            res.status(404).json({ error: 'Name not found' });
-            return;
-        }
-
-        res.json({ name, did });
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-// GET /.well-known/webfinger — RFC 7033 WebFinger discovery
-app.get('/.well-known/webfinger', async (req: Request, res: Response) => {
-    try {
-        const resource = req.query.resource as string;
-
-        if (!resource) {
-            res.status(400).json({ error: 'Missing required "resource" query parameter' });
-            return;
-        }
-
-        // Parse acct: URI — expect "acct:name@domain"
-        const acctMatch = resource.match(/^acct:([^@]+)@(.+)$/);
-        if (!acctMatch) {
-            res.status(400).json({ error: 'Resource must be in "acct:name@domain" format' });
-            return;
-        }
-
-        const [, name, domain] = acctMatch;
-
-        // Verify the domain matches this service
-        if (SERVICE_DOMAIN && domain !== SERVICE_DOMAIN) {
-            res.status(404).json({ error: 'Unknown domain' });
-            return;
-        }
-
-        const did = await findNameDid(name);
-        if (!did) {
-            res.status(404).json({ error: 'Name not found' });
-            return;
-        }
-
-        const jrd: any = {
-            subject: resource,
-            aliases: [did],
-            links: [
-                {
-                    rel: 'self',
-                    type: 'application/activity+json',
-                    href: `${PUBLIC_URL}/api/name/${name}`,
-                },
-                {
-                    rel: 'http://webfinger.net/rel/profile-page',
-                    type: 'text/html',
-                    href: `${PUBLIC_URL}/name/${name}`,
-                },
-                {
-                    rel: 'https://w3id.org/did',
-                    type: 'application/json',
-                    href: `https://${SERVICE_DOMAIN}/api/v1/did/${did}`,
-                },
-                {
-                    rel: 'http://webfinger.net/rel/avatar',
-                    href: `${PUBLIC_URL}/api/name/${name}/avatar`,
-                },
-            ],
-        };
-
-        res.set('Content-Type', 'application/jrd+json');
-        res.json(jrd);
-    }
-    catch (error) {
-        console.log(error);
-        res.status(500).send(String(error));
-    }
-});
-
-process.on('uncaughtException', (error) => {
-    console.error('Unhandled exception caught', error);
-});
-
-process.on('unhandledRejection', (reason, promise) => {
-    console.error('Unhandled rejection at:', promise, 'reason:', reason);
-});
-
-const DMAIL_POLL_INTERVAL_MS = 60_000; // 1 minute
-
-async function pollDmailForEmail(): Promise<void> {
-    if (!emailBridge?.isConfigured()) return;
-
-    try {
-        await keymaster.setCurrentId(SERVICE_NAME);
-        await keymaster.refreshNotices();
-
-        const dmails = await keymaster.listDmail();
-        for (const [dmailDid, item] of Object.entries(dmails)) {
-            if (!item.tags.includes('unread')) continue;
-
-            // Resolve sender info (shared by both paths)
-            const rawSender = typeof item.sender === 'string' ? item.sender : 'Unknown';
-            const isDid = rawSender.startsWith('did:');
-            let senderName: string;
-            let fromEmail: string;
-
-            if (isDid) {
-                const senderUser = await db.getUser(rawSender);
-                if (senderUser?.name) {
-                    senderName = senderUser.name;
-                    fromEmail = `${senderName}@${SERVICE_DOMAIN}`;
-                } else {
-                    senderName = 'dmail-user';
-                    fromEmail = SENDGRID_FROM_EMAIL;
-                }
-            } else {
-                senderName = rawSender;
-                fromEmail = `${senderName}@${SERVICE_DOMAIN}`;
-            }
-
-            // Path 1: Reply to a bridged email (has reference matching a stored mapping)
-            if (item.message.reference) {
-                const mapping = await emailBridge.lookupEmailMapping(item.message.reference);
-                if (mapping) {
-                    await emailBridge.sendEmail({
-                        to: mapping.emailAddress,
-                        subject: item.message.subject,
-                        body: item.message.body,
-                        senderName,
-                        senderDid: mapping.recipientDid,
-                        dmailDid,
-                        fromEmail,
-                    });
-                    await keymaster.fileDmail(dmailDid, ['inbox']);
-                    console.log(`Forwarded reply dmail ${dmailDid} from ${senderName} to ${mapping.emailAddress}`);
-                    continue;
-                }
-            }
-
-            // Path 2: Compose new email via "[email to addr] subject" convention
-            if (serviceDID && (item.message.to.includes(serviceDID) || item.message.cc.includes(serviceDID))) {
-                const emailToMatch = item.message.subject.match(/^\[email to ([^\]]+)\]\s*(.*)/i);
-                if (emailToMatch) {
-                    const toEmail = emailToMatch[1].trim();
-                    const realSubject = emailToMatch[2] || '(no subject)';
-
-                    await emailBridge.sendEmail({
-                        to: toEmail,
-                        subject: realSubject,
-                        body: item.message.body,
-                        senderName,
-                        senderDid: rawSender,
-                        dmailDid,
-                        fromEmail,
-                    });
-                    await keymaster.fileDmail(dmailDid, ['inbox']);
-                    console.log(`Composed email from ${senderName} to ${toEmail}: ${realSubject}`);
-                    continue;
-                }
-            }
-        }
-    } catch (error) {
-        console.error('Dmail poll error:', error);
-    }
-}
-
-let dmailPollInFlight = false;
-
-function startDmailPollLoop(): void {
-    console.log(`${SERVICE_NAME} dmail poll loop started (interval: ${DMAIL_POLL_INTERVAL_MS / 1000}s)`);
-
-    const runPoll = async () => {
-        if (dmailPollInFlight) return;
-        dmailPollInFlight = true;
-        try {
-            await pollDmailForEmail();
-        } finally {
-            dmailPollInFlight = false;
-        }
-    };
-
-    // Initial poll after a short delay to let startup finish
-    setTimeout(() => {
-        runPoll();
-        setInterval(runPoll, DMAIL_POLL_INTERVAL_MS);
-    }, 5000);
-}
-
 app.listen(HOST_PORT, '0.0.0.0', async () => {
     if (HERALD_DATABASE_TYPE === 'sqlite') {
-        db = new DbSqlite(path.join(DATA_DIR, 'db.sqlite'));
+        ctx.db = new DbSqlite(path.join(DATA_DIR, 'db.sqlite'));
     } else if (HERALD_DATABASE_TYPE === 'redis') {
-        db = new DbRedis(SERVICE_NAME);
+        ctx.db = new DbRedis(SERVICE_NAME);
     } else {
-        db = new DbJson(path.join(DATA_DIR, 'db.json'));
+        ctx.db = new DbJson(path.join(DATA_DIR, 'db.json'));
     }
 
-    if (db.init) {
+    if (ctx.db.init) {
         try {
-            await db.init();
+            await ctx.db.init();
         } catch (e: any) {
             console.error(`Error initialising database: ${e.message}`);
             process.exit(1);
@@ -1427,8 +163,8 @@ app.listen(HOST_PORT, '0.0.0.0', async () => {
     const keymasterUrl = process.env.ARCHON_HERALD_KEYMASTER_URL?.trim();
 
     if (keymasterUrl) {
-        keymaster = new KeymasterClient();
-        await keymaster.connect({
+        ctx.keymaster = new KeymasterClient();
+        await ctx.keymaster.connect({
             url: keymasterUrl,
             waitUntilReady: true,
             intervalSeconds: 5,
@@ -1455,7 +191,7 @@ app.listen(HOST_PORT, '0.0.0.0', async () => {
         });
         const wallet = new WalletJson('wallet.json', DATA_DIR);
         const cipher = new CipherNode();
-        keymaster = new Keymaster({
+        ctx.keymaster = new Keymaster({
             gatekeeper,
             wallet,
             cipher,
@@ -1463,7 +199,7 @@ app.listen(HOST_PORT, '0.0.0.0', async () => {
         });
 
         // Load existing wallet (decrypt and restore IDs/aliases)
-        await keymaster.loadWallet();
+        await ctx.keymaster.loadWallet();
         console.log(`${SERVICE_NAME} using gatekeeper at ${GATEKEEPER_URL}`);
     }
 
@@ -1473,12 +209,12 @@ app.listen(HOST_PORT, '0.0.0.0', async () => {
     // Initialize email bridge if SendGrid is configured
     if (SENDGRID_API_KEY) {
         const emailService = new SendGridEmailService(SENDGRID_API_KEY);
-        emailBridge = new EmailBridge({
+        ctx.emailBridge = new EmailBridge({
             domain: SERVICE_DOMAIN,
             parseDomain: SENDGRID_PARSE_DOMAIN,
             fromEmail: SENDGRID_FROM_EMAIL,
             fromName: SERVICE_NAME,
-        }, db, emailService);
+        }, ctx.db, emailService);
         console.log(`${SERVICE_NAME} email bridge enabled (from: ${SENDGRID_FROM_EMAIL}, parse: ${SENDGRID_PARSE_DOMAIN})`);
         startDmailPollLoop();
     } else {

--- a/services/herald/server/src/routes.ts
+++ b/services/herald/server/src/routes.ts
@@ -1,0 +1,1302 @@
+import express, { NextFunction, Request, Response } from 'express';
+import cors from 'cors';
+import { socksDispatcher } from 'fetch-socks';
+import multer from 'multer';
+
+import type Keymaster from '@didcid/keymaster';
+import type KeymasterClient from '@didcid/clients/keymaster';
+import type { DatabaseInterface, User } from './db/interfaces.js';
+import type { EmailBridge } from './email-bridge.js';
+import { createOAuthRoutes } from './oauth/index.js';
+import {
+    IPFS_API_URL,
+    IPNS_KEY_NAME,
+    MEMBERSHIP_SCHEMA_DID,
+    OWNER_DID,
+    PUBLIC_URL,
+    SENDGRID_API_KEY,
+    SENDGRID_FROM_EMAIL,
+    SERVICE_DOMAIN,
+    SERVICE_NAME,
+    TOR_PROXY,
+    WALLET_URL,
+    WEBHOOK_SECRET,
+} from './config.js';
+
+// Mutable state owned by the bootstrap in index.ts. Routes read it through this
+// object because it is populated after the routes are registered.
+export interface HeraldContext {
+    keymaster: Keymaster | KeymasterClient;
+    db: DatabaseInterface;
+    emailBridge: EmailBridge | null;
+    serviceDID: string;
+}
+
+export function createHeraldRoutes(ctx: HeraldContext): {
+    router: express.Router;
+    startDmailPollLoop: () => void;
+} {
+    const router = express.Router();
+    const logins: Record<string, {
+        response: string;
+        challenge: string;
+        did: string;
+        verify: any;
+    }> = {};
+
+    function validateName(name: any): { ok: boolean; trimmedName?: string; message?: string } {
+        if (!name || typeof name !== 'string') {
+            return { ok: false, message: 'Name is required' };
+        }
+        const trimmedName = name.trim().toLowerCase();
+        if (trimmedName.length < 3 || trimmedName.length > 32) {
+            return { ok: false, message: 'Name must be 3-32 characters' };
+        }
+        if (!/^[a-z0-9_-]+$/.test(trimmedName)) {
+            return { ok: false, message: 'Name can only contain letters, numbers, hyphens, and underscores' };
+        }
+        return { ok: true, trimmedName };
+    }
+
+    async function checkNameAvailability(trimmedName: string, excludeDid?: string): Promise<boolean> {
+        const existingDid = await ctx.db.findDidByName(trimmedName);
+        return !existingDid || existingDid === excludeDid;
+    }
+
+    async function issueOrUpdateCredential(did: string, user: any, trimmedName: string): Promise<void> {
+        if (!MEMBERSHIP_SCHEMA_DID) {
+            console.warn(`Skipping credential issuance for ${trimmedName}: ARCHON_HERALD_MEMBERSHIP_SCHEMA_DID is not set`);
+            return;
+        }
+
+        await ctx.keymaster.setCurrentId(SERVICE_NAME);
+
+        if (user.credentialDid) {
+            const vc: any = await ctx.keymaster.getCredential(user.credentialDid);
+            if (!vc) throw new Error('Failed to fetch existing credential');
+            vc.credentialSubject.name = `${trimmedName}@${SERVICE_DOMAIN}`;
+            vc.validFrom = new Date().toISOString();
+            const updated = await ctx.keymaster.updateCredential(user.credentialDid, vc);
+            if (!updated) throw new Error('Failed to update credential');
+            user.credentialIssuedAt = new Date().toISOString();
+            console.log(`Updated credential ${user.credentialDid} for ${trimmedName}`);
+        } else {
+            const boundCredential = await ctx.keymaster.bindCredential(did, {
+                schema: MEMBERSHIP_SCHEMA_DID,
+                validFrom: new Date().toISOString(),
+                claims: { name: `${trimmedName}@${SERVICE_DOMAIN}` }
+            });
+            const credentialDid = await ctx.keymaster.issueCredential(boundCredential);
+            user.credentialDid = credentialDid;
+            user.credentialIssuedAt = new Date().toISOString();
+            console.log(`Issued new credential ${credentialDid} for ${trimmedName}`);
+        }
+    }
+
+    async function revokeCredential(user: any, name: string): Promise<void> {
+        if (user.credentialDid) {
+            try {
+                await ctx.keymaster.setCurrentId(SERVICE_NAME);
+                await ctx.keymaster.revokeCredential(user.credentialDid);
+                console.log(`Revoked credential ${user.credentialDid} for ${name}`);
+            } catch (err) {
+                console.log(`Failed to revoke credential: ${err}`);
+            }
+            delete user.credentialDid;
+            delete user.credentialIssuedAt;
+        }
+    }
+
+    async function verifyBearerToken(req: Request): Promise<string | null> {
+        const authHeader = req.headers.authorization;
+        if (!authHeader?.startsWith('Bearer ')) return null;
+        const response = authHeader.slice(7);
+        if (!response) return null;
+        const verify = await ctx.keymaster.verifyResponse(response, { retries: 10 });
+        if (!verify.match || !verify.responder) return null;
+        return verify.responder;
+    }
+
+    async function ensureUser(did: string): Promise<User> {
+        const now = new Date().toISOString();
+        const existingUser = await ctx.db.getUser(did);
+        if (existingUser) {
+            return existingUser;
+        }
+        const user = { firstLogin: now, lastLogin: now, logins: 1 };
+        await ctx.db.setUser(did, user);
+        return user;
+    }
+
+    async function findNameDid(name: string): Promise<string | null> {
+        return ctx.db.findDidByName(name);
+    }
+
+    async function listUsers(): Promise<Record<string, User>> {
+        return ctx.db.listUsers();
+    }
+
+    function buildRegistry(users: Record<string, User>): { version: number; updated: string; names: Record<string, string> } {
+        const names: Record<string, string> = {};
+
+        for (const [did, user] of Object.entries(users)) {
+            if (user.name) {
+                names[user.name] = did;
+            }
+        }
+
+        return {
+            version: 1,
+            updated: new Date().toISOString(),
+            names,
+        };
+    }
+
+    async function resolveLightningEndpoint(name: string): Promise<{ did: string; endpoint: string } | null> {
+        const did = await findNameDid(name);
+        if (!did) return null;
+
+        const didDoc: any = await ctx.keymaster.resolveDID(did);
+        if (!didDoc?.didDocument?.service) return null;
+
+        const lightning = didDoc.didDocument.service.find(
+            (s: any) => s.type === 'Lightning' || s.id?.endsWith('#lightning')
+        );
+        if (!lightning?.serviceEndpoint) return null;
+
+        return { did, endpoint: lightning.serviceEndpoint };
+    }
+
+    async function resolveAvatarImage(name: string): Promise<{
+    did: string;
+    avatarDid: string;
+    file: {
+        data: Buffer;
+        type: string;
+        filename?: string;
+        bytes?: number;
+    };
+} | null> {
+        const did = await findNameDid(name);
+        if (!did) return null;
+
+        const memberDoc: any = await ctx.keymaster.resolveDID(did);
+        const avatarDid = typeof memberDoc?.didDocumentData?.avatar === 'string'
+            ? memberDoc.didDocumentData.avatar.trim()
+            : '';
+
+        if (!avatarDid) return null;
+
+        const image = await ctx.keymaster.getImage(avatarDid);
+        const data = image?.file?.data ?? null;
+
+        if (!data || !Buffer.isBuffer(data) || !image?.file?.type || !image.image) {
+            return null;
+        }
+
+        return {
+            did,
+            avatarDid,
+            file: {
+                ...image.file,
+                data,
+            },
+        };
+    }
+
+    function getSafeAvatarContentType(contentType: string): string {
+        const normalizedType = contentType.trim().toLowerCase();
+        const allowedAvatarContentTypes = new Set([
+            'image/avif',
+            'image/gif',
+            'image/jpeg',
+            'image/jpg',
+            'image/png',
+            'image/webp',
+        ]);
+
+        return allowedAvatarContentTypes.has(normalizedType)
+            ? normalizedType
+            : 'application/octet-stream';
+    }
+
+    function isAuthenticated(req: Request, res: Response, next: NextFunction): void {
+        if (!req.session.user && req.session.challenge) {
+            const challengeData = logins[req.session.challenge];
+            if (challengeData) {
+                req.session.user = { did: challengeData.did };
+            }
+        }
+
+        if (req.session.user) {
+            return next();
+        }
+        res.status(401).send('You need to log in first');
+    }
+
+    function isOwner(req: Request, res: Response, next: NextFunction): void {
+        isAuthenticated(req, res, () => {
+            const userDid = req.session.user?.did;
+            if (userDid === OWNER_DID) {
+                return next();
+            }
+            res.status(403).send('Owner access required');
+        });
+    }
+
+    async function loginUser(response: string): Promise<any> {
+        const verify = await ctx.keymaster.verifyResponse(response, { retries: 10 });
+
+        if (verify.match) {
+            const challenge = verify.challenge;
+            const did = verify.responder!;
+            const now = new Date().toISOString();
+            const user = await ctx.db.getUser(did);
+
+            if (user) {
+                user.lastLogin = now;
+                user.logins = (user.logins || 0) + 1;
+                await ctx.db.setUser(did, user);
+            } else {
+                await ctx.db.setUser(did, {
+                    firstLogin: now,
+                    lastLogin: now,
+                    logins: 1,
+                });
+            }
+
+            logins[challenge] = {
+                response,
+                challenge,
+                did,
+                verify,
+            };
+        }
+
+        return verify;
+    }
+
+    const corsOptions = {
+        origin: true,
+        methods: ['GET', 'POST', 'PUT', 'DELETE'],
+        credentials: true,
+        optionsSuccessStatus: 200
+    };
+
+    router.use(cors(corsOptions));
+
+    router.options('/api/{*path}', cors(corsOptions));
+    router.options('/.well-known/{*path}', cors(corsOptions));
+
+    // Helper function for OAuth
+    async function getMemberByDID(did: string): Promise<any> {
+        const user = await ctx.db.getUser(did);
+        if (user) {
+            return {
+                ...user,
+                did,
+                handle: user.name
+            };
+        }
+        return null;
+    }
+
+    // Mount OAuth routes (ctx.keymaster accessed lazily)
+    const oauthRouter = createOAuthRoutes(() => ctx.keymaster, getMemberByDID);
+    router.use('/oauth', oauthRouter);
+    console.log('OAuth routes mounted at /oauth');
+
+    // OIDC Discovery at root level (required by spec)
+    router.get('/.well-known/openid-configuration', (_req: Request, res: Response) => {
+        const issuer = PUBLIC_URL;
+        res.json({
+            issuer,
+            authorization_endpoint: `${issuer}/oauth/authorize`,
+            token_endpoint: `${issuer}/oauth/token`,
+            userinfo_endpoint: `${issuer}/oauth/userinfo`,
+            response_types_supported: ['code'],
+            subject_types_supported: ['public'],
+            id_token_signing_alg_values_supported: ['ES256'],
+            scopes_supported: ['openid', 'profile'],
+            claims_supported: ['sub', 'name', 'preferred_username', 'picture']
+        });
+    });
+
+    router.get('/api/version', async (_: Request, res: Response) => {
+        try {
+            res.json(1);
+        } catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    router.get('/api/config', (_: Request, res: Response) => {
+        res.json({
+            serviceName: SERVICE_NAME,
+            serviceDID: ctx.serviceDID,
+            ...(SENDGRID_API_KEY ? { relayAgent: ctx.serviceDID } : {}),
+            serviceDomain: SERVICE_DOMAIN,
+            publicUrl: PUBLIC_URL,
+            walletUrl: WALLET_URL,
+        });
+    });
+
+    router.get('/api/challenge', async (req: Request, res: Response) => {
+        try {
+            const challenge = await ctx.keymaster.createChallenge({
+            // @ts-ignore
+                callback: `${PUBLIC_URL}/api/login`
+            });
+            req.session.challenge = challenge;
+            const challengeURL = `${WALLET_URL}?challenge=${challenge}`;
+
+            const doc = await ctx.keymaster.resolveDID(challenge);
+            console.log(JSON.stringify(doc, null, 4));
+            res.json({ challenge, challengeURL });
+        } catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    // Email bridge: inbound email webhook (SendGrid Inbound Parse)
+    const inboundEmailUpload = multer();
+    router.post('/api/inbound-email', inboundEmailUpload.none(), async (req: Request, res: Response) => {
+        try {
+            if (!ctx.emailBridge?.isConfigured()) {
+                res.status(404).json({ error: 'Email bridge not configured' });
+                return;
+            }
+
+            // Verify webhook authenticity via query parameter token
+            if (WEBHOOK_SECRET && req.query.secret !== WEBHOOK_SECRET) {
+                console.warn('Inbound email webhook rejected: invalid or missing secret');
+                res.status(401).json({ error: 'Unauthorized' });
+                return;
+            }
+
+            const email = ctx.emailBridge.parseInboundEmail(req.body);
+            if (!email) {
+                console.warn('Inbound email missing required fields');
+                res.status(400).json({ error: 'Missing from or to fields' });
+                return;
+            }
+
+            const spamScore = parseFloat(email.spam_score || '0');
+            if (spamScore > 5) {
+                console.warn(`Inbound email rejected: spam score ${spamScore} from ${email.from}`);
+                res.status(200).json({ ok: true, action: 'spam-rejected' });
+                return;
+            }
+
+            const token = ctx.emailBridge.extractReplyToken(email.to);
+            if (token) {
+                const tokenData = await ctx.emailBridge.lookupToken(token);
+                if (!tokenData) {
+                    console.warn(`Inbound email with expired/unknown token from ${email.from}`);
+                    res.status(200).json({ ok: true, action: 'token-expired' });
+                    return;
+                }
+
+                // Reply to an outbound email: create dmail to original sender
+                const replyFromEmail = ctx.emailBridge.extractEmailAddress(email.from) || email.from;
+                await ctx.keymaster.setCurrentId(SERVICE_NAME);
+                const dmailMessage = {
+                    to: [tokenData.senderDid],
+                    cc: [] as string[],
+                    subject: `[email from ${replyFromEmail}] ${email.subject}`,
+                    body: email.text || '(no text content)',
+                    reference: tokenData.originalDmailDid,
+                };
+                const dmailDid = await ctx.keymaster.createDmail(dmailMessage, { registry: 'hyperswarm' });
+                const noticeDid = await ctx.keymaster.sendDmail(dmailDid);
+
+                await ctx.emailBridge.storeEmailMapping(dmailDid, replyFromEmail, tokenData.senderDid);
+                console.log(`Inbound email from ${email.from} → dmail ${dmailDid} to ${tokenData.senderDid} (notice: ${noticeDid})`);
+                res.status(200).json({ ok: true, action: 'delivered', dmailDid });
+                return;
+            }
+
+            // No reply token — try to resolve recipient as a Herald name
+            const recipientName = ctx.emailBridge.extractRecipientName(email.to);
+            if (!recipientName) {
+                console.warn(`Inbound email with no recognizable recipient from ${email.from} to ${email.to}`);
+                res.status(200).json({ ok: true, action: 'no-recipient-ignored' });
+                return;
+            }
+
+            const recipientDid = await ctx.db.findDidByName(recipientName);
+            if (!recipientDid) {
+                console.warn(`Inbound email to unknown Herald name "${recipientName}" from ${email.from}`);
+                res.status(200).json({ ok: true, action: 'unknown-name-ignored' });
+                return;
+            }
+
+            // Unsolicited inbound: create dmail from Herald to the named recipient
+            const senderEmail = ctx.emailBridge.extractEmailAddress(email.from) || email.from;
+            await ctx.keymaster.setCurrentId(SERVICE_NAME);
+            const dmailMessage = {
+                to: [recipientDid],
+                cc: [] as string[],
+                subject: `[email from ${senderEmail}] ${email.subject}`,
+                body: email.text || '(no text content)',
+            };
+            const dmailDid = await ctx.keymaster.createDmail(dmailMessage, { registry: 'hyperswarm' });
+            const noticeDid = await ctx.keymaster.sendDmail(dmailDid);
+
+            await ctx.emailBridge.storeEmailMapping(dmailDid, senderEmail, recipientDid);
+            console.log(`Inbound email from ${email.from} → dmail ${dmailDid} to ${recipientName} (${recipientDid}) (notice: ${noticeDid})`);
+            res.status(200).json({ ok: true, action: 'delivered', dmailDid });
+        } catch (error) {
+            console.error('Error processing inbound email:', error);
+            res.status(200).json({ ok: true, action: 'error' });
+        }
+    });
+
+    // Email bridge: send email (authenticated)
+    router.post('/api/send-email', async (req: Request, res: Response) => {
+        try {
+            if (!ctx.emailBridge?.isConfigured()) {
+                res.status(404).json({ error: 'Email bridge not configured' });
+                return;
+            }
+
+            const senderDid = await verifyBearerToken(req);
+            if (!senderDid) {
+                res.status(401).json({ error: 'Authentication required' });
+                return;
+            }
+
+            const user = await ctx.db.getUser(senderDid);
+            if (!user?.name) {
+                res.status(403).json({ error: 'Herald name required to send email' });
+                return;
+            }
+
+            const { to, subject, body, dmailDid } = req.body;
+            if (!to || !subject || !body || !dmailDid) {
+                res.status(400).json({ error: 'Missing required fields: to, subject, body, dmailDid' });
+                return;
+            }
+
+            const result = await ctx.emailBridge.sendEmail({
+                to,
+                subject,
+                body,
+                senderName: user.name,
+                senderDid,
+                dmailDid,
+            });
+
+            console.log(`Email sent by ${user.name} (${senderDid}) to ${to}`);
+            res.json({ ok: true, token: result.token });
+        } catch (error) {
+            console.error('Error sending email:', error);
+            res.status(500).json({ error: 'Failed to send email' });
+        }
+    });
+
+    router.get('/api/login', cors(corsOptions), async (req: Request, res: Response) => {
+        try {
+            const { response } = req.query;
+            if (typeof response !== 'string') {
+                res.status(400).json({ error: 'Missing or invalid response param' });
+                return;
+            }
+            const verify = await loginUser(response);
+            if (!verify.challenge) {
+                res.json({ authenticated: false });
+                return;
+            }
+            req.session.user = {
+                did: verify.responder
+            };
+            res.json({ authenticated: verify.match });
+        } catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    router.post('/api/login', cors(corsOptions), async (req: Request, res: Response) => {
+        try {
+            const { response } = req.body;
+            const verify = await loginUser(response);
+            if (!verify.challenge) {
+                res.json({ authenticated: false });
+                return;
+            }
+            req.session.user = {
+                did: verify.responder
+            };
+            res.json({ authenticated: verify.match });
+        } catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    router.post('/api/logout', async (req: Request, res: Response) => {
+        try {
+            req.session.destroy(err => {
+                if (err) {
+                    console.log(err);
+                }
+            });
+            res.json({ ok: true });
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    router.get('/api/check-auth', async (req: Request, res: Response) => {
+        try {
+            if (!req.session.user && req.session.challenge) {
+                const challengeData = logins[req.session.challenge];
+                if (challengeData) {
+                    req.session.user = { did: challengeData.did };
+                }
+            }
+
+            const isAuthenticated = !!req.session.user;
+            const userDID = isAuthenticated ? req.session.user?.did : null;
+            let profile: any = null;
+
+            if (isAuthenticated && userDID) {
+                profile = await ctx.db.getUser(userDID);
+            }
+
+            const auth = {
+                isAuthenticated,
+                userDID,
+                isOwner: isAuthenticated && userDID === OWNER_DID,
+                profile,
+            };
+
+            res.json(auth);
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    router.get('/api/users', isAuthenticated, async (_: Request, res: Response) => {
+        try {
+            const users = Object.keys(await listUsers());
+            res.json(users);
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    router.get('/api/admin', isOwner, async (_: Request, res: Response) => {
+        try {
+            res.json({ users: await listUsers() });
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    // Publish registry to IPFS and update IPNS
+    router.post('/api/admin/publish', isOwner, async (_: Request, res: Response) => {
+        try {
+        // Build registry from DB
+            const registry = buildRegistry(await listUsers());
+
+            const registryJson = JSON.stringify(registry, null, 2);
+
+            // Add to IPFS
+            const formData = new FormData();
+            formData.append('file', new Blob([registryJson], { type: 'application/json' }), 'registry.json');
+
+            const addResponse = await fetch(`${IPFS_API_URL}/add?pin=true`, {
+                method: 'POST',
+                body: formData
+            });
+
+            if (!addResponse.ok) {
+                throw new Error(`IPFS add failed: ${addResponse.statusText}`);
+            }
+
+            const addResult = await addResponse.json();
+            const cid = addResult.Hash;
+
+            console.log(`Registry added to IPFS: ${cid}`);
+
+            // Publish to IPNS
+            const publishResponse = await fetch(
+                `${IPFS_API_URL}/name/publish?arg=/ipfs/${cid}&key=${IPNS_KEY_NAME}`,
+                { method: 'POST' }
+            );
+
+            if (!publishResponse.ok) {
+                throw new Error(`IPNS publish failed: ${publishResponse.statusText}`);
+            }
+
+            const publishResult = await publishResponse.json();
+
+            console.log(`Registry published to IPNS: ${publishResult.Name}`);
+
+            res.json({
+                ok: true,
+                cid,
+                ipns: publishResult.Name,
+                registry
+            });
+        }
+        catch (error: any) {
+            console.log(error);
+            res.status(500).json({ ok: false, error: error.message || String(error) });
+        }
+    });
+
+    router.get('/api/profile/:did', isAuthenticated, async (req: Request, res: Response) => {
+        try {
+            const did = req.params.did as string;
+            const user = await ctx.db.getUser(did);
+            if (!user) {
+                res.status(404).send('Not found');
+                return;
+            }
+
+            const profile: User = { ...user };
+
+            profile.did = did;
+            profile.isUser = (req.session?.user?.did === did);
+
+            res.json(profile);
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    router.get('/api/profile/:did/name', isAuthenticated, async (req: Request, res: Response) => {
+        try {
+            const did = req.params.did as string;
+            const user = await ctx.db.getUser(did);
+            if (!user) {
+                res.status(404).send('Not found');
+                return;
+            }
+
+            res.json({ name: user.name });
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    router.put('/api/profile/:did/name', isAuthenticated, async (req: Request, res: Response) => {
+        try {
+            const did = req.params.did as string;
+
+            if (!req.session.user || req.session.user.did !== did) {
+                res.status(403).json({ message: 'Forbidden' });
+                return;
+            }
+
+            const validation = validateName(req.body.name);
+            if (!validation.ok) {
+                res.status(400).json({ ok: false, message: validation.message });
+                return;
+            }
+            const trimmedName = validation.trimmedName!;
+
+            const user = await ctx.db.getUser(did);
+            if (!user) {
+                res.status(404).send('Not found');
+                return;
+            }
+
+            if (!(await checkNameAvailability(trimmedName, did))) {
+                res.status(409).json({ ok: false, message: 'Name already taken' });
+                return;
+            }
+
+            user.name = trimmedName;
+            await issueOrUpdateCredential(did, user, trimmedName);
+            await ctx.db.setUser(did, user);
+
+            res.json({ ok: true, message: `name set to ${trimmedName}` });
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    // Delete name and revoke credential (session-based)
+    router.delete('/api/profile/:did/name', isAuthenticated, async (req: Request, res: Response) => {
+        try {
+            const did = req.params.did as string;
+
+            if (!req.session.user || req.session.user.did !== did) {
+                res.status(403).json({ message: 'Forbidden' });
+                return;
+            }
+
+            const user = await ctx.db.getUser(did);
+            if (!user) {
+                res.status(404).send('Not found');
+                return;
+            }
+
+            const deletedName = user.name;
+
+            await revokeCredential(user, deletedName || '');
+            delete user.name;
+            await ctx.db.setUser(did, user);
+
+            res.json({ ok: true, message: `name '${deletedName}' deleted and credential revoked` });
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    // Stateless name claim (Bearer token auth)
+    router.put('/api/name', async (req: Request, res: Response) => {
+        try {
+            const did = await verifyBearerToken(req);
+            if (!did) {
+                res.status(401).json({ ok: false, message: 'Valid Bearer token (response DID) required' });
+                return;
+            }
+
+            const validation = validateName(req.body.name);
+            if (!validation.ok) {
+                res.status(400).json({ ok: false, message: validation.message });
+                return;
+            }
+            const trimmedName = validation.trimmedName!;
+
+            const user = await ensureUser(did);
+
+            if (!(await checkNameAvailability(trimmedName, did))) {
+                res.status(409).json({ ok: false, message: 'Name already taken' });
+                return;
+            }
+
+            user.name = trimmedName;
+            await issueOrUpdateCredential(did, user, trimmedName);
+            await ctx.db.setUser(did, user);
+
+            let credential = null;
+            if (user.credentialDid) {
+                credential = await ctx.keymaster.getCredential(user.credentialDid);
+            }
+
+            res.json({
+                ok: true,
+                name: trimmedName,
+                did,
+                credentialDid: user.credentialDid,
+                credentialIssuedAt: user.credentialIssuedAt,
+                credential,
+            });
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    // Stateless name delete (Bearer token auth)
+    router.delete('/api/name', async (req: Request, res: Response) => {
+        try {
+            const did = await verifyBearerToken(req);
+            if (!did) {
+                res.status(401).json({ ok: false, message: 'Valid Bearer token (response DID) required' });
+                return;
+            }
+
+            const user = await ctx.db.getUser(did);
+            if (!user) {
+                res.status(404).json({ ok: false, message: 'User not found' });
+                return;
+            }
+
+            const deletedName = user.name;
+
+            if (!deletedName) {
+                res.status(404).json({ ok: false, message: 'No name to delete' });
+                return;
+            }
+
+            await revokeCredential(user, deletedName);
+            delete user.name;
+            await ctx.db.setUser(did, user);
+
+            res.json({ ok: true, message: `name '${deletedName}' deleted and credential revoked` });
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    // Export name registry for IPNS publication
+    router.get('/api/registry', async (_: Request, res: Response) => {
+        try {
+            res.json(buildRegistry(await listUsers()));
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    // Resolve a name to a DID
+    router.get('/api/name/:name', async (req: Request, res: Response) => {
+        try {
+            const name = (req.params.name as string).trim().toLowerCase();
+            const did = await findNameDid(name);
+            if (did) {
+                res.json({ name, did });
+                return;
+            }
+
+            res.status(404).json({ error: 'Name not found' });
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    // Public directory.json - same as /api/registry for IPNS compatibility
+    router.get('/directory.json', async (_: Request, res: Response) => {
+        try {
+            res.json(buildRegistry(await listUsers()));
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    // Resolve a member name to their DID document
+    // Public API endpoint for member lookup
+    router.get('/api/member/:name', async (req: Request, res: Response) => {
+        try {
+            const name = (req.params.name as string).trim().toLowerCase();
+            const memberDid = await findNameDid(name);
+            if (!memberDid) {
+                res.status(404).json({ error: 'Name not found', name });
+                return;
+            }
+
+            // Fetch DID document from gatekeeper
+            const didDoc = await ctx.keymaster.resolveDID(memberDid);
+
+            res.json(didDoc);
+        }
+        catch (error: any) {
+            console.log(error);
+            res.status(500).json({ error: error.message || String(error) });
+        }
+    });
+
+    // Resolve a member name to their avatar image
+    router.get('/api/name/:name/avatar', async (req: Request, res: Response) => {
+        try {
+            const name = (req.params.name as string).trim().toLowerCase();
+            const avatar = await resolveAvatarImage(name);
+
+            if (!avatar) {
+                res.status(404).json({ error: 'Avatar not found', name });
+                return;
+            }
+
+            res.set('X-Content-Type-Options', 'nosniff');
+            res.set('Content-Type', getSafeAvatarContentType(avatar.file.type));
+            res.set('Content-Length', String(avatar.file.data.length));
+            if (avatar.file.filename) {
+                res.set('Content-Disposition', `inline; filename="${encodeURIComponent(avatar.file.filename)}"`);
+            }
+
+            res.send(avatar.file.data);
+        }
+        catch (error: any) {
+            console.log(error);
+            res.status(500).json({ error: error.message || String(error) });
+        }
+    });
+
+
+    // Admin: Delete a user
+    router.delete('/api/admin/user/:did', isOwner, async (req: Request, res: Response) => {
+        try {
+            const did = decodeURIComponent(req.params.did as string);
+            const user = await ctx.db.getUser(did);
+            if (!user) {
+                res.status(404).json({ error: 'User not found' });
+                return;
+            }
+
+            // Don't allow deleting the owner
+            if (did === OWNER_DID) {
+                res.status(403).json({ error: 'Cannot delete the owner account' });
+                return;
+            }
+
+            const userName = user.name || did;
+            await ctx.db.deleteUser(did);
+
+            console.log(`Deleted user ${userName} (${did})`);
+            res.json({ ok: true, message: `User ${userName} deleted` });
+        }
+        catch (error: any) {
+            console.log(error);
+            res.status(500).json({ error: error.message || String(error) });
+        }
+    });
+
+    // Get member's credential
+    router.get('/api/credential', isAuthenticated, async (req: Request, res: Response) => {
+        try {
+            const userDid = req.session.user?.did;
+            if (!userDid) {
+                res.status(401).json({ error: 'Not authenticated' });
+                return;
+            }
+
+            const user = await ctx.db.getUser(userDid);
+
+            if (!user) {
+                res.status(404).json({ error: 'User not found' });
+                return;
+            }
+
+            if (!user.credentialDid) {
+                res.json({
+                    hasCredential: false,
+                    name: user.name || null,
+                    message: 'No credential issued yet'
+                });
+                return;
+            }
+
+            // Fetch the credential
+            const credential = await ctx.keymaster.getCredential(user.credentialDid);
+
+            res.json({
+                hasCredential: true,
+                credentialDid: user.credentialDid,
+                credentialIssuedAt: user.credentialIssuedAt,
+                credential
+            });
+        }
+        catch (error: any) {
+            console.log(error);
+            const errorMsg = error?.message || error?.error || (typeof error === 'string' ? error : JSON.stringify(error));
+            res.status(500).json({ error: errorMsg });
+        }
+    });
+
+
+    // LUD16 Lightning Address support
+    const LN_MIN_SENDABLE = 1000;        // 1 sat in msats
+    const LN_MAX_SENDABLE = 100000000000; // 100k sats in msats
+
+    router.get('/.well-known/lnurlp/:name', async (req: Request, res: Response) => {
+        try {
+            const name = (req.params.name as string).trim().toLowerCase();
+            const result = await resolveLightningEndpoint(name);
+
+            if (!result) {
+                res.json({ status: 'ERROR', reason: 'No Lightning service found for this name' });
+                return;
+            }
+
+            const metadata = JSON.stringify([
+                ['text/plain', `Payment to ${name}@${SERVICE_DOMAIN}`],
+                ['text/identifier', `${name}@${SERVICE_DOMAIN}`]
+            ]);
+
+            res.json({
+                tag: 'payRequest',
+                callback: `${PUBLIC_URL}/api/lnurlp/${name}/callback`,
+                minSendable: LN_MIN_SENDABLE,
+                maxSendable: LN_MAX_SENDABLE,
+                metadata,
+            });
+        }
+        catch (error: any) {
+            console.log(error);
+            res.json({ status: 'ERROR', reason: error.message || 'Internal error' });
+        }
+    });
+
+    router.get('/api/lnurlp/:name/callback', async (req: Request, res: Response) => {
+        try {
+            const name = (req.params.name as string).trim().toLowerCase();
+            const amount = parseInt(req.query.amount as string, 10);
+
+            if (!amount || amount < LN_MIN_SENDABLE || amount > LN_MAX_SENDABLE) {
+                res.json({ status: 'ERROR', reason: `Amount must be between ${LN_MIN_SENDABLE} and ${LN_MAX_SENDABLE} msats` });
+                return;
+            }
+
+            const result = await resolveLightningEndpoint(name);
+            if (!result) {
+                res.json({ status: 'ERROR', reason: 'No Lightning service found for this name' });
+                return;
+            }
+
+            // LUD16 amount is in millisatoshis, convert to satoshis for Lightning endpoint
+            const amountSats = Math.floor(amount / 1000);
+            const invoiceUrl = `${result.endpoint}?amount=${amountSats}`;
+            const fetchOptions: any = {};
+
+            if (result.endpoint.includes('.onion') && TOR_PROXY) {
+                const [host, port] = TOR_PROXY.split(':');
+                fetchOptions.dispatcher = socksDispatcher({
+                    type: 5,
+                    host: host || 'localhost',
+                    port: parseInt(port || '9050'),
+                });
+            }
+
+            const response = await fetch(invoiceUrl, fetchOptions);
+            if (!response.ok) {
+                res.json({ status: 'ERROR', reason: 'Lightning service returned an error' });
+                return;
+            }
+
+            const data: any = await response.json();
+
+            // Normalize to LUD06 format (pr + routes)
+            res.json({
+                pr: data.pr || data.paymentRequest,
+                routes: data.routes || [],
+            });
+        }
+        catch (error: any) {
+            console.log(error);
+            res.json({ status: 'ERROR', reason: error.message || 'Internal error' });
+        }
+    });
+
+    // ── Well-Known Endpoints (Issue #4) ─────────────────────────────────
+
+    // GET /.well-known/names — list/directory of registered names
+    router.get('/.well-known/names', async (_: Request, res: Response) => {
+        try {
+            res.json(buildRegistry(await listUsers()));
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    // GET /.well-known/names/:name — resolve a name to a DID
+    router.get('/.well-known/names/:name', async (req: Request, res: Response) => {
+        try {
+            const name = (req.params.name as string).trim().toLowerCase();
+            const did = await findNameDid(name);
+
+            if (!did) {
+                res.status(404).json({ error: 'Name not found' });
+                return;
+            }
+
+            res.json({ name, did });
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    // GET /.well-known/webfinger — RFC 7033 WebFinger discovery
+    router.get('/.well-known/webfinger', async (req: Request, res: Response) => {
+        try {
+            const resource = req.query.resource as string;
+
+            if (!resource) {
+                res.status(400).json({ error: 'Missing required "resource" query parameter' });
+                return;
+            }
+
+            // Parse acct: URI — expect "acct:name@domain"
+            const acctMatch = resource.match(/^acct:([^@]+)@(.+)$/);
+            if (!acctMatch) {
+                res.status(400).json({ error: 'Resource must be in "acct:name@domain" format' });
+                return;
+            }
+
+            const [, name, domain] = acctMatch;
+
+            // Verify the domain matches this service
+            if (SERVICE_DOMAIN && domain !== SERVICE_DOMAIN) {
+                res.status(404).json({ error: 'Unknown domain' });
+                return;
+            }
+
+            const did = await findNameDid(name);
+            if (!did) {
+                res.status(404).json({ error: 'Name not found' });
+                return;
+            }
+
+            const jrd: any = {
+                subject: resource,
+                aliases: [did],
+                links: [
+                    {
+                        rel: 'self',
+                        type: 'application/activity+json',
+                        href: `${PUBLIC_URL}/api/name/${name}`,
+                    },
+                    {
+                        rel: 'http://webfinger.net/rel/profile-page',
+                        type: 'text/html',
+                        href: `${PUBLIC_URL}/name/${name}`,
+                    },
+                    {
+                        rel: 'https://w3id.org/did',
+                        type: 'application/json',
+                        href: `https://${SERVICE_DOMAIN}/api/v1/did/${did}`,
+                    },
+                    {
+                        rel: 'http://webfinger.net/rel/avatar',
+                        href: `${PUBLIC_URL}/api/name/${name}/avatar`,
+                    },
+                ],
+            };
+
+            res.set('Content-Type', 'application/jrd+json');
+            res.json(jrd);
+        }
+        catch (error) {
+            console.log(error);
+            res.status(500).send(String(error));
+        }
+    });
+
+    process.on('uncaughtException', (error) => {
+        console.error('Unhandled exception caught', error);
+    });
+
+    process.on('unhandledRejection', (reason, promise) => {
+        console.error('Unhandled rejection at:', promise, 'reason:', reason);
+    });
+
+    const DMAIL_POLL_INTERVAL_MS = 60_000; // 1 minute
+
+    async function pollDmailForEmail(): Promise<void> {
+        if (!ctx.emailBridge?.isConfigured()) return;
+
+        try {
+            await ctx.keymaster.setCurrentId(SERVICE_NAME);
+            await ctx.keymaster.refreshNotices();
+
+            const dmails = await ctx.keymaster.listDmail();
+            for (const [dmailDid, item] of Object.entries(dmails)) {
+                if (!item.tags.includes('unread')) continue;
+
+                // Resolve sender info (shared by both paths)
+                const rawSender = typeof item.sender === 'string' ? item.sender : 'Unknown';
+                const isDid = rawSender.startsWith('did:');
+                let senderName: string;
+                let fromEmail: string;
+
+                if (isDid) {
+                    const senderUser = await ctx.db.getUser(rawSender);
+                    if (senderUser?.name) {
+                        senderName = senderUser.name;
+                        fromEmail = `${senderName}@${SERVICE_DOMAIN}`;
+                    } else {
+                        senderName = 'dmail-user';
+                        fromEmail = SENDGRID_FROM_EMAIL;
+                    }
+                } else {
+                    senderName = rawSender;
+                    fromEmail = `${senderName}@${SERVICE_DOMAIN}`;
+                }
+
+                // Path 1: Reply to a bridged email (has reference matching a stored mapping)
+                if (item.message.reference) {
+                    const mapping = await ctx.emailBridge.lookupEmailMapping(item.message.reference);
+                    if (mapping) {
+                        await ctx.emailBridge.sendEmail({
+                            to: mapping.emailAddress,
+                            subject: item.message.subject,
+                            body: item.message.body,
+                            senderName,
+                            senderDid: mapping.recipientDid,
+                            dmailDid,
+                            fromEmail,
+                        });
+                        await ctx.keymaster.fileDmail(dmailDid, ['inbox']);
+                        console.log(`Forwarded reply dmail ${dmailDid} from ${senderName} to ${mapping.emailAddress}`);
+                        continue;
+                    }
+                }
+
+                // Path 2: Compose new email via "[email to addr] subject" convention
+                if (ctx.serviceDID && (item.message.to.includes(ctx.serviceDID) || item.message.cc.includes(ctx.serviceDID))) {
+                    const emailToMatch = item.message.subject.match(/^\[email to ([^\]]+)\]\s*(.*)/i);
+                    if (emailToMatch) {
+                        const toEmail = emailToMatch[1].trim();
+                        const realSubject = emailToMatch[2] || '(no subject)';
+
+                        await ctx.emailBridge.sendEmail({
+                            to: toEmail,
+                            subject: realSubject,
+                            body: item.message.body,
+                            senderName,
+                            senderDid: rawSender,
+                            dmailDid,
+                            fromEmail,
+                        });
+                        await ctx.keymaster.fileDmail(dmailDid, ['inbox']);
+                        console.log(`Composed email from ${senderName} to ${toEmail}: ${realSubject}`);
+                        continue;
+                    }
+                }
+            }
+        } catch (error) {
+            console.error('Dmail poll error:', error);
+        }
+    }
+
+    let dmailPollInFlight = false;
+
+    function startDmailPollLoop(): void {
+        console.log(`${SERVICE_NAME} dmail poll loop started (interval: ${DMAIL_POLL_INTERVAL_MS / 1000}s)`);
+
+        const runPoll = async () => {
+            if (dmailPollInFlight) return;
+            dmailPollInFlight = true;
+            try {
+                await pollDmailForEmail();
+            } finally {
+                dmailPollInFlight = false;
+            }
+        };
+
+        // Initial poll after a short delay to let startup finish
+        setTimeout(() => {
+            runPoll();
+            setInterval(runPoll, DMAIL_POLL_INTERVAL_MS);
+        }, 5000);
+    }
+
+
+    return { router, startDmailPollLoop };
+}

--- a/tests/herald/routes.test.ts
+++ b/tests/herald/routes.test.ts
@@ -1,0 +1,594 @@
+import { jest } from '@jest/globals';
+import express from 'express';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import request from 'supertest';
+
+// config.ts reads the environment at module-evaluation time, and oauth/index.ts
+// (imported transitively) would otherwise write its signing key to /app/server/data.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'herald-routes-'));
+process.env.ARCHON_HERALD_JWT_KEY_PATH = path.join(tmpDir, 'oauth-signing-key.json');
+process.env.ARCHON_HERALD_DOMAIN = 'archon.test';
+process.env.ARCHON_HERALD_NAME = 'name-service';
+process.env.ARCHON_HERALD_OWNER_DID = 'did:cid:owner';
+process.env.ARCHON_DRAWBRIDGE_PUBLIC_HOST = 'https://archon.test';
+
+let createHeraldRoutes: any;
+let logSpy: any;
+let warnSpy: any;
+let errorSpy: any;
+
+beforeAll(async () => {
+    ({ createHeraldRoutes } = await import('../../services/herald/server/src/routes'));
+});
+
+beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+});
+
+afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function createDb(users: Record<string, any> = {}) {
+    return {
+        getUser: jest.fn<any>(async (did: string) => users[did] ?? null),
+        setUser: jest.fn<any>(async (did: string, user: any) => { users[did] = user; }),
+        deleteUser: jest.fn<any>(async (did: string) => {
+            if (!users[did]) return false;
+            delete users[did];
+            return true;
+        }),
+        listUsers: jest.fn<any>(async () => users),
+        findDidByName: jest.fn<any>(async (name: string) =>
+            Object.entries(users).find(([, u]: any) => u.name === name)?.[0] ?? null),
+        setReplyToken: jest.fn<any>(), getReplyToken: jest.fn<any>(),
+        deleteExpiredReplyTokens: jest.fn<any>(async () => 0),
+        setEmailMapping: jest.fn<any>(), getEmailMapping: jest.fn<any>(),
+    };
+}
+
+function mount(overrides: { db?: any; keymaster?: any; session?: any } = {}) {
+    const db = overrides.db ?? createDb();
+    const ctx: any = {
+        keymaster: overrides.keymaster ?? {},
+        db,
+        emailBridge: null,
+        serviceDID: 'did:cid:service',
+    };
+
+    const app = express();
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: true }));
+    // Stand in for express-session, which the bootstrap installs.
+    app.use((req: any, _res, next) => {
+        req.session = { ...(overrides.session ?? {}), destroy: (cb: any) => cb?.() };
+        next();
+    });
+    const { router } = createHeraldRoutes(ctx);
+    app.use(router);
+
+    return { app, ctx, db };
+}
+
+describe('herald public endpoints', () => {
+    it('reports service configuration', async () => {
+        const { app } = mount();
+
+        const response = await request(app).get('/api/config');
+
+        expect(response.status).toBe(200);
+        expect(response.body).toMatchObject({
+            serviceName: 'name-service',
+            serviceDID: 'did:cid:service',
+            serviceDomain: 'archon.test',
+        });
+    });
+
+    it('builds the name registry from users that have a name', async () => {
+        const db = createDb({
+            'did:cid:alice': { name: 'alice' },
+            'did:cid:bob': { name: 'bob' },
+            'did:cid:anon': { logins: 3 },
+        });
+        const { app } = mount({ db });
+
+        const response = await request(app).get('/api/registry');
+
+        expect(response.status).toBe(200);
+        expect(response.body.names).toEqual({ alice: 'did:cid:alice', bob: 'did:cid:bob' });
+        expect(response.body.version).toBe(1);
+    });
+
+    it('resolves a name to its DID, and 404s an unknown one', async () => {
+        const db = createDb({ 'did:cid:alice': { name: 'alice' } });
+        const { app } = mount({ db });
+
+        const found = await request(app).get('/api/name/alice');
+        expect(found.status).toBe(200);
+        expect(found.body).toMatchObject({ name: 'alice', did: 'did:cid:alice' });
+
+        const missing = await request(app).get('/api/name/nobody');
+        expect(missing.status).toBe(404);
+    });
+
+    it('serves the directory document', async () => {
+        const db = createDb({ 'did:cid:alice': { name: 'alice' } });
+        const { app } = mount({ db });
+
+        const response = await request(app).get('/directory.json');
+
+        expect(response.status).toBe(200);
+        expect(response.body.names).toEqual({ alice: 'did:cid:alice' });
+    });
+
+    it('serves the well-known names list and lookup', async () => {
+        const db = createDb({ 'did:cid:alice': { name: 'alice' } });
+        const { app } = mount({ db });
+
+        const list = await request(app).get('/.well-known/names');
+        expect(list.status).toBe(200);
+
+        const one = await request(app).get('/.well-known/names/alice');
+        expect(one.status).toBe(200);
+
+        const missing = await request(app).get('/.well-known/names/nobody');
+        expect(missing.status).toBe(404);
+    });
+});
+
+describe('herald authentication gates', () => {
+    it('rejects unauthenticated access to protected routes', async () => {
+        const { app } = mount();
+
+        for (const path of ['/api/users', '/api/credential']) {
+            const response = await request(app).get(path);
+            expect([path, response.status]).toEqual([path, 401]);
+        }
+    });
+
+    it('rejects a non-owner from owner-only routes', async () => {
+        const { app } = mount({ session: { user: { did: 'did:cid:notowner' } } });
+
+        const response = await request(app).get('/api/admin');
+
+        expect(response.status).toBe(403);
+    });
+
+    it('admits the configured owner', async () => {
+        const db = createDb({ 'did:cid:owner': { name: 'owner' } });
+        const { app } = mount({ db, session: { user: { did: 'did:cid:owner' } } });
+
+        const response = await request(app).get('/api/admin');
+
+        expect(response.status).toBe(200);
+    });
+
+    it('lists users for an authenticated caller', async () => {
+        const db = createDb({ 'did:cid:alice': { name: 'alice' } });
+        const { app } = mount({ db, session: { user: { did: 'did:cid:alice' } } });
+
+        const response = await request(app).get('/api/users');
+
+        expect(response.status).toBe(200);
+        expect(response.body).toContain('did:cid:alice');
+    });
+});
+
+describe('herald name validation', () => {
+    const cases: Array<[string, any, number]> = [
+        ['missing', undefined, 400],
+        ['too short', 'ab', 400],
+        ['too long', 'a'.repeat(33), 400],
+        ['illegal characters', 'bad name!', 400],
+        ['non-string', 12345, 400],
+    ];
+
+    it.each(cases)('rejects a %s name', async (_label, name, expected) => {
+        // The route authenticates before it validates, so a valid bearer token is
+        // needed to reach the name checks at all.
+        const keymaster = {
+            verifyResponse: jest.fn<any>().mockResolvedValue({ match: true, responder: 'did:cid:alice' }),
+        };
+        const { app } = mount({ keymaster, session: { user: { did: 'did:cid:alice' } } });
+
+        const response = await request(app)
+            .put('/api/name')
+            .set('Authorization', 'Bearer valid-response')
+            .send({ name });
+
+        expect(response.status).toBe(expected);
+    });
+
+    it('rejects a name already taken by someone else', async () => {
+        const db = createDb({
+            'did:cid:alice': { name: 'taken' },
+            'did:cid:bob': {},
+        });
+        const keymaster = {
+            verifyResponse: jest.fn<any>().mockResolvedValue({ match: true, responder: 'did:cid:bob' }),
+        };
+        const { app } = mount({ db, keymaster, session: { user: { did: 'did:cid:bob' } } });
+
+        const response = await request(app)
+            .put('/api/name')
+            .set('Authorization', 'Bearer some-response')
+            .send({ name: 'taken' });
+
+        expect([400, 409]).toContain(response.status);
+    });
+});
+
+describe('herald bearer token handling', () => {
+    it('rejects a request with no bearer token', async () => {
+        const { app } = mount();
+
+        const response = await request(app).put('/api/name').send({ name: 'alice' });
+
+        expect(response.status).toBe(401);
+    });
+
+    it('rejects a bearer token that does not verify', async () => {
+        const keymaster = {
+            verifyResponse: jest.fn<any>().mockResolvedValue({ match: false }),
+        };
+        const { app } = mount({ keymaster });
+
+        const response = await request(app)
+            .put('/api/name')
+            .set('Authorization', 'Bearer bad-response')
+            .send({ name: 'alice' });
+
+        expect(response.status).toBe(401);
+    });
+});
+
+describe('herald avatar content type', () => {
+    it('404s an avatar for an unknown name', async () => {
+        const { app } = mount();
+
+        const response = await request(app).get('/api/name/nobody/avatar');
+
+        expect(response.status).toBe(404);
+    });
+});
+
+describe('herald webfinger', () => {
+    it('requires a resource parameter in acct: form', async () => {
+        const { app } = mount();
+
+        const missing = await request(app).get('/.well-known/webfinger');
+        expect(missing.status).toBe(400);
+        expect(missing.body.error).toMatch(/resource/i);
+
+        const malformed = await request(app).get('/.well-known/webfinger?resource=not-an-acct');
+        expect(malformed.status).toBe(400);
+        expect(malformed.body.error).toMatch(/acct:name@domain/);
+    });
+
+    it('rejects a domain that is not this service', async () => {
+        const { app } = mount();
+
+        const response = await request(app).get('/.well-known/webfinger?resource=acct:alice@elsewhere.test');
+
+        expect(response.status).toBe(404);
+        expect(response.body).toEqual({ error: 'Unknown domain' });
+    });
+
+    it('404s a name this service does not host', async () => {
+        const { app } = mount();
+
+        const response = await request(app).get('/.well-known/webfinger?resource=acct:nobody@archon.test');
+
+        expect(response.status).toBe(404);
+        expect(response.body).toEqual({ error: 'Name not found' });
+    });
+
+    it('returns a JRD document for a known name', async () => {
+        const db = createDb({ 'did:cid:alice': { name: 'alice' } });
+        const { app } = mount({ db });
+
+        const response = await request(app).get('/.well-known/webfinger?resource=acct:alice@archon.test');
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-type']).toContain('application/jrd+json');
+        expect(response.body.subject).toBe('acct:alice@archon.test');
+        expect(response.body.aliases).toEqual(['did:cid:alice']);
+
+        const rels = response.body.links.map((l: any) => l.rel);
+        expect(rels).toEqual(expect.arrayContaining([
+            'self',
+            'http://webfinger.net/rel/profile-page',
+            'https://w3id.org/did',
+            'http://webfinger.net/rel/avatar',
+        ]));
+        expect(response.body.links[0].href).toContain('/api/name/alice');
+    });
+});
+
+describe('herald session login', () => {
+    function keymasterVerifying(result: any) {
+        return { verifyResponse: jest.fn<any>().mockResolvedValue(result) };
+    }
+
+    it('rejects a GET login with no response parameter', async () => {
+        const { app } = mount();
+
+        const response = await request(app).get('/api/login');
+
+        expect(response.status).toBe(400);
+        expect(response.body).toEqual({ error: 'Missing or invalid response param' });
+    });
+
+    it('reports not authenticated when the response carries no challenge', async () => {
+        const keymaster = keymasterVerifying({ match: false });
+        const { app } = mount({ keymaster });
+
+        const get = await request(app).get('/api/login?response=abc');
+        expect(get.status).toBe(200);
+        expect(get.body).toEqual({ authenticated: false });
+
+        const post = await request(app).post('/api/login').send({ response: 'abc' });
+        expect(post.body).toEqual({ authenticated: false });
+    });
+
+    it('authenticates a verified response and records the login', async () => {
+        const db = createDb();
+        const keymaster = keymasterVerifying({
+            match: true,
+            challenge: 'did:cid:challenge',
+            responder: 'did:cid:alice',
+        });
+        const { app } = mount({ db, keymaster });
+
+        const response = await request(app).get('/api/login?response=abc');
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ authenticated: true });
+        expect(db.setUser).toHaveBeenCalledWith('did:cid:alice', expect.objectContaining({ logins: 1 }));
+    });
+
+    it('increments the login count for a returning user', async () => {
+        const db = createDb({ 'did:cid:alice': { logins: 4, firstLogin: 'earlier' } });
+        const keymaster = keymasterVerifying({
+            match: true,
+            challenge: 'did:cid:challenge2',
+            responder: 'did:cid:alice',
+        });
+        const { app } = mount({ db, keymaster });
+
+        await request(app).post('/api/login').send({ response: 'abc' });
+
+        expect(db.setUser).toHaveBeenCalledWith('did:cid:alice', expect.objectContaining({ logins: 5 }));
+    });
+
+    it('reports a login failure as 500', async () => {
+        const keymaster = { verifyResponse: jest.fn<any>().mockRejectedValue(new Error('gatekeeper down')) };
+        const { app } = mount({ keymaster });
+
+        const response = await request(app).get('/api/login?response=abc');
+
+        expect(response.status).toBe(500);
+    });
+
+    it('destroys the session on logout', async () => {
+        const { app } = mount({ session: { user: { did: 'did:cid:alice' } } });
+
+        const response = await request(app).post('/api/logout');
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ ok: true });
+    });
+});
+
+describe('herald check-auth', () => {
+    it('reports an anonymous caller', async () => {
+        const { app } = mount();
+
+        const response = await request(app).get('/api/check-auth');
+
+        expect(response.status).toBe(200);
+        expect(response.body).toMatchObject({ isAuthenticated: false, userDID: null, isOwner: false });
+    });
+
+    it('reports an authenticated non-owner with their profile', async () => {
+        const db = createDb({ 'did:cid:alice': { name: 'alice', logins: 2 } });
+        const { app } = mount({ db, session: { user: { did: 'did:cid:alice' } } });
+
+        const response = await request(app).get('/api/check-auth');
+
+        expect(response.body).toMatchObject({
+            isAuthenticated: true,
+            userDID: 'did:cid:alice',
+            isOwner: false,
+            profile: { name: 'alice' },
+        });
+    });
+
+    it('flags the configured owner', async () => {
+        const db = createDb({ 'did:cid:owner': { name: 'owner' } });
+        const { app } = mount({ db, session: { user: { did: 'did:cid:owner' } } });
+
+        const response = await request(app).get('/api/check-auth');
+
+        expect(response.body.isOwner).toBe(true);
+    });
+});
+
+describe('herald profile', () => {
+    it('404s an unknown profile', async () => {
+        const { app } = mount({ session: { user: { did: 'did:cid:alice' } } });
+
+        const response = await request(app).get('/api/profile/did:cid:nobody');
+
+        expect(response.status).toBe(404);
+    });
+
+    it('marks the caller own profile', async () => {
+        const db = createDb({
+            'did:cid:alice': { name: 'alice' },
+            'did:cid:bob': { name: 'bob' },
+        });
+        const { app } = mount({ db, session: { user: { did: 'did:cid:alice' } } });
+
+        const own = await request(app).get('/api/profile/did:cid:alice');
+        expect(own.status).toBe(200);
+        expect(own.body).toMatchObject({ did: 'did:cid:alice', isUser: true });
+
+        const other = await request(app).get('/api/profile/did:cid:bob');
+        expect(other.body).toMatchObject({ did: 'did:cid:bob', isUser: false });
+    });
+});
+
+describe('herald credential', () => {
+    it('404s when the authenticated user has no record', async () => {
+        const { app } = mount({ session: { user: { did: 'did:cid:ghost' } } });
+
+        const response = await request(app).get('/api/credential');
+
+        expect(response.status).toBe(404);
+        expect(response.body).toEqual({ error: 'User not found' });
+    });
+
+    it('reports no credential issued yet', async () => {
+        const db = createDb({ 'did:cid:alice': { name: 'alice' } });
+        const { app } = mount({ db, session: { user: { did: 'did:cid:alice' } } });
+
+        const response = await request(app).get('/api/credential');
+
+        expect(response.status).toBe(200);
+        expect(response.body).toMatchObject({ hasCredential: false, name: 'alice' });
+    });
+
+    it('returns the issued credential', async () => {
+        const db = createDb({
+            'did:cid:alice': { name: 'alice', credentialDid: 'did:cid:cred', credentialIssuedAt: 'then' },
+        });
+        const keymaster = { getCredential: jest.fn<any>().mockResolvedValue({ id: 'vc-1' }) };
+        const { app } = mount({ db, keymaster, session: { user: { did: 'did:cid:alice' } } });
+
+        const response = await request(app).get('/api/credential');
+
+        expect(response.status).toBe(200);
+        expect(response.body).toMatchObject({
+            hasCredential: true,
+            credentialDid: 'did:cid:cred',
+            credential: { id: 'vc-1' },
+        });
+    });
+
+    it('reports a credential fetch failure as 500 with a message', async () => {
+        const db = createDb({ 'did:cid:alice': { credentialDid: 'did:cid:cred' } });
+        const keymaster = { getCredential: jest.fn<any>().mockRejectedValue(new Error('resolver down')) };
+        const { app } = mount({ db, keymaster, session: { user: { did: 'did:cid:alice' } } });
+
+        const response = await request(app).get('/api/credential');
+
+        expect(response.status).toBe(500);
+        expect(response.body.error).toBe('resolver down');
+    });
+});
+
+describe('herald stateless name assignment', () => {
+    function keymasterFor(responder: string, extra: Record<string, any> = {}) {
+        return {
+            verifyResponse: jest.fn<any>().mockResolvedValue({ match: true, responder }),
+            setCurrentId: jest.fn<any>().mockResolvedValue(undefined),
+            bindCredential: jest.fn<any>().mockResolvedValue({ bound: true }),
+            issueCredential: jest.fn<any>().mockResolvedValue('did:cid:newcred'),
+            getCredential: jest.fn<any>().mockResolvedValue({ id: 'vc-1', credentialSubject: {} }),
+            updateCredential: jest.fn<any>().mockResolvedValue(true),
+            revokeCredential: jest.fn<any>().mockResolvedValue(true),
+            ...extra,
+        };
+    }
+
+    it('assigns a name and issues a membership credential', async () => {
+        const db = createDb({ 'did:cid:alice': {} });
+        const keymaster = keymasterFor('did:cid:alice');
+        const { app } = mount({ db, keymaster });
+
+        const response = await request(app)
+            .put('/api/name')
+            .set('Authorization', 'Bearer valid')
+            .send({ name: 'Alice' });
+
+        expect(response.status).toBe(200);
+        expect(response.body).toMatchObject({ ok: true, name: 'alice', did: 'did:cid:alice' });
+        // The name is normalized to lower case before storage.
+        expect(db.setUser).toHaveBeenCalledWith('did:cid:alice', expect.objectContaining({ name: 'alice' }));
+        expect(keymaster.issueCredential).toHaveBeenCalled();
+        expect(response.body.credentialDid).toBe('did:cid:newcred');
+    });
+
+    it('updates an existing credential instead of issuing a second one', async () => {
+        const db = createDb({ 'did:cid:alice': { name: 'old', credentialDid: 'did:cid:cred' } });
+        const keymaster = keymasterFor('did:cid:alice');
+        const { app } = mount({ db, keymaster });
+
+        const response = await request(app)
+            .put('/api/name')
+            .set('Authorization', 'Bearer valid')
+            .send({ name: 'newname' });
+
+        expect(response.status).toBe(200);
+        expect(keymaster.updateCredential).toHaveBeenCalledWith('did:cid:cred', expect.anything());
+        expect(keymaster.issueCredential).not.toHaveBeenCalled();
+    });
+
+    it('deletes a name and revokes its credential', async () => {
+        const db = createDb({ 'did:cid:alice': { name: 'alice', credentialDid: 'did:cid:cred' } });
+        const keymaster = keymasterFor('did:cid:alice');
+        const { app } = mount({ db, keymaster });
+
+        const response = await request(app)
+            .delete('/api/name')
+            .set('Authorization', 'Bearer valid');
+
+        expect(response.status).toBe(200);
+        expect(response.body.ok).toBe(true);
+        expect(keymaster.revokeCredential).toHaveBeenCalledWith('did:cid:cred');
+        expect(db.setUser).toHaveBeenCalledWith('did:cid:alice', expect.not.objectContaining({ name: 'alice' }));
+    });
+
+    it('rejects a delete with no bearer token, unknown user, or no name', async () => {
+        const noToken = mount();
+        await expect(request(noToken.app).delete('/api/name')).resolves.toMatchObject({ status: 401 });
+
+        const ghost = mount({ keymaster: keymasterFor('did:cid:ghost') });
+        const missing = await request(ghost.app).delete('/api/name').set('Authorization', 'Bearer valid');
+        expect(missing.status).toBe(404);
+
+        const noName = mount({
+            db: createDb({ 'did:cid:alice': { logins: 1 } }),
+            keymaster: keymasterFor('did:cid:alice'),
+        });
+        const nameless = await request(noName.app).delete('/api/name').set('Authorization', 'Bearer valid');
+        expect(nameless.status).toBe(404);
+        expect(nameless.body.message).toMatch(/No name to delete/);
+    });
+
+    it('reports a keymaster failure during assignment as 500', async () => {
+        const db = createDb({ 'did:cid:alice': {} });
+        const keymaster = keymasterFor('did:cid:alice', {
+            issueCredential: jest.fn<any>().mockRejectedValue(new Error('issuer down')),
+        });
+        const { app } = mount({ db, keymaster });
+
+        const response = await request(app)
+            .put('/api/name')
+            .set('Authorization', 'Bearer valid')
+            .send({ name: 'alice' });
+
+        expect(response.status).toBe(500);
+    });
+});


### PR DESCRIPTION
## ⚠️ This PR lowers the headline coverage number, on purpose

**96.52% → 92.91%.** Read the second table before reacting:

| | before | after |
| --- | --- | --- |
| covered lines | 7,763 | **8,060** (+297) |
| measured lines | 8,043 | **8,675** (+632) |

632 lines that were *always* untested became **visible**, and 297 of them are now genuinely covered. Nothing got worse — the metric stopped flattering us. This is the same dynamic as #705, which is what started this whole thread: with no `collectCoverageFrom`, untested files are invisible rather than zero.

## Why

`index.ts` built its Express app at module scope and called `app.listen()` at import time, so importing it booted the server. Its **34 routes were untestable and uncounted** — the last instance of the pattern #705, #706 and #819 fixed elsewhere.

## What

Split into three files:

- **`config.ts`** — the environment-derived constants. Extracting these *first* meant the 38 constant references inside the moved code needed no rewriting at all.
- **`routes.ts`** — `createHeraldRoutes(ctx)`, returning `{ router, startDmailPollLoop }` (the latter is the only symbol the bootstrap still needs).
- **`index.ts`** — 1,490 → ~210 lines, bootstrap only: app creation, session, service identity, database/keymaster wiring, listen.

`keymaster`, `db`, `emailBridge` and `serviceDID` are assigned *after* the routes register, so they are read lazily through a `HeraldContext` the bootstrap populates.

## Behaviour-preserving — verified, not asserted

The block was moved **programmatically** and diffed against the original with the same transformations applied: **it matches exactly**, modulo indentation from `eslint --fix`. Route set **identical (34 before, 34 after)**. The service's own `tsc -p tsconfig.json` is clean.

Two hazards worth recording for whoever does this next:

- A naive `\bkeymaster\b` rewrite **corrupted import specifiers** — `'@didcid/keymaster'` became `'@didcid/ctx.keymaster'`. String literals now get stashed before the identifier rewrite.
- The object shorthand `serviceDID,` became invalid syntax as `ctx.serviceDID,`. **`tsc` caught it** — which is exactly why the diff alone is not sufficient verification.

`multer` is declared in root `devDependencies` at herald's own `^2.2.0` so `routes.ts` resolves in CI (`services/*` are not workspaces, so `npm ci` never installs their dependencies — same as `macaroons.js` in #817, with the same version-sync obligation).

## Tests

42 tests, taking `routes.ts` to **45%**: public endpoints, authentication and owner gates, name validation, the **full name lifecycle** (assign, credential issue vs update, delete with revocation), webfinger, session login and login-count increment, check-auth, profile, and credential.

Two of my assertions were wrong and the code was right — corrected to match actual behaviour rather than the reverse: `/api/users` returns an array of DIDs (not a map), and `/api/name` **authenticates before it validates**, so name-validation tests need a bearer token to reach the checks at all.

## Follow-up

The remaining 55% of `routes.ts` is the awkward tail — SendGrid inbound-email webhook, IPNS publishing, the dmail poll loop, LNURLp callback — each needing real fixture work. Deliberately split out rather than rushed into an already-large refactor.

With this merged, **every Archon service is now testable**; `collectCoverageFrom` scoped per-directory becomes the natural next step to stop this class of blind spot recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)