### PR TITLE
fix(gatekeeper): cancel the save timer when stop() fails, and close the last coverage gaps

### DIFF
--- a/packages/gatekeeper/src/db/json-cache.ts
+++ b/packages/gatekeeper/src/db/json-cache.ts
@@ -16,11 +16,15 @@ export default class DbJsonCache extends AbstractJson {
     }
 
     async stop(): Promise<void> {
-        this.saveDb(); // Save the current state one last time
-
-        if (this.saveLoopTimeoutId !== null) {
-            clearTimeout(this.saveLoopTimeoutId); // Cancel the next scheduled saveLoop
-            this.saveLoopTimeoutId = null; // Reset the timeout ID
+        // Cancel the scheduled save even if the final save throws — otherwise an
+        // unwritable database leaves the timer armed and the process can never exit.
+        try {
+            this.saveDb(); // Save the current state one last time
+        } finally {
+            if (this.saveLoopTimeoutId !== null) {
+                clearTimeout(this.saveLoopTimeoutId); // Cancel the next scheduled saveLoop
+                this.saveLoopTimeoutId = null; // Reset the timeout ID
+            }
         }
     }
 

--- a/tests/didcomm/config.test.ts
+++ b/tests/didcomm/config.test.ts
@@ -1,0 +1,33 @@
+import config from '../../services/didcomm/server/src/config.js';
+
+describe('didcomm service config', () => {
+    it('provides defaults for every setting', () => {
+        expect(config).toMatchObject({
+            gatekeeperURL: expect.any(String),
+            didcommPort: expect.any(Number),
+            bindAddress: expect.any(String),
+            uploadLimit: expect.any(String),
+            messageTtlMs: expect.any(Number),
+            db: expect.any(String),
+            redisURL: expect.any(String),
+            torProxy: expect.any(String),
+            allowPrivateEgress: expect.any(Boolean),
+        });
+    });
+
+    it('defaults egress to Tor-less and private destinations disallowed', () => {
+        // These two gate outbound delivery, so their defaults are the safe ones:
+        // no proxy configured, and private/loopback destinations refused unless
+        // explicitly opted into for dev.
+        expect(config.torProxy).toBe(process.env.ARCHON_DIDCOMM_TOR_PROXY || '');
+        expect(config.allowPrivateEgress).toBe(
+            process.env.ARCHON_DIDCOMM_ALLOW_PRIVATE_EGRESS === 'true',
+        );
+    });
+
+    it('defaults the message TTL to seven days', () => {
+        if (!process.env.ARCHON_DIDCOMM_MESSAGE_TTL_MS) {
+            expect(config.messageTtlMs).toBe(7 * 24 * 60 * 60 * 1000);
+        }
+    });
+});

--- a/tests/gatekeeper/db-json-backends.test.ts
+++ b/tests/gatekeeper/db-json-backends.test.ts
@@ -1,0 +1,218 @@
+import { jest } from '@jest/globals';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import DbJson from '../../packages/gatekeeper/src/db/json.ts';
+import DbJsonCache from '../../packages/gatekeeper/src/db/json-cache.ts';
+import type { GatekeeperEvent } from '../../packages/clients/src/gatekeeper-types.ts';
+
+const DID = 'did:cid:bagaaieraabc';
+
+function event(opid: string): GatekeeperEvent {
+    return {
+        registry: 'local',
+        time: '2026-01-01T00:00:00Z',
+        did: DID,
+        opid,
+        operation: { type: 'create' } as any,
+    };
+}
+
+let dir: string;
+let logSpy: any;
+let errorSpy: any;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'gk-json-'));
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+});
+
+describe('DbJson', () => {
+    it('creates an empty database file when none exists', async () => {
+        const db = new DbJson('gk', dir);
+
+        await expect(db.getEvents(DID)).resolves.toEqual([]);
+
+        const file = join(dir, 'gk.json');
+        expect(existsSync(file)).toBe(true);
+        expect(JSON.parse(readFileSync(file, 'utf-8'))).toEqual({ dids: {} });
+    });
+
+    it('creates the data folder on demand', async () => {
+        const nested = join(dir, 'deeply', 'nested');
+        const db = new DbJson('gk', nested);
+
+        await db.addEvent(DID, event('op1'));
+
+        expect(existsSync(join(nested, 'gk.json'))).toBe(true);
+    });
+
+    it('persists events to disk and reads them back in a fresh instance', async () => {
+        const db = new DbJson('gk', dir);
+        await db.addEvent(DID, event('op1'));
+
+        const reopened = new DbJson('gk', dir);
+        const events = await reopened.getEvents(DID);
+        expect(events.map(e => e.opid)).toEqual(['op1']);
+    });
+
+    it('recovers from a corrupt file by starting empty', async () => {
+        const file = join(dir, 'gk.json');
+        writeFileSync(file, '{ not valid json');
+
+        const db = new DbJson('gk', dir);
+
+        await expect(db.getEvents(DID)).resolves.toEqual([]);
+        // The unreadable file is replaced rather than left in place.
+        expect(JSON.parse(readFileSync(file, 'utf-8'))).toEqual({ dids: {} });
+    });
+
+    it('deletes the database file on reset', async () => {
+        const db = new DbJson('gk', dir);
+        await db.addEvent(DID, event('op1'));
+        const file = join(dir, 'gk.json');
+        expect(existsSync(file)).toBe(true);
+
+        await db.resetDb();
+
+        expect(existsSync(file)).toBe(false);
+        await expect(db.getEvents(DID)).resolves.toEqual([]);
+    });
+
+    it('is a no-op to reset when no file exists', async () => {
+        const db = new DbJson('never-written', dir);
+
+        await expect(db.resetDb()).resolves.toBeUndefined();
+    });
+});
+
+describe('DbJsonCache', () => {
+    // start() schedules a repeating save; every test must stop() it or the timer
+    // keeps Jest alive, and CI runs without --forceExit.
+    async function withCache(fn: (db: DbJsonCache) => Promise<void>): Promise<void> {
+        const db = new DbJsonCache('gk', dir);
+        try {
+            await fn(db);
+        } finally {
+            await db.stop();
+        }
+    }
+
+    it('buffers writes in memory and flushes them on stop', async () => {
+        await withCache(async db => {
+            // The constructor already wrote an empty file: loadDb() falls into its
+            // catch for a missing file and saves the empty database immediately.
+            const file = join(dir, 'gk.json');
+            expect(JSON.parse(readFileSync(file, 'utf-8'))).toEqual({ dids: {} });
+
+            await db.addEvent(DID, event('op1'));
+
+            // writeDb only updates the cache, so the file is still the empty one.
+            expect(JSON.parse(readFileSync(file, 'utf-8'))).toEqual({ dids: {} });
+
+            await db.stop();
+
+            const written = JSON.parse(readFileSync(file, 'utf-8'));
+            expect(Object.keys(written.dids)).toHaveLength(1);
+        });
+    });
+
+    it('loads an existing file into the cache', async () => {
+        const seeded = { dids: { bagaaieraabc: [event('seeded')] } };
+        writeFileSync(join(dir, 'gk.json'), JSON.stringify(seeded));
+
+        await withCache(async db => {
+            const events = await db.getEvents(DID);
+            expect(events.map(e => e.opid)).toEqual(['seeded']);
+        });
+    });
+
+    it('starts empty when the file is corrupt or has no dids key', async () => {
+        writeFileSync(join(dir, 'gk.json'), '{ not valid json');
+        await withCache(async db => {
+            await expect(db.getEvents(DID)).resolves.toEqual([]);
+        });
+
+        // A structurally valid file missing `dids` is treated the same way.
+        writeFileSync(join(dir, 'other.json'), JSON.stringify({ somethingElse: true }));
+        const db = new DbJsonCache('other', dir);
+        try {
+            await expect(db.getEvents(DID)).resolves.toEqual([]);
+        } finally {
+            await db.stop();
+        }
+    });
+
+    it('schedules a repeating save that stop() cancels', async () => {
+        const db = new DbJsonCache('gk', dir);
+        await db.start();
+
+        expect(existsSync(join(dir, 'gk.json'))).toBe(true);
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('DID db saved'));
+
+        // Without this the 20s timer would keep the process alive.
+        await db.stop();
+    });
+
+    it('fails fast when the data folder cannot be created', async () => {
+        // Point the data folder through a file, so mkdir cannot succeed.
+        const blocker = join(dir, 'a-file');
+        writeFileSync(blocker, 'x');
+
+        // The constructor calls loadDb(), which saves on the missing-file path — so
+        // an unwritable folder surfaces at construction rather than being swallowed
+        // later by saveLoop's catch.
+        expect(() => new DbJsonCache('gk', join(blocker, 'sub'))).toThrow(/ENOTDIR|ENOENT/);
+    });
+
+    it('logs a save failure from the loop instead of throwing', async () => {
+        const db = new DbJsonCache('gk', dir);
+        try {
+            // Make the next save fail by replacing the target with a directory.
+            rmSync(join(dir, 'gk.json'));
+            mkdirSync(join(dir, 'gk.json'));
+
+            await expect(db.start()).resolves.toBeUndefined();
+            expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Error in saveLoop'));
+        } finally {
+            // stop() rethrows the failed save, but must still cancel the timer —
+            // otherwise the armed timeout keeps the process alive forever.
+            await expect(db.stop()).rejects.toThrow();
+        }
+    });
+
+    it('cancels the scheduled save even when the final save fails', async () => {
+        const db = new DbJsonCache('gk', dir);
+        await db.start();
+
+        // Make the final save fail by replacing the target file with a directory.
+        rmSync(join(dir, 'gk.json'));
+        mkdirSync(join(dir, 'gk.json'));
+
+        await expect(db.stop()).rejects.toThrow();
+
+        // The timer is cleared regardless, so a second stop is a quiet no-op path.
+        expect((db as any).saveLoopTimeoutId).toBeNull();
+    });
+
+    it('clears the cache and the file on reset', async () => {
+        await withCache(async db => {
+            await db.addEvent(DID, event('op1'));
+            await db.stop(); // flush to disk
+            expect(existsSync(join(dir, 'gk.json'))).toBe(true);
+
+            const fresh = await db.resetDb();
+
+            expect(fresh).toEqual({ dids: {} });
+            await expect(db.getEvents(DID)).resolves.toEqual([]);
+        });
+    });
+});

--- a/tests/keymaster/wallet-cache.test.ts
+++ b/tests/keymaster/wallet-cache.test.ts
@@ -1,0 +1,68 @@
+import { jest } from '@jest/globals';
+
+import WalletCache from '../../packages/keymaster/src/db/cache.ts';
+import type { StoredWallet, WalletBase } from '../../packages/keymaster/src/types.ts';
+
+const wallet = { version: 2, seed: {}, counter: 0, current: 'Alice', ids: {} } as StoredWallet;
+const other = { version: 2, seed: {}, counter: 1, current: 'Bob', ids: {} } as StoredWallet;
+
+function baseWallet(stored: StoredWallet | null = null) {
+    return {
+        saveWallet: jest.fn<any>().mockResolvedValue(true),
+        loadWallet: jest.fn<any>().mockResolvedValue(stored),
+    } as unknown as WalletBase;
+}
+
+describe('WalletCache', () => {
+    it('reads through to the base wallet only once', async () => {
+        const base = baseWallet(wallet);
+        const cache = new WalletCache(base);
+
+        await expect(cache.loadWallet()).resolves.toEqual(wallet);
+        await expect(cache.loadWallet()).resolves.toEqual(wallet);
+
+        expect(base.loadWallet).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps asking the base wallet while it has nothing to cache', async () => {
+        const base = baseWallet(null);
+        const cache = new WalletCache(base);
+
+        await expect(cache.loadWallet()).resolves.toBeNull();
+        await expect(cache.loadWallet()).resolves.toBeNull();
+
+        // A null result is not cached, so each call re-reads.
+        expect(base.loadWallet).toHaveBeenCalledTimes(2);
+    });
+
+    it('writes through and serves the saved wallet from cache', async () => {
+        const base = baseWallet(wallet);
+        const cache = new WalletCache(base);
+
+        await expect(cache.saveWallet(other)).resolves.toBe(true);
+        expect(base.saveWallet).toHaveBeenCalledWith(other, false);
+
+        // The save populated the cache, so no read reaches the base wallet.
+        await expect(cache.loadWallet()).resolves.toEqual(other);
+        expect(base.loadWallet).not.toHaveBeenCalled();
+    });
+
+    it('passes the overwrite flag through', async () => {
+        const base = baseWallet();
+        const cache = new WalletCache(base);
+
+        await cache.saveWallet(wallet, true);
+
+        expect(base.saveWallet).toHaveBeenCalledWith(wallet, true);
+    });
+
+    it('reports a base-wallet save failure', async () => {
+        const base = {
+            saveWallet: jest.fn<any>().mockResolvedValue(false),
+            loadWallet: jest.fn<any>().mockResolvedValue(null),
+        } as unknown as WalletBase;
+        const cache = new WalletCache(base);
+
+        await expect(cache.saveWallet(wallet)).resolves.toBe(false);
+    });
+});


### PR DESCRIPTION
## A real resource leak, found by writing the tests

`DbJsonCache.stop()` did not cancel its save timer when the final save threw:

```js
async stop() {
    this.saveDb();                 // throws if the write fails
    if (this.saveLoopTimeoutId !== null) {
        clearTimeout(...);         // ← never reached
    }
}
```

**A gatekeeper on the `json-cache` backend with an unwritable database cannot shut down.** `stop()` throws, the 20-second save timer stays armed, and the process never exits — a hung container until the orchestrator SIGKILLs it.

I found it the hard way: a test hung for 400 seconds, which is precisely the symptom.

Fixed with `try/finally` so the timer is always cancelled while the save error still propagates to the caller, plus a regression test asserting `saveLoopTimeoutId` is null after a failed stop.

## Coverage

Closes the four files still at 0% after #822 exposed them. **No file in the repo is now below 60%.**

| file | before | after |
| --- | --- | --- |
| `packages/gatekeeper/src/db/json-cache.ts` | 0% | **97.2%** |
| `packages/gatekeeper/src/db/json.ts` | 0% | **100%** |
| `packages/keymaster/src/db/cache.ts` | 0% | **100%** |
| `services/didcomm/server/src/config.js` | 0% | **100%** |
| repo total | 95.19% | **95.85%** |

1,945 tests passing, eslint clean.

## Two construction-time behaviours, now documented by test

Both contradicted my initial assumptions, so they are worth stating:

- **The constructor writes a file.** `loadDb()` falls into its catch on a missing file and immediately saves an empty database, so disk is touched before any explicit save.
- **The constructor throws when the data folder cannot be created**, rather than deferring to `saveLoop`'s catch — because that save runs during construction.

Also covered: `WalletCache` does **not** cache a null result, so it keeps re-reading until the base wallet has something (correct, but easy to misread as a caching bug).

## Left alone

`DbJsonCache.loadDb()` reads and parses the file **twice** — assigning `dbCache` from one parse, then overwriting it with another. Wasteful, not incorrect, so unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)