### PR TITLE
test(keymaster): cover WalletSQLite defaults and connection guards

### DIFF
--- a/tests/keymaster/wallet-db.test.ts
+++ b/tests/keymaster/wallet-db.test.ts
@@ -1,5 +1,5 @@
 import { mkdtemp, rm } from 'fs/promises';
-import { existsSync } from 'fs';
+import { existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -110,6 +110,74 @@ describe('WalletSQLite', () => {
             await expect(wallet.connect()).resolves.toBeUndefined();
             await expect(wallet.disconnect()).resolves.toBeUndefined();
             await expect(wallet.disconnect()).resolves.toBeUndefined();
+        });
+    });
+});
+
+describe('WalletSQLite defaults and guards', () => {
+    // NOTE: unlike WalletJson.saveWallet, which does mkdirSync(dataFolder,
+    // {recursive:true}), WalletSQLite.connect never creates its folder — it opens
+    // `${dataFolder}/${file}` directly and sqlite fails with SQLITE_CANTOPEN if the
+    // directory is absent. These tests therefore create `data/` first.
+    it('does not create its data folder, unlike WalletJson', async () => {
+        await withTempDir(async dir => {
+            const wallet = new WalletSQLite('wallet.db', join(dir, 'missing'));
+
+            await expect(wallet.saveWallet(walletOne)).rejects.toThrow(/SQLITE_CANTOPEN/);
+        });
+    });
+
+    it('defaults to data/wallet.db when constructed with no arguments', async () => {
+        await withTempDir(async dir => {
+            // The default path is relative to the working directory, so run from a
+            // temp dir rather than writing data/wallet.db into the repo.
+            const cwd = process.cwd();
+            process.chdir(dir);
+            mkdirSync(join(dir, 'data'), { recursive: true });
+            try {
+                const wallet = new WalletSQLite();
+                try {
+                    await expect(wallet.saveWallet(walletOne)).resolves.toBe(true);
+                    await expect(wallet.loadWallet()).resolves.toStrictEqual(walletOne);
+                    expect(existsSync(join(dir, 'data', 'wallet.db'))).toBe(true);
+                } finally {
+                    await wallet.disconnect();
+                }
+            } finally {
+                process.chdir(cwd);
+            }
+        });
+    });
+
+    it('create() applies the same defaults', async () => {
+        await withTempDir(async dir => {
+            const cwd = process.cwd();
+            process.chdir(dir);
+            mkdirSync(join(dir, 'data'), { recursive: true });
+            try {
+                const wallet = await WalletSQLite.create();
+                try {
+                    await expect(wallet.loadWallet()).resolves.toBeNull();
+                    expect(existsSync(join(dir, 'data', 'wallet.db'))).toBe(true);
+                } finally {
+                    await wallet.disconnect();
+                }
+            } finally {
+                process.chdir(cwd);
+            }
+        });
+    });
+
+    it('reports a failed connection rather than dereferencing a null handle', async () => {
+        await withTempDir(async dir => {
+            const wallet = new WalletSQLite('wallet.db', dir);
+            // Both methods call connect() first and then re-check the handle. Stub
+            // connect to a no-op so the handle stays null and the guard is reached —
+            // it is otherwise unreachable, since a successful connect always sets it.
+            (wallet as any).connect = async () => {};
+
+            await expect(wallet.saveWallet(walletOne)).rejects.toThrow('DB failed to connect.');
+            await expect(wallet.loadWallet()).rejects.toThrow('DB failed to connect.');
         });
     });
 });


### PR DESCRIPTION
## Result

| | before | after |
| --- | --- | --- |
| `db/sqlite.ts` branches | 53.8% (7/13) | **100%** (13/13) |
| `db/sqlite.ts` lines | 93.1% | **100%** |
| repo branches | 86.46% | **86.68%** |

4 tests. 2,066 passing, eslint clean. Test-only.

## A real asymmetry, surfaced by covering the default arguments

The two wallet backends implement the same interface but differ on folder creation:

```js
// WalletJson.saveWallet
if (!fs.existsSync(this.dataFolder)) {
    fs.mkdirSync(this.dataFolder, { recursive: true });
}

// WalletSQLite.connect — no equivalent
this.db = await open({ filename: this.walletName, driver: sqlite3.Database });
```

`WalletSQLite` opens `${dataFolder}/${file}` directly, so an **absent directory fails with a raw `SQLITE_CANTOPEN`** rather than being created, or reported with a message that says what is wrong.

The existing tests never hit this because they always pass an already-created temp dir. Only the **default-argument path** exposes it — which is precisely the branch that was uncovered, so the gap in coverage and the gap in behaviour were the same gap.

**Pinned by test asserting current behaviour rather than changed.** Whether two implementations of one interface should agree here is a design call, not something to decide inside a coverage PR. Practically: a fresh deployment using the sqlite wallet needs `data/` to exist beforehand. The Docker images likely provide it via a volume mount, so this may never have bitten anyone.

## The other branches

Four unexercised default parameters (`walletFileName` and `dataFolder`, on both the constructor and `create()`), and the two defensive `!this.db` guards — reachable only by stubbing `connect()` to a no-op, since a successful connect always sets the handle. That is noted in a comment so the next reader knows the guard is otherwise dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)