### PR TITLE
test(mcp-server): cover the secret redactor

### DIFF
--- a/tests/mcp-server/redact.test.ts
+++ b/tests/mcp-server/redact.test.ts
@@ -1,0 +1,210 @@
+import { redactSecretText, errorMessage } from '../../packages/mcp-server/src/redact.ts';
+
+// These assertions deliberately check that the secret is ABSENT from the output,
+// not merely that a placeholder appears — a redactor that emits "<redacted>" while
+// still leaking the value elsewhere in the string would otherwise pass.
+function expectRedacted(output: string, secret: string) {
+    expect(output).not.toContain(secret);
+    expect(output).toContain('<redacted>');
+}
+
+describe('redactSecretText: assignments', () => {
+    it('redacts a bare assignment for every recognised key', () => {
+        const keys = [
+            'ARCHON_ADMIN_API_KEY', 'ARCHON_PASSPHRASE', 'ARCHON_ENCRYPTED_PASSPHRASE',
+            'api_key', 'api-key', 'apikey', 'token', 'access_token',
+            'passphrase', 'password', 'mnemonic',
+            'recovery_phrase', 'recovery-phrase', 'recoveryPhrase',
+            'nsec', 'bolt11', 'adminKey', 'invoiceKey',
+        ];
+
+        for (const key of keys) {
+            const output = redactSecretText(`${key}=SUPERSECRET`);
+            expect([key, output]).toEqual([key, `${key}=<redacted>`]);
+        }
+    });
+
+    it('is case-insensitive on the key', () => {
+        expectRedacted(redactSecretText('TOKEN=SUPERSECRET'), 'SUPERSECRET');
+        expectRedacted(redactSecretText('PassPhrase=SUPERSECRET'), 'SUPERSECRET');
+    });
+
+    it('redacts single- and double-quoted values whole', () => {
+        expectRedacted(redactSecretText('token="secret with spaces"'), 'secret with spaces');
+        expectRedacted(redactSecretText("token='secret with spaces'"), 'secret with spaces');
+    });
+
+    it('redacts an unquoted multi-word passphrase up to the next assignment or EOL', () => {
+        expectRedacted(
+            redactSecretText('mnemonic=abandon abandon abandon about'),
+            'abandon abandon abandon about',
+        );
+
+        const followed = redactSecretText('passphrase=my secret words user=alice');
+        expect(followed).not.toContain('my secret words');
+        expect(followed).toContain('user=alice');
+
+        const beforeUrl = redactSecretText('passphrase=my secret words https://example.test/x');
+        expect(beforeUrl).not.toContain('my secret words');
+        expect(beforeUrl).toContain('https://example.test/x');
+    });
+
+    it('leaves unrelated assignments alone', () => {
+        const output = redactSecretText('user=alice registry=hyperswarm count=3');
+
+        expect(output).toBe('user=alice registry=hyperswarm count=3');
+        expect(output).not.toContain('<redacted>');
+    });
+
+    it('redacts several secrets in one string', () => {
+        const output = redactSecretText('token=aaa password=bbb user=carol');
+
+        expect(output).not.toContain('aaa');
+        expect(output).not.toContain('bbb');
+        expect(output).toContain('user=carol');
+    });
+});
+
+describe('redactSecretText: URLs', () => {
+    it('strips basic-auth credentials', () => {
+        const bothParts = redactSecretText('see https://alice:hunter2@example.test/path');
+        expect(bothParts).not.toContain('hunter2');
+        expect(bothParts).not.toContain('alice');
+
+        // A username with no password, and a password with no username.
+        const userOnly = redactSecretText('https://alice@example.test/path');
+        expect(userOnly).not.toContain('alice');
+
+        const passOnly = redactSecretText('https://:hunter2@example.test/path');
+        expect(passOnly).not.toContain('hunter2');
+    });
+
+    it('redacts secret query parameters and keeps the rest', () => {
+        for (const param of ['api_key', 'apikey', 'access_token', 'token', 'key', 'password', 'passphrase']) {
+            const output = redactSecretText(`https://example.test/x?${param}=SUPERSECRET&page=2`);
+            expect([param, output.includes('SUPERSECRET')]).toEqual([param, false]);
+            expect(output).toContain('page=2');
+        }
+    });
+
+    it('matches secret parameters case-insensitively', () => {
+        const output = redactSecretText('https://example.test/x?API_KEY=SUPERSECRET');
+
+        expect(output).not.toContain('SUPERSECRET');
+    });
+
+    it('emits a readable placeholder rather than a percent-encoded one', () => {
+        const output = redactSecretText('https://example.test/x?token=SUPERSECRET');
+
+        expect(output).toContain('<redacted>');
+        expect(output).not.toContain('%3Credacted%3E');
+    });
+
+    it('redacts an API key carried in the path for known provider hosts', () => {
+        for (const host of [
+            'eth-mainnet.alchemy.com',
+            'alchemy.com',
+            'mainnet.infura.io',
+            'infura.io',
+            'x.quicknode.com',
+        ]) {
+            const output = redactSecretText(`https://${host}/v2/SUPERSECRET`);
+            expect([host, output.includes('SUPERSECRET')]).toEqual([host, false]);
+            expect(output).toContain('/v2/<redacted>');
+        }
+    });
+
+    it('leaves the path alone for other hosts', () => {
+        const output = redactSecretText('https://example.test/v2/not-a-secret');
+
+        expect(output).toContain('/v2/not-a-secret');
+    });
+
+    it('does not treat a lookalike host as a provider host', () => {
+        // The patterns anchor on `(^|.)alchemy.com$`, so this must not match.
+        const output = redactSecretText('https://alchemy.com.evil.test/v2/PUBLICVALUE');
+
+        expect(output).toContain('PUBLICVALUE');
+    });
+
+    it('leaves an unparsable URL-like string untouched', () => {
+        // http:// with nothing after it fails the URL constructor, hitting the catch.
+        const output = redactSecretText('http://');
+
+        expect(output).toBe('http://');
+    });
+});
+
+describe('redactSecretText: input types', () => {
+    it('reads the message off an Error', () => {
+        const output = redactSecretText(new Error('failed with token=SUPERSECRET'));
+
+        expectRedacted(output, 'SUPERSECRET');
+    });
+
+    it('serialises a plain object and redacts inside it', () => {
+        const output = redactSecretText({ note: 'token=SUPERSECRET' });
+
+        expect(output).not.toContain('SUPERSECRET');
+        expect(output).toContain('note');
+    });
+
+    it('falls back to String(value) when serialisation yields nothing usable', () => {
+        // JSON.stringify(undefined) is undefined, and an empty string is falsy, so
+        // both fall through to String(value) rather than producing "undefined".
+        expect(redactSecretText(undefined)).toBe('undefined');
+        expect(redactSecretText('')).toBe('');
+        expect(redactSecretText(null)).toBe('null');
+    });
+
+    it('handles numbers and booleans', () => {
+        expect(redactSecretText(42)).toBe('42');
+        expect(redactSecretText(false)).toBe('false');
+    });
+});
+
+describe('errorMessage', () => {
+    it('prefers an `error` string property', () => {
+        const output = errorMessage({ error: 'boom token=SUPERSECRET', message: 'ignored' });
+
+        expect(output).toContain('boom');
+        expect(output).not.toContain('SUPERSECRET');
+        expect(output).not.toContain('ignored');
+    });
+
+    it('falls back to a `message` string property', () => {
+        const output = errorMessage({ message: 'boom token=SUPERSECRET' });
+
+        expect(output).toContain('boom');
+        expect(output).not.toContain('SUPERSECRET');
+    });
+
+    it('ignores a non-string error property and uses message instead', () => {
+        const output = errorMessage({ error: { nested: true }, message: 'the real message' });
+
+        expect(output).toBe('the real message');
+    });
+
+    it('reads an Error instance through its message property', () => {
+        expect(errorMessage(new Error('plain failure'))).toBe('plain failure');
+    });
+
+    it('serialises anything else', () => {
+        expect(errorMessage('a bare string')).toBe('a bare string');
+        expect(errorMessage(null)).toBe('null');
+        expect(errorMessage(undefined)).toBe('undefined');
+        expect(errorMessage(404)).toBe('404');
+        expect(errorMessage({ status: 500 })).toContain('500');
+    });
+
+    it('redacts secrets regardless of which shape carried them', () => {
+        for (const input of [
+            { error: 'passphrase=hunter2' },
+            { message: 'passphrase=hunter2' },
+            new Error('passphrase=hunter2'),
+            'passphrase=hunter2',
+        ]) {
+            expect(errorMessage(input)).not.toContain('hunter2');
+        }
+    });
+});


### PR DESCRIPTION
## Why

`redact.ts` had **no dedicated test file** — it was exercised only incidentally, through the plain-string path, leaving **65.2% branch coverage on the code that decides whether a secret reaches a log**. Untested branches here are the ones where a credential either does or does not get masked, and that failure is invisible until it is already in a logfile.

| | before | after |
| --- | --- | --- |
| `redact.ts` branches | 65.2% | **95.7%** (22/23) |
| `redact.ts` lines | — | **96.4%** |
| repo branches | 84.44% | **84.66%** |

24 tests. 2,002 passing, eslint clean. Test-only.

## Two choices specific to testing a redactor

**Every assertion checks the secret is ABSENT**, not merely that `<redacted>` appears. A redactor that emits the placeholder while still leaking the value elsewhere in the string would pass a naive `toContain('<redacted>')` check, so the helper asserts both directions.

**The provider-host matching is tested for bypass, not just for function.** `TOKEN_PATH_HOSTS` anchors on `(^|\.)alchemy\.com$`, so `https://alchemy.com.evil.test/v2/KEY` must **not** be treated as a provider host. It isn't — the anchoring is correct — but nothing asserted it, and an unanchored pattern would have let an attacker-controlled hostname influence redaction.

## Covered

- basic-auth credentials with username-only, password-only, and both
- all seven secret query parameters, case-insensitively
- provider API keys carried in the URL **path** (alchemy / infura / quicknode, bare and subdomain), and that other hosts' paths are left alone
- quoted, unquoted and multi-word passphrases, including where the unquoted match terminates (next assignment, following URL, or EOL)
- `Error`, plain object, `null`, `undefined`, number, boolean and empty-string inputs
- `errorMessage`'s three shapes, including a non-string `error` property falling through to `message`
- that unrelated assignments (`user=alice`) are untouched — a redactor that over-redacts is its own problem

## The one remaining branch

`redact.ts:30`'s `?? ['/']` fallback is unreachable: the replace callback only fires on a match of `/\/v\d+\/[^/?#]+/`, so the inner `/\/v\d+\//` match cannot fail. Left alone rather than contorting a test to reach dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)