### PR TITLE
test(keymaster): cover the DIDComm protocol builders' optional branches

### DIFF
--- a/tests/keymaster/didcomm-protocols.test.ts
+++ b/tests/keymaster/didcomm-protocols.test.ts
@@ -13,11 +13,15 @@ import {
     DISCOVER_FEATURES_QUERIES_TYPE,
     DISCOVER_FEATURES_DISCLOSE_TYPE,
     OUT_OF_BAND_INVITATION_TYPE,
+    offerCredential,
+    requestCredential,
     issueCredentialMessage,
     requestPresentation,
     presentationMessage,
     attachedJson,
     ISSUE_CREDENTIAL_TYPE,
+    ISSUE_CREDENTIAL_OFFER_TYPE,
+    ISSUE_CREDENTIAL_REQUEST_TYPE,
     PRESENT_PROOF_REQUEST_TYPE,
     PRESENT_PROOF_PRESENTATION_TYPE,
     VC_ATTACHMENT_FORMAT,
@@ -135,5 +139,223 @@ describe('coordinate-mediation 2.0 builders', () => {
         const list = keylist(['did:cid:bob']);
         expect(list.type).toBe(KEYLIST_TYPE);
         expect((list.body as any).keys[0]).toEqual({ recipient_did: 'did:cid:bob' });
+    });
+});
+
+// The builders above are exercised with their optional arguments omitted, which
+// leaves every `thid ? ... : {}` and default-parameter branch untaken. These
+// cover the other side — the threading and comment paths that message
+// correlation actually depends on.
+
+describe('optional and default parameters', () => {
+    it('honours a non-default trust ping response flag', () => {
+        expect(trustPing().body.response_requested).toBe(true);
+        expect(trustPing(false).body.response_requested).toBe(false);
+    });
+
+    it('honours a non-default discover-features match', () => {
+        const defaulted = discoverFeaturesQuery().body.queries as any[];
+        expect(defaulted[0].match).toBe('*');
+
+        const specific = discoverFeaturesQuery('https://didcomm.org/trust-ping/*').body.queries as any[];
+        expect(specific[0].match).toBe('https://didcomm.org/trust-ping/*');
+        expect(specific[0]['feature-type']).toBe('protocol');
+    });
+
+    it('merges an out-of-band body over the default accept list', () => {
+        const bare = outOfBandInvitation('did:cid:alice');
+        expect(bare.body).toEqual({ accept: ['didcomm/v2'] });
+
+        const withGoal = outOfBandInvitation('did:cid:alice', {
+            goal_code: 'issue-vc',
+            goal: 'Issue a credential',
+        });
+        expect(withGoal.body).toEqual({
+            accept: ['didcomm/v2'],
+            goal_code: 'issue-vc',
+            goal: 'Issue a credential',
+        });
+
+        // An explicit accept overrides the default rather than appending to it.
+        const overridden = outOfBandInvitation('did:cid:alice', { accept: ['didcomm/v1'] });
+        expect(overridden.body.accept).toEqual(['didcomm/v1']);
+    });
+});
+
+describe('out-of-band URL encoding', () => {
+    const invitation = { type: OUT_OF_BAND_INVITATION_TYPE, from: 'did:cid:alice', body: {} };
+
+    it('appends _oob with ? on a bare base and & when the base already has a query', () => {
+        expect(encodeOutOfBandInvitation(invitation)).toContain('https://didcomm.org?_oob=');
+
+        const custom = encodeOutOfBandInvitation(invitation, 'https://wallet.test/connect');
+        expect(custom).toContain('https://wallet.test/connect?_oob=');
+
+        const withQuery = encodeOutOfBandInvitation(invitation, 'https://wallet.test/connect?ref=email');
+        expect(withQuery).toContain('?ref=email&_oob=');
+    });
+
+    it('produces url-safe base64 with no padding', () => {
+        const encoded = encodeOutOfBandInvitation(invitation);
+        const oob = encoded.split('_oob=')[1];
+
+        expect(oob).not.toMatch(/[+/=]/);
+    });
+
+    it('round-trips through a full URL or a bare _oob value', () => {
+        const url = encodeOutOfBandInvitation(invitation, 'https://wallet.test/connect?ref=email');
+        expect(decodeOutOfBandInvitation(url)).toEqual(invitation);
+
+        const bare = url.split('_oob=')[1];
+        expect(decodeOutOfBandInvitation(bare)).toEqual(invitation);
+    });
+
+    it('round-trips a payload containing characters that differ between base64 alphabets', () => {
+        // '?' and '~' push the encoder into the +/ range that must be substituted.
+        const tricky = { ...invitation, body: { goal: 'a?b~c>d???' } };
+
+        const encoded = encodeOutOfBandInvitation(tricky);
+        expect(decodeOutOfBandInvitation(encoded)).toEqual(tricky);
+    });
+});
+
+describe('issue-credential optional fields', () => {
+    it('omits an absent comment and includes a present one', () => {
+        expect(offerCredential()).toEqual({ type: ISSUE_CREDENTIAL_OFFER_TYPE, body: {} });
+        expect(offerCredential('please accept')).toEqual({
+            type: ISSUE_CREDENTIAL_OFFER_TYPE,
+            body: { comment: 'please accept' },
+        });
+    });
+
+    it('threads a request only when a thid is supplied', () => {
+        const untethered = requestCredential();
+        expect(untethered.thid).toBeUndefined();
+        expect(untethered.body).toEqual({});
+
+        const threaded = requestCredential('thid-1');
+        expect(threaded.thid).toBe('thid-1');
+
+        const both = requestCredential('thid-1', 'please issue');
+        expect(both).toEqual({
+            type: ISSUE_CREDENTIAL_REQUEST_TYPE,
+            thid: 'thid-1',
+            body: { comment: 'please issue' },
+        });
+
+        // A comment without a thid must not invent one.
+        const commentOnly = requestCredential(undefined, 'please issue');
+        expect(commentOnly.thid).toBeUndefined();
+        expect(commentOnly.body).toEqual({ comment: 'please issue' });
+    });
+
+    it('threads and comments an issued credential independently', () => {
+        const credential = { id: 'did:cid:vc' };
+
+        const bare = issueCredentialMessage(credential);
+        expect(bare.thid).toBeUndefined();
+        expect(bare.body).not.toHaveProperty('comment');
+
+        const threaded = issueCredentialMessage(credential, { thid: 'thid-1' });
+        expect(threaded.thid).toBe('thid-1');
+        expect(threaded.body).not.toHaveProperty('comment');
+
+        const commented = issueCredentialMessage(credential, { comment: 'here you go' });
+        expect(commented.thid).toBeUndefined();
+        expect((commented.body as any).comment).toBe('here you go');
+
+        const both = issueCredentialMessage(credential, { thid: 'thid-1', comment: 'here you go' });
+        expect(both.thid).toBe('thid-1');
+        // The formats block survives alongside the comment.
+        expect((both.body as any).formats[0].format).toBe(VC_ATTACHMENT_FORMAT);
+        expect(attachedJson(both)).toEqual(credential);
+    });
+});
+
+describe('present-proof optional fields', () => {
+    it('omits an absent comment on a presentation request', () => {
+        expect(requestPresentation().body).toEqual({});
+        expect(requestPresentation('prove it').body).toEqual({ comment: 'prove it' });
+    });
+
+    it('threads and comments a presentation independently', () => {
+        const presentation = { id: 'did:cid:vp' };
+
+        const bare = presentationMessage(presentation);
+        expect(bare.thid).toBeUndefined();
+
+        const both = presentationMessage(presentation, { thid: 'thid-2', comment: 'as requested' });
+        expect(both.thid).toBe('thid-2');
+        expect((both.body as any).comment).toBe('as requested');
+        expect((both.body as any).formats[0].format).toBe(VP_ATTACHMENT_FORMAT);
+        expect(attachedJson(both)).toEqual(presentation);
+    });
+});
+
+describe('attachedJson lookup', () => {
+    it('reads a non-default attachment index', () => {
+        const message = {
+            attachments: [
+                { data: { json: { first: true } } },
+                { data: { json: { second: true } } },
+            ],
+        };
+
+        expect(attachedJson(message)).toEqual({ first: true });
+        expect(attachedJson(message, 1)).toEqual({ second: true });
+    });
+
+    it('returns undefined rather than throwing on a malformed message', () => {
+        expect(attachedJson({} as any)).toBeUndefined();
+        expect(attachedJson({ attachments: [] })).toBeUndefined();
+        expect(attachedJson({ attachments: [{}] })).toBeUndefined();
+        expect(attachedJson({ attachments: [{ data: {} }] })).toBeUndefined();
+        expect(attachedJson({ attachments: [{ data: { json: { a: 1 } } }] }, 5)).toBeUndefined();
+        expect(attachedJson(null as any)).toBeUndefined();
+    });
+});
+
+describe('coordinate-mediation threading', () => {
+    it('threads a grant only when a thid is supplied', () => {
+        const bare = mediateGrant('did:cid:router');
+        expect(bare.thid).toBeUndefined();
+        expect(bare.body).toEqual({ routing_did: 'did:cid:router' });
+
+        const threaded = mediateGrant('did:cid:router', 'thid-3');
+        expect(threaded.thid).toBe('thid-3');
+    });
+
+    it('threads a deny only when a thid is supplied', () => {
+        expect(mediateDeny().thid).toBeUndefined();
+        expect(mediateDeny('thid-4').thid).toBe('thid-4');
+    });
+
+    it('defaults keylist updates to add and honours remove', () => {
+        const added = keylistUpdate(['did:cid:a', 'did:cid:b']).body.updates as any[];
+        expect(added.map(u => u.action)).toEqual(['add', 'add']);
+        expect(added.map(u => u.recipient_did)).toEqual(['did:cid:a', 'did:cid:b']);
+
+        const removed = keylistUpdate(['did:cid:a'], 'remove').body.updates as any[];
+        expect(removed[0]).toEqual({ recipient_did: 'did:cid:a', action: 'remove' });
+    });
+
+    it('threads a keylist update response only when a thid is supplied', () => {
+        const updated = [{ recipient_did: 'did:cid:a', action: 'add' as const, result: 'success' as const }];
+
+        expect(keylistUpdateResponse(updated).thid).toBeUndefined();
+        expect(keylistUpdateResponse(updated, 'thid-5').thid).toBe('thid-5');
+    });
+
+    it('threads a keylist only when a thid is supplied', () => {
+        expect(keylist(['did:cid:a']).thid).toBeUndefined();
+
+        const threaded = keylist(['did:cid:a'], 'thid-6');
+        expect(threaded.thid).toBe('thid-6');
+        expect(threaded.body.keys).toEqual([{ recipient_did: 'did:cid:a' }]);
+    });
+
+    it('builds an empty keylist for no recipients', () => {
+        expect(keylist([]).body.keys).toEqual([]);
+        expect(keylistUpdate([]).body.updates).toEqual([]);
     });
 });


### PR DESCRIPTION
## Why this file

`didcomm-protocols.ts` sat at **96.2% lines but 38.9% branches** — the signature of code that runs in tests but only ever with one shape of input. Every builder was called with its optional arguments omitted, so each `thid ? { thid } : {}`, optional `comment`, and default parameter had one side that never executed.

Those branches are not incidental. **The threading identifier is what ties a DIDComm response back to its request** — and `requestCredential(thid)`, `mediateGrant(routingDid, thid)`, `keylistUpdateResponse(updated, thid)` and `keylist(dids, thid)` had never emitted a `thid` in any test.

## Result

| | before | after |
| --- | --- | --- |
| `didcomm-protocols.ts` branches | 38.9% | **100%** (36/36) |
| `didcomm-protocols.ts` lines | 96.2% | **100%** |
| repo branches | 83.15% | **83.90%** |

20 tests added (10 → 30). 1,965 passing, eslint clean. Test-only.

## Cases chosen for where this shape of code usually breaks

- **`requestCredential(undefined, comment)`** — a comment with no thid must not invent one. Easy to get backwards with spread-conditionals.
- **`encodeOutOfBandInvitation`** against a base that already carries a query string, exercising the `?` vs `&` separator — plus a round trip through a payload containing `?` and `~`, so the hand-rolled base64url substitution of `+`/`/` → `-`/`_` is actually exercised rather than assumed.
- **`attachedJson`** against malformed messages (`{}`, empty attachments, missing `data`, out-of-range index, `null`) — it parses data that arrived over the wire, so it must return `undefined` rather than throw.
- **`outOfBandInvitation`** with an explicit `accept`, confirming it **overrides** the default rather than appending to it.

## Reading the Coveralls number

Worth recording, since it caused me to misreport coverage repeatedly in earlier PRs: **Coveralls' headline blends lines and branches**:

```
lines    8157/8511  = 95.84%
branches 3483/4060  = 85.79%
combined 11640/12571 = 92.59%   ← the number on the badge
```

So the badge reads ~3pp below the lines-only figure by construction. **Lines are essentially done at ~95.9%; branches are the remaining dimension.** Next largest branch gaps: `keymaster.ts` (148 missed), `herald/routes.ts` (63), `gatekeeper.ts` (21), `mcp-server/tools.ts` (17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)