### PR TITLE
ci: run the gatekeeper TS/Rust parity harness, and fix what it found

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -78,6 +78,62 @@ jobs:
           name: E2E Artifacts (${{ matrix.gatekeeper }}, ${{ matrix.keymaster }})
           path: e2e-results.xml
 
+  # Replays the shared request flows in tests/gatekeeper/api-parity-flows.json
+  # against BOTH gatekeeper implementations and diffs the responses. The runner
+  # (scripts/gatekeeper-parity.mjs) already existed but nothing invoked it, so
+  # TS/Rust parity was maintained by porting discipline with no regression guard
+  # — see #771. #823 is a concrete example of the divergence this catches: block
+  # `time` was stringified in both ports, and the Rust one returned it as a JSON
+  # string, leaving `timeISO` null in anchoring metadata.
+  gatekeeper_parity:
+    name: gatekeeper parity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "22.15.0"
+
+      - name: Pin npm 10.9.2
+        run: npm install --global npm@10.9.2
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Start both gatekeepers
+        env:
+          GIT_COMMIT: ${{ github.sha }}
+        run: |
+          docker compose -f docker/compose/gatekeeper-parity.yml up -d --build --wait
+
+      - name: Run parity checks
+        env:
+          TS_GATEKEEPER_URL: http://localhost:4224
+          RUST_GATEKEEPER_URL: http://localhost:4324
+          ARCHON_ADMIN_API_KEY: parity-admin-key
+        run: node scripts/gatekeeper-parity.mjs
+
+      - name: Grab logs
+        if: always()
+        run: |
+          docker compose -f docker/compose/gatekeeper-parity.yml logs --no-color \
+            > gatekeeper-parity-logs.txt
+          tail -100 gatekeeper-parity-logs.txt
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f docker/compose/gatekeeper-parity.yml down -v
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: gatekeeper-parity-logs
+          path: gatekeeper-parity-logs.txt
+
   # Single stable status that rolls up every build_test_images matrix leg, so
   # branch protection can require one check instead of the fragile per-leg
   # matrix names. `if: always()` is required: without it this job is skipped

--- a/docker/compose/gatekeeper-parity.yml
+++ b/docker/compose/gatekeeper-parity.yml
@@ -1,0 +1,83 @@
+# Runs BOTH gatekeeper implementations side by side so
+# scripts/gatekeeper-parity.mjs can replay the shared request flows against
+# each and diff the responses. Used by the gatekeeper-parity CI job; also
+# usable locally:
+#
+#   docker compose -f docker/compose/gatekeeper-parity.yml up -d --build
+#   TS_GATEKEEPER_URL=http://localhost:4224 \
+#   RUST_GATEKEEPER_URL=http://localhost:4324 \
+#   ARCHON_ADMIN_API_KEY=<key> node scripts/gatekeeper-parity.mjs
+#
+# Design notes:
+#
+# - The two services need SEPARATE storage. The flows create DIDs, so a shared
+#   store would let whichever implementation ran first turn the other's create
+#   into a duplicate. Each therefore uses the `json` backend against its own
+#   volume, which also keeps mongo and redis out of this job entirely.
+# - IPFS is deliberately SHARED. It is content-addressed, so identical content
+#   must yield identical CIDs — sharing it is safe, and a CID divergence between
+#   the two is exactly the kind of difference worth catching.
+name: archon-gatekeeper-parity
+
+services:
+  ipfs:
+    image: ipfs/kubo:v0.40.1
+    volumes:
+      - parity-ipfs:/data/ipfs
+    healthcheck:
+      test: ["CMD-SHELL", "wget --post-data='' -qO- http://127.0.0.1:5001/api/v0/version >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 15s
+
+  gatekeeper-ts:
+    build:
+      context: ../..
+      dockerfile: docker/Dockerfile.gatekeeper-ts
+      args:
+        GIT_COMMIT: ${GIT_COMMIT:-unknown}
+    image: ghcr.io/archetech/gatekeeper-typescript
+    environment: &parity_env
+      ARCHON_GATEKEEPER_PORT: 4224
+      ARCHON_BIND_ADDRESS: 0.0.0.0
+      ARCHON_ADMIN_API_KEY: ${ARCHON_ADMIN_API_KEY:-parity-admin-key}
+      ARCHON_GATEKEEPER_DB: json
+      ARCHON_GATEKEEPER_DID_PREFIX: ${ARCHON_GATEKEEPER_DID_PREFIX:-did:cid}
+      ARCHON_GATEKEEPER_REGISTRIES: ${ARCHON_GATEKEEPER_REGISTRIES:-local,hyperswarm}
+      ARCHON_IPFS_URL: http://ipfs:5001/api/v0
+    ports:
+      - "4224:4224"
+    volumes:
+      - parity-ts-data:/app/gatekeeper/data
+    healthcheck: &parity_health
+      test: ["CMD-SHELL", "test \"$(wget -qO- http://127.0.0.1:4224/api/v1/ready)\" = \"true\""]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    depends_on:
+      ipfs:
+        condition: service_healthy
+
+  gatekeeper-rust:
+    build:
+      context: ../..
+      dockerfile: docker/Dockerfile.gatekeeper-rust
+      args:
+        GIT_COMMIT: ${GIT_COMMIT:-unknown}
+    image: ghcr.io/archetech/gatekeeper-rust
+    environment: *parity_env
+    ports:
+      - "4324:4224"
+    volumes:
+      - parity-rust-data:/app/gatekeeper/data
+    healthcheck: *parity_health
+    depends_on:
+      ipfs:
+        condition: service_healthy
+
+volumes:
+  parity-ipfs:
+  parity-ts-data:
+  parity-rust-data:

--- a/docs/gatekeeper-api.json
+++ b/docs/gatekeeper-api.json
@@ -1581,15 +1581,12 @@
         },
         "responses": {
           "200": {
-            "description": "The updated queue after clearing the specified events.",
+            "description": "Whether the specified events were cleared from the queue.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "description": "An array of remaining events in the queue. Could be empty if all events were cleared.",
-                  "items": {
-                    "type": "object"
-                  }
+                  "type": "boolean",
+                  "description": "true when the batch was cleared. This documented an array of remaining events until the TS/Rust parity harness caught the mismatch: GatekeeperDb.clearQueue and GatekeeperClient.clearQueue are both typed Promise<boolean> and the implementation has always returned a boolean, so the array shape was never correct.\n"
                 }
               }
             }

--- a/docs/services/gatekeeper/README.md
+++ b/docs/services/gatekeeper/README.md
@@ -1209,7 +1209,7 @@ timestamps and container labels.
 
 ## 16. Test fixtures
 
-Three shared JSON fixtures drive cross-language conformance:
+Five shared JSON fixtures drive cross-language conformance:
 
 | File | Purpose |
 | --- | --- |
@@ -1220,10 +1220,25 @@ Three shared JSON fixtures drive cross-language conformance:
 | [tests/gatekeeper/metrics-parity.json](../../../tests/gatekeeper/metrics-parity.json) | Required metric names + route normalization expectations. |
 
 The script [scripts/gatekeeper-parity.mjs](../../../scripts/gatekeeper-parity.mjs)
-runs side-by-side HTTP and metrics diffs against any two implementations
-listening on `GATEKEEPER_URL_A` and `GATEKEEPER_URL_B`. New implementations
-SHOULD pass this script against the TypeScript reference before being
-considered drop-in.
+replays every fixture and flow against two running implementations and diffs
+the responses per each entry's `compareMode`. It reads `TS_GATEKEEPER_URL` and
+`RUST_GATEKEEPER_URL` (not `GATEKEEPER_URL_A`/`_B`) and exits non-zero on the
+first divergence. New implementations SHOULD pass it against the TypeScript
+reference before being considered drop-in.
+
+It runs on every PR via the `gatekeeper parity` job in
+[.github/workflows/docker-build-test.yml](../../../.github/workflows/docker-build-test.yml),
+which starts both gatekeepers side by side using
+[docker/compose/gatekeeper-parity.yml](../../../docker/compose/gatekeeper-parity.yml).
+To run it locally:
+
+```sh
+docker compose -f docker/compose/gatekeeper-parity.yml up -d --build --wait
+TS_GATEKEEPER_URL=http://localhost:4224 \
+RUST_GATEKEEPER_URL=http://localhost:4324 \
+ARCHON_ADMIN_API_KEY=parity-admin-key node scripts/gatekeeper-parity.mjs
+docker compose -f docker/compose/gatekeeper-parity.yml down -v
+```
 
 The CI workflow
 [.github/workflows/docker-build-test.yml](../../../.github/workflows/docker-build-test.yml)

--- a/rust/services/gatekeeper/src/api.rs
+++ b/rust/services/gatekeeper/src/api.rs
@@ -23,7 +23,7 @@ use crate::{
     build_search_index, chrono_like_now, classify_conformant_error, clear_search_index,
     delete_search_doc, generate_did_from_operation, handle_did_operation, import_batch_impl,
     normalize_path, process_events_impl, query_docs_impl, record_metrics, refresh_metrics_snapshot,
-    resolve_local_doc_async, search_docs_impl, verify_db_impl, AppState, BlockLookup,
+    is_valid_did, resolve_local_doc_async, search_docs_impl, verify_db_impl, AppState, BlockLookup,
     GatekeeperDb, ResolveOptions,
 };
 
@@ -808,10 +808,16 @@ pub(crate) async fn clear_queue(
         .filter(|value| value.is_object())
         .collect::<Vec<_>>();
 
-    let remaining = {
+    // Return the boolean the TypeScript gatekeeper returns, not the remaining
+    // queue. GatekeeperDb.clearQueue and GatekeeperClient.clearQueue are both
+    // typed Promise<boolean>, so a TS client talking to this service previously
+    // received an array where it expected a boolean. (The swagger annotation
+    // documented an array; the annotation was wrong, and is corrected alongside
+    // this change.) Also propagate the store result instead of discarding it —
+    // `let _ =` meant a storage failure was reported as success.
+    let cleared = {
         let mut store = state.store.lock().await;
-        let _ = store.clear_queue(&registry, &operations);
-        store.get_queue(&registry)
+        store.clear_queue(&registry, &operations).unwrap_or(false)
     };
     record_metrics(
         &state,
@@ -820,7 +826,7 @@ pub(crate) async fn clear_queue(
         200,
         start.elapsed().as_secs_f64(),
     );
-    Json(json!(remaining)).into_response()
+    Json(json!(cleared)).into_response()
 }
 
 pub(crate) async fn process_events_route(
@@ -1083,7 +1089,18 @@ pub(crate) async fn resolve_did(
     let local_doc = match resolve_local_doc_async(&state, &did, resolve_options.clone()).await {
         Ok(doc) => doc,
         Err(_) => {
-            let error_kind = if !did.starts_with("did:") {
+            // Use the same syntax check as the conformant surface. This previously
+            // tested only for a `did:` prefix, so a DID that is syntactically
+            // invalid for this method — a foreign method such as did:example:, or a
+            // malformed CID — came back as notFound where the TypeScript gatekeeper
+            // (and this service's own /1.0/identifiers surface) return invalidDid.
+            // #676/#685/#687 brought the conformant surface to parity; this legacy
+            // surface was never brought along.
+            //
+            // Deliberately NOT classify_conformant_error: that maps a non-DID-level
+            // failure to internalError, which this surface has never returned.
+            // notFound stays the default, matching TypeScript.
+            let error_kind = if !is_valid_did(&did) {
                 "invalidDid"
             } else {
                 "notFound"

--- a/rust/services/gatekeeper/src/resolver.rs
+++ b/rust/services/gatekeeper/src/resolver.rs
@@ -448,6 +448,19 @@ pub(crate) async fn update_metrics_from_check(state: &AppState, did_check: &Chec
     }
 
     state.metrics.gatekeeper_dids_by_registry.reset();
+    // Seed a zero series for every configured registry before applying counts.
+    // The prometheus crate omits a GaugeVec with no series entirely, so with no
+    // DIDs yet this family vanished from /metrics — while the TypeScript
+    // gatekeeper (prom-client) always emits its HELP/TYPE. A dashboard doing
+    // label_values(gatekeeper_dids_by_registry, registry) therefore got nothing
+    // from this service until the first DID existed.
+    for registry in &state.config.registries {
+        state
+            .metrics
+            .gatekeeper_dids_by_registry
+            .with_label_values(&[registry])
+            .set(0.0);
+    }
     for (registry, count) in &did_check.by_registry {
         state
             .metrics

--- a/rust/services/gatekeeper/tests/http_contract.rs
+++ b/rust/services/gatekeeper/tests/http_contract.rs
@@ -280,7 +280,22 @@ async fn http_contract_matches_resolution_error_and_supported_registry_semantics
     let invalid = response.json::<Value>().await?;
     assert_eq!(invalid["didResolutionMetadata"]["error"], "invalidDid");
 
-    let missing_did = "did:cid:bagaaieramissing";
+    // A malformed CID is invalid DID syntax for this method, not a missing
+    // document. This asserted notFound until the TS/Rust parity harness showed
+    // the legacy /did/ surface classifying differently from both the TypeScript
+    // gatekeeper and this service's own /1.0/identifiers surface.
+    let malformed_did = "did:cid:bagaaieramissing";
+    let response = service
+        .client
+        .get(format!("{}/did/{malformed_did}", service.base_url))
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+    let malformed = response.json::<Value>().await?;
+    assert_eq!(malformed["didResolutionMetadata"]["error"], "invalidDid");
+
+    // A well-formed CID that simply is not stored is the notFound case.
+    let missing_did = "did:cid:bafkreiawdmk6fmqc5p237vffyctazpzdgvgqfdj2i3hx2idtodxkwhyj5m";
     let response = service
         .client
         .get(format!("{}/did/{missing_did}", service.base_url))

--- a/services/gatekeeper/server/src/v1-sync-router.ts
+++ b/services/gatekeeper/server/src/v1-sync-router.ts
@@ -376,14 +376,17 @@ export function createSyncRouter(options: CreateV1RouterOptions): express.Router
      *
      *     responses:
      *       200:
-     *         description: The updated queue after clearing the specified events.
+     *         description: Whether the specified events were cleared from the queue.
      *         content:
      *           application/json:
      *             schema:
-     *               type: array
-     *               description: An array of remaining events in the queue. Could be empty if all events were cleared.
-     *               items:
-     *                 type: object
+     *               type: boolean
+     *               description: >
+     *                 true when the batch was cleared. This documented an array of
+     *                 remaining events until the TS/Rust parity harness caught the
+     *                 mismatch: GatekeeperDb.clearQueue and GatekeeperClient.clearQueue
+     *                 are both typed Promise<boolean> and the implementation has always
+     *                 returned a boolean, so the array shape was never correct.
      *       500:
      *         description: Internal Server Error.
      *         content:

--- a/tests/gatekeeper/api-parity-fixtures.json
+++ b/tests/gatekeeper/api-parity-fixtures.json
@@ -70,28 +70,31 @@
     "name": "queue-invalid-registry",
     "method": "GET",
     "path": "/api/v1/queue/mock",
-    "expectedStatus": 500,
+    "expectedStatus": 200,
     "compareMode": "text",
-    "requiresAdminKey": true
+    "requiresAdminKey": true,
+    "note": "an unknown but well-formed registry name is auto-registered, not rejected"
   },
   {
     "name": "queue-clear-invalid-registry",
     "method": "POST",
     "path": "/api/v1/queue/mock/clear",
-    "expectedStatus": 500,
+    "expectedStatus": 200,
     "compareMode": "text",
     "headers": {
       "content-type": "application/json"
     },
     "requiresAdminKey": true,
-    "body": []
+    "body": [],
+    "note": "an unknown but well-formed registry name is auto-registered, not rejected"
   },
   {
     "name": "block-invalid-registry-latest",
     "method": "GET",
     "path": "/api/v1/block/mock/latest",
-    "expectedStatus": 500,
-    "compareMode": "text"
+    "expectedStatus": 200,
+    "compareMode": "text",
+    "note": "an unknown but well-formed registry name is auto-registered, not rejected"
   },
   {
     "name": "batch-import-invalid-payload",


### PR DESCRIPTION
Closes #771.

## The issue's premise was wrong

#771 reported that `api-parity-flows.json` declares a harness nothing runs, and proposed wiring up a runner or deleting the manifest. **Neither applies — the runner already exists.** [`scripts/gatekeeper-parity.mjs`](../blob/main/scripts/gatekeeper-parity.mjs) reads both manifests and implements the flow engine.

The issue's grep covered `*.ts`, `*.js`, `*.rs`, `*.yml`, `*.json`. The runner is a **`.mjs`** file — the one extension not in the list. My first grep repeated the omission.

The real gap was **automation**: the script needs two live services and had no npm script or CI step, so parity was maintained by porting discipline with no regression guard.

## What this adds

- **`docker/compose/gatekeeper-parity.yml`** — runs both implementations side by side. They get **separate storage** (the flows create DIDs, so a shared store would turn the second implementation's create into a duplicate) but deliberately **share IPFS**, which is content-addressed — a CID divergence is itself worth failing on.
- **A `gatekeeper parity` job** replaying every fixture and flow on each PR.

## Running it for the first time found four defects

**1. `POST /queue/:registry/clear` returned different types.** TypeScript `true`, Rust `[]`. `GatekeeperDb.clearQueue` and `GatekeeperClient.clearQueue` are both typed `Promise<boolean>`, so a TS client against a Rust gatekeeper received an array where it expected a boolean — masked because `[]` is truthy, so `if (await clearQueue(...))` worked by accident.

Rust was faithfully implementing the **swagger annotation, which documented an array and was itself wrong**. The annotation is corrected and `docs/gatekeeper-api.json` regenerated.

**2. A swallowed error in the same handler.** `let _ = store.clear_queue(...)` discarded the `Result`, so a storage failure was reported to the caller as success.

**3. Legacy `/api/v1/did/` error classification.** It used a crude `did:` prefix check, so a malformed CID or a foreign DID method returned `notFound` where TypeScript — and this service's own `/1.0/identifiers` surface — return `invalidDid`. **#676/#685/#687 brought the conformant surface to parity; the legacy surface was never brought along.**

**4. `gatekeeper_dids_by_registry` missing from the Rust scrape.** The prometheus crate omits a `GaugeVec` with no series, while prom-client always emits `HELP`/`TYPE` — so a dashboard doing `label_values(gatekeeper_dids_by_registry, registry)` got nothing from Rust until the first DID existed. Now seeded with a zero series per configured registry.

## Also corrected

- **Three stale fixtures** expected 500 for an unknown registry; both implementations return 200, because a well-formed unknown registry name is auto-registered rather than rejected.
- **The Rust contract test asserted `did:cid:bagaaieramissing → notFound`**, encoding defect 3. Corrected, and the distinction it was missing is now pinned: a **malformed** CID is `invalidDid`, a **well-formed but absent** one is `notFound`.
- **The README documented `GATEKEEPER_URL_A`/`GATEKEEPER_URL_B`**; the script requires `TS_GATEKEEPER_URL`/`RUST_GATEKEEPER_URL`. Anyone following the docs would have hit the usage error — a plausible reason it went unrun.

## Verification

Run end to end locally against both containers: **58 checks pass** (20 fixtures, 33 flows, deterministic vectors, metrics). Full Rust suite green (48 tests). JS suite 2,066 passing.

Two of my own missteps, both caught by tests rather than review:

- My first fix for defect 3 reused `classify_conformant_error`, which introduced `internalError` — a status that surface has never returned. The existing contract test caught it; the minimal fix swaps only the syntax check and keeps `notFound` as the default.
- I briefly reported a `registries` mismatch as a divergence when it was **asymmetric container state** — the TS container survived a rebuild carrying in-memory state while Rust was recreated. A clean `down -v` showed both behave identically. Worth knowing when running locally: start both services fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)