### PR TITLE
test(herald): cover the inbound-email webhook secret and Tor routing

### DIFF
--- a/tests/herald/routes-env.test.ts
+++ b/tests/herald/routes-env.test.ts
@@ -1,0 +1,177 @@
+import { jest } from '@jest/globals';
+import express from 'express';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import request from 'supertest';
+
+// config.ts reads the environment at module-evaluation time, so these must be set
+// before the dynamic import below. They live in their own file because the main
+// routes suite needs them UNSET — a webhook secret would otherwise have to be
+// threaded through every inbound-email test, and TOR_PROXY would change the
+// LNURLp fetch path for all of them.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'herald-env-'));
+process.env.ARCHON_HERALD_JWT_KEY_PATH = path.join(tmpDir, 'oauth-signing-key.json');
+process.env.ARCHON_HERALD_DOMAIN = 'archon.test';
+process.env.ARCHON_HERALD_NAME = 'name-service';
+process.env.ARCHON_HERALD_WEBHOOK_SECRET = 'hook-secret';
+process.env.ARCHON_HERALD_TOR_PROXY = 'tor-host:9150';
+
+let createHeraldRoutes: any;
+let logSpy: any;
+let warnSpy: any;
+let errorSpy: any;
+
+beforeAll(async () => {
+    ({ createHeraldRoutes } = await import('../../services/herald/server/src/routes'));
+});
+
+beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+    jest.restoreAllMocks();
+});
+
+afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function createDb(users: Record<string, any> = {}) {
+    return {
+        getUser: jest.fn<any>(async (did: string) => users[did] ?? null),
+        setUser: jest.fn<any>(async () => {}),
+        deleteUser: jest.fn<any>(async () => true),
+        listUsers: jest.fn<any>(async () => users),
+        findDidByName: jest.fn<any>(async (name: string) =>
+            Object.entries(users).find(([, u]: any) => u.name === name)?.[0] ?? null),
+        setReplyToken: jest.fn<any>(), getReplyToken: jest.fn<any>(),
+        deleteExpiredReplyTokens: jest.fn<any>(async () => 0),
+        setEmailMapping: jest.fn<any>(), getEmailMapping: jest.fn<any>(),
+    };
+}
+
+function mount(overrides: { db?: any; keymaster?: any; emailBridge?: any } = {}) {
+    const ctx: any = {
+        keymaster: overrides.keymaster ?? {},
+        db: overrides.db ?? createDb(),
+        emailBridge: overrides.emailBridge ?? null,
+        serviceDID: 'did:cid:service',
+    };
+
+    const app = express();
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: true }));
+    app.use((req: any, _res, next) => {
+        req.session = { destroy: (cb: any) => cb?.() };
+        next();
+    });
+    const { router } = createHeraldRoutes(ctx);
+    app.use(router);
+
+    return { app, ctx };
+}
+
+describe('inbound email webhook secret', () => {
+    function bridge() {
+        return {
+            isConfigured: jest.fn<any>().mockReturnValue(true),
+            parseInboundEmail: jest.fn<any>((body: any) =>
+                body.from && body.to ? { ...body, subject: body.subject ?? '', text: body.text ?? '' } : null),
+            extractReplyToken: jest.fn<any>().mockReturnValue(null),
+            extractEmailAddress: jest.fn<any>((v: string) => v),
+            extractRecipientName: jest.fn<any>().mockReturnValue(null),
+            lookupToken: jest.fn<any>().mockResolvedValue(null),
+            storeEmailMapping: jest.fn<any>().mockResolvedValue(undefined),
+        };
+    }
+
+    it('rejects a request with no secret when one is configured', async () => {
+        const { app } = mount({ emailBridge: bridge() });
+
+        const response = await request(app)
+            .post('/api/inbound-email')
+            .send({ from: 'a@b.com', to: 'alice@archon.test' });
+
+        expect(response.status).toBe(401);
+        expect(response.body).toEqual({ error: 'Unauthorized' });
+    });
+
+    it('rejects a request whose secret does not match', async () => {
+        const { app } = mount({ emailBridge: bridge() });
+
+        const response = await request(app)
+            .post('/api/inbound-email?secret=wrong')
+            .send({ from: 'a@b.com', to: 'alice@archon.test' });
+
+        expect(response.status).toBe(401);
+    });
+
+    it('accepts a request carrying the configured secret', async () => {
+        const { app } = mount({ emailBridge: bridge() });
+
+        const response = await request(app)
+            .post('/api/inbound-email?secret=hook-secret')
+            .send({ from: 'a@b.com', to: 'postmaster@archon.test' });
+
+        // Past the gate: it reaches the recipient resolution and ignores the mail.
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ ok: true, action: 'no-recipient-ignored' });
+    });
+
+    it('checks the secret before parsing the body', async () => {
+        const eb = bridge();
+        const { app } = mount({ emailBridge: eb });
+
+        await request(app).post('/api/inbound-email').send({ nonsense: true });
+
+        // An unauthenticated caller must not reach the parser at all.
+        expect(eb.parseInboundEmail).not.toHaveBeenCalled();
+    });
+});
+
+describe('LNURLp callback over Tor', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => { global.fetch = originalFetch; });
+
+    function withEndpoint(endpoint: string) {
+        const db = createDb({ 'did:cid:alice': { name: 'alice' } });
+        return mount({
+            db,
+            keymaster: {
+                resolveDID: jest.fn<any>().mockResolvedValue({
+                    didDocument: { service: [{ type: 'Lightning', serviceEndpoint: endpoint }] },
+                }),
+            },
+        });
+    }
+
+    it('routes an .onion endpoint through the configured SOCKS proxy', async () => {
+        const { app } = withEndpoint('http://abcd.onion/invoice');
+        const fetchMock = jest.fn<any>().mockResolvedValue({ ok: true, json: async () => ({ pr: 'lnbc1' }) });
+        global.fetch = fetchMock as any;
+
+        const response = await request(app).get('/api/lnurlp/alice/callback?amount=100000');
+
+        expect(response.body).toMatchObject({ pr: 'lnbc1' });
+        // A dispatcher is attached only for .onion destinations.
+        expect(fetchMock.mock.calls[0][1].dispatcher).toBeDefined();
+    });
+
+    it('does not attach a proxy dispatcher for a clearnet endpoint', async () => {
+        const { app } = withEndpoint('https://ln.test/invoice');
+        const fetchMock = jest.fn<any>().mockResolvedValue({ ok: true, json: async () => ({ pr: 'lnbc2' }) });
+        global.fetch = fetchMock as any;
+
+        await request(app).get('/api/lnurlp/alice/callback?amount=100000');
+
+        expect(fetchMock.mock.calls[0][1].dispatcher).toBeUndefined();
+    });
+});

--- a/tests/herald/routes.test.ts
+++ b/tests/herald/routes.test.ts
@@ -1599,3 +1599,85 @@ describe('lightning endpoint resolution', () => {
         expect(response.body).toMatchObject({ status: 'ERROR', reason: 'resolver down' });
     });
 });
+
+describe('inbound email fallbacks', () => {
+    function bridge(over: Record<string, any> = {}) {
+        return {
+            isConfigured: jest.fn<any>().mockReturnValue(true),
+            parseInboundEmail: jest.fn<any>((body: any) =>
+                body.from && body.to
+                    ? { ...body, subject: body.subject ?? '(no subject)', text: body.text ?? '' }
+                    : null),
+            extractReplyToken: jest.fn<any>().mockReturnValue(null),
+            // Returning null forces the `|| email.from` fallback below.
+            extractEmailAddress: jest.fn<any>().mockReturnValue(null),
+            extractRecipientName: jest.fn<any>().mockReturnValue('alice'),
+            lookupToken: jest.fn<any>().mockResolvedValue(null),
+            storeEmailMapping: jest.fn<any>().mockResolvedValue(undefined),
+            ...over,
+        };
+    }
+
+    function keymaster() {
+        return {
+            setCurrentId: jest.fn<any>().mockResolvedValue(undefined),
+            createDmail: jest.fn<any>().mockResolvedValue('did:cid:dmail'),
+            sendDmail: jest.fn<any>().mockResolvedValue('did:cid:notice'),
+        };
+    }
+
+    it('falls back to the raw From header when no address can be extracted', async () => {
+        const km = keymaster();
+        const m = mount({ db: createDb({ 'did:cid:alice': { name: 'alice' } }), keymaster: km });
+        m.ctx.emailBridge = bridge();
+
+        await request(m.app)
+            .post('/api/inbound-email')
+            .send({ from: 'Weird Header <<>>', to: 'alice@archon.test', subject: 'hi', text: 'body' });
+
+        expect(km.createDmail).toHaveBeenCalledWith(
+            expect.objectContaining({ subject: expect.stringContaining('Weird Header') }),
+            { registry: 'hyperswarm' },
+        );
+    });
+
+    it('substitutes placeholder text for an empty body', async () => {
+        const km = keymaster();
+        const m = mount({ db: createDb({ 'did:cid:alice': { name: 'alice' } }), keymaster: km });
+        m.ctx.emailBridge = bridge();
+
+        await request(m.app)
+            .post('/api/inbound-email')
+            .send({ from: 'bob@ext.test', to: 'alice@archon.test', subject: 'hi' });
+
+        expect(km.createDmail).toHaveBeenCalledWith(
+            expect.objectContaining({ body: '(no text content)' }),
+            { registry: 'hyperswarm' },
+        );
+    });
+
+    it('applies the same fallbacks on the reply path', async () => {
+        const km = keymaster();
+        const m = mount({ db: createDb(), keymaster: km });
+        m.ctx.emailBridge = bridge({
+            extractReplyToken: jest.fn<any>().mockReturnValue('tok'),
+            lookupToken: jest.fn<any>().mockResolvedValue({
+                senderDid: 'did:cid:alice',
+                originalDmailDid: 'did:cid:orig',
+            }),
+        });
+
+        await request(m.app)
+            .post('/api/inbound-email')
+            .send({ from: 'Unparseable', to: 'reply+tok@parse.archon.test' });
+
+        expect(km.createDmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                subject: expect.stringContaining('Unparseable'),
+                body: '(no text content)',
+                reference: 'did:cid:orig',
+            }),
+            { registry: 'hyperswarm' },
+        );
+    });
+});


### PR DESCRIPTION
## Result

| | before | after |
| --- | --- | --- |
| `routes.ts` branches | 81.9% (35 missed) | **86.5%** (26 missed) |
| `routes.ts` lines | 88.8% | **89.7%** |
| repo branches | 86.06% | **86.46%** |

9 tests. 2,062 passing, eslint clean. Test-only.

## Two clusters were env-gated

`WEBHOOK_SECRET` and `TOR_PROXY` are read from `config.ts` at **module-evaluation time**, so they need their own test file with the env set before the dynamic import. The main routes suite requires them *unset* — otherwise every inbound-email test would have to thread a secret through, and the LNURLp fetch path would change for all of them.

## Webhook secret

Rejects a missing secret, rejects a mismatched one, accepts the configured one — and asserts the **secret is checked before the body is parsed**, so an unauthenticated caller never reaches the parser. That ordering is the actual security property; the status code alone would not prove it.

## Tor routing

An `.onion` endpoint gets a SOCKS dispatcher attached; a clearnet endpoint does not. That is the branch deciding whether a payment request leaves over clearnet, and nothing exercised either side.

## Fallbacks

An unparseable `From` header falling back to the raw header, and an empty body substituting placeholder text — on both the reply and unsolicited inbound paths.

## One of my own bugs, recorded because it is instructive

The `bridge(over)` helper built its object but **never spread `over` into it**, so the reply-path overrides were silently discarded and the test exercised the *unsolicited* path while claiming to test the reply path.

It surfaced only because the assertion was specific enough to fail on `createDmail` being called zero times. A looser "did not throw" assertion would have passed happily against the wrong branch.

That is the third helper-level mistake this session that produced a green test proving nothing — the others being an assertion looping over an empty mock-call list, and a test whose stated premise was wrong. **All three were caught by asserting on concrete call arguments rather than on absence of failure**, which seems worth generalising.

## Remaining

26 branches in `routes.ts`, now genuinely scattered — no cluster larger than 2, mostly `error.message || String(error)` fallbacks in catch blocks. Not worth a dedicated pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)