### PR TITLE
feat(herald): add /id/:name identity page rendering the DID document as cards

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -103,6 +103,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # The parity script imports @didcid/cipher and @didcid/ipfs from their
+      # built output. `npm ci` only installs — no package defines a `prepare`
+      # script — so without this the script dies on ERR_MODULE_NOT_FOUND before
+      # it reaches either gatekeeper.
+      - name: Build workspace packages
+        run: npm run build
+
       - name: Start both gatekeepers
         env:
           GIT_COMMIT: ${{ github.sha }}

--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -526,6 +526,9 @@ function Home() {
                         <Button component={Link} to='/members' variant="outlined" size="small">
                             Members
                         </Button>
+                        <Button component={Link} to='/directory' variant="outlined" size="small">
+                            Directory
+                        </Button>
                         {auth.isOwner &&
                             <Button component={Link} to='/owner' variant="outlined" size="small">
                                 Owner
@@ -578,6 +581,12 @@ function Home() {
                     >
                         Prove Your DID & Claim Your Name
                     </Button>
+
+                    <Box sx={{ mt: 2 }}>
+                        <Button component={Link} to="/directory" variant="text" size="small">
+                            Browse the directory
+                        </Button>
+                    </Box>
 
                     {/* AI Agent Instructions */}
                     <Box sx={{

--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -1599,14 +1599,20 @@ function ViewMember() {
                     <Button component={Link} to="/members" variant="outlined">
                         ← Back to Directory
                     </Button>
-                    <Button
-                        component="a"
-                        href={`https://explorer.archon.technology/search?did=${memberData?.id}`}
-                        target="_blank"
-                        variant="outlined"
-                    >
-                        View on Archon Explorer
-                    </Button>
+                    {/* The DID lives at didDocument.id — the payload has no top-level
+                        `id`, so the old `memberData?.id` always linked to ?did=undefined.
+                        Rendered conditionally so a missing DID hides the button rather
+                        than producing another dead link. */}
+                    {memberData?.didDocument?.id && (
+                        <Button
+                            component="a"
+                            href={`https://explorer.archon.technology/search?did=${memberData.didDocument.id}`}
+                            target="_blank"
+                            variant="outlined"
+                        >
+                            View on Archon Explorer
+                        </Button>
+                    )}
                 </Box>
             </Box>
         </div>

--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -1113,75 +1113,120 @@ function ViewDirectory() {
 
     return (
         <div className="App">
-            <Header title="Directory" />
-
             <Box sx={{ maxWidth: 800, mx: 'auto' }}>
-                <Box sx={{ mb: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
-                    <Typography variant="body2" sx={{ color: '#666' }}>
-                        {directory.length} registered {directory.length === 1 ? 'identity' : 'identities'} on {serviceName}
-                    </Typography>
-                    {lastUpdated && (
-                        <Typography variant="body2" sx={{ color: '#888' }}>
-                            Last updated: {formatTimestamp(lastUpdated)}
-                        </Typography>
-                    )}
+                <Box sx={{ ...surface, mb: 2.5, overflow: 'hidden' }}>
+                    <Box sx={{
+                        background: 'linear-gradient(135deg, #2c3e50 0%, #46637f 100%)',
+                        px: 3,
+                        py: 3,
+                        display: 'flex',
+                        alignItems: 'baseline',
+                        justifyContent: 'space-between',
+                        gap: 2,
+                        flexWrap: 'wrap',
+                    }}>
+                        <Box sx={{ minWidth: 0 }}>
+                            <Typography component="h1" sx={{
+                                fontWeight: 700,
+                                fontSize: { xs: '1.5rem', sm: '2rem' },
+                                color: '#fff',
+                                lineHeight: 1.15,
+                            }}>
+                                Directory
+                            </Typography>
+                            <Typography sx={{
+                                mt: 0.5,
+                                fontSize: '0.75rem',
+                                fontWeight: 600,
+                                letterSpacing: '0.08em',
+                                textTransform: 'uppercase',
+                                color: 'rgba(255, 255, 255, 0.6)',
+                            }}>
+                                {serviceName}
+                            </Typography>
+                        </Box>
+                        {lastUpdated && (
+                            <Typography sx={{ fontSize: '0.8125rem', color: 'rgba(255, 255, 255, 0.65)' }}>
+                                Updated {formatTimestamp(lastUpdated)}
+                            </Typography>
+                        )}
+                    </Box>
                 </Box>
 
-                {directory.length === 0 ? (
-                    <Box sx={{
-                        backgroundColor: '#f8f9fa',
-                        borderRadius: 2,
-                        p: 4,
-                        border: '1px solid #e9ecef',
-                        textAlign: 'center',
-                    }}>
-                        <Typography variant="body1" sx={{ color: '#666' }}>
+                <Card
+                    title={directory.length === 1 ? 'Registered identity' : 'Registered identities'}
+                    accent="#3b82f6"
+                    action={<CountChip count={directory.length} />}
+                >
+                    {directory.length === 0 ? (
+                        <Typography sx={{ color: '#64748b', fontSize: '0.9375rem', py: 1 }}>
                             No names have been registered yet.
                         </Typography>
-                    </Box>
-                ) : (
-                    <Table sx={{ backgroundColor: '#fff', borderRadius: 2, overflow: 'hidden' }}>
-                        <TableBody>
-                            {directory.map((entry) => (
-                                <TableRow key={entry.did} sx={{ '&:hover': { backgroundColor: '#f8f9fa' } }}>
-                                    <TableCell sx={{ fontWeight: 600, fontSize: '1.1rem', color: '#2c3e50' }}>
-                                        <Link
-                                            to={`/id/${entry.name}`}
-                                            style={{ textDecoration: 'none', color: 'inherit' }}
-                                        >
-                                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-                                                <Avatar
-                                                    src={`${api.defaults.baseURL}/name/${entry.name}/avatar`}
-                                                    alt={entry.name}
-                                                    sx={{ width: 36, height: 36 }}
-                                                >
-                                                    {entry.name[0]?.toUpperCase()}
-                                                </Avatar>
-                                                {entry.name}@{serviceDomain}
-                                            </Box>
-                                        </Link>
-                                    </TableCell>
-                                    <TableCell sx={{ color: '#666', fontFamily: 'monospace', fontSize: '0.85rem' }}>
-                                        {entry.did.substring(0, 20)}...{entry.did.substring(entry.did.length - 8)}
-                                    </TableCell>
-                                    <TableCell align="right">
-                                        <Button
-                                            component={Link}
-                                            to={`/id/${entry.name}`}
-                                            size="small"
-                                            variant="outlined"
-                                        >
-                                            View Identity
-                                        </Button>
-                                    </TableCell>
-                                </TableRow>
-                            ))}
-                        </TableBody>
-                    </Table>
-                )}
+                    ) : (
+                        directory.map((entry, index) => (
+                            <Box
+                                key={entry.did}
+                                component={Link}
+                                to={`/id/${entry.name}`}
+                                sx={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 2,
+                                    px: 1.5,
+                                    py: 1.5,
+                                    mx: -1.5,
+                                    borderRadius: 2,
+                                    textDecoration: 'none',
+                                    color: 'inherit',
+                                    borderBottom: index === directory.length - 1
+                                        ? 'none'
+                                        : '1px solid rgba(15, 23, 42, 0.05)',
+                                    transition: 'background-color 120ms ease',
+                                    '&:hover': {
+                                        backgroundColor: '#f8fafc',
+                                        textDecoration: 'none',
+                                    },
+                                    '&:hover .row-chevron': { color: '#2c3e50', transform: 'translateX(2px)' },
+                                }}
+                            >
+                                <Avatar
+                                    src={`${api.defaults.baseURL}/name/${entry.name}/avatar`}
+                                    alt={entry.name}
+                                    sx={{ width: 40, height: 40, flexShrink: 0 }}
+                                >
+                                    {entry.name[0]?.toUpperCase()}
+                                </Avatar>
+                                <Box sx={{ minWidth: 0, flex: 1 }}>
+                                    <Typography sx={{ fontWeight: 600, fontSize: '1rem', color: '#0f172a' }}>
+                                        {entry.name}
+                                        <Box component="span" sx={{ color: '#94a3b8', fontWeight: 500 }}>
+                                            @{serviceDomain}
+                                        </Box>
+                                    </Typography>
+                                    <Box component="span" sx={{ ...codePill, mt: 0.5, fontSize: '0.75rem', color: '#64748b' }}>
+                                        {entry.did.substring(0, 20)}…{entry.did.substring(entry.did.length - 8)}
+                                    </Box>
+                                </Box>
+                                <Box
+                                    className="row-chevron"
+                                    component="span"
+                                    sx={{
+                                        color: '#cbd5e1',
+                                        fontSize: '1.25rem',
+                                        lineHeight: 1,
+                                        flexShrink: 0,
+                                        transition: 'color 120ms ease, transform 120ms ease',
+                                    }}
+                                >
+                                    →
+                                </Box>
+                            </Box>
+                        ))
+                    )}
+                </Card>
 
-                <Box sx={{ mt: 3, textAlign: 'center' }}>
-                    <Button component={Link} to="/" variant="text">
+                <Box sx={{ mt: 1, textAlign: 'center' }}>
+                    <Button component={Link} to="/" variant="text" sx={{ textTransform: 'none' }}>
                         ← Back to Home
                     </Button>
                 </Box>

--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -7,7 +7,7 @@ import {
     Routes,
     Route,
 } from "react-router-dom";
-import { Alert, Avatar, Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, TextField, Typography } from '@mui/material';
+import { Alert, Avatar, Box, Button, CircularProgress, Dialog, DialogActions, DialogContent, TextField, Typography } from '@mui/material';
 import { Table, TableBody, TableRow, TableCell } from '@mui/material';
 import axios from 'axios';
 import { format, differenceInDays } from 'date-fns';
@@ -288,36 +288,143 @@ function formatTimestamp(time: string): string {
     return format(date, 'MMM d, yyyy h:mm a');
 }
 
-function Card({ title, children, action }: { title: string, children: React.ReactNode, action?: React.ReactNode }) {
+// Shared surface treatment for the identity page. The rest of the app puts
+// #f8f9fa panels on a #f5f7fa gradient background, which reads as flat because
+// the card and the page are nearly the same value. White panels lifted with a
+// soft shadow give the cards an edge to catch instead.
+const MONO = 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace';
+
+const surface = {
+    backgroundColor: '#fff',
+    borderRadius: 3,
+    border: '1px solid rgba(15, 23, 42, 0.07)',
+    boxShadow: '0 1px 2px rgba(15, 23, 42, 0.04), 0 12px 32px -18px rgba(15, 23, 42, 0.28)',
+};
+
+const inset = {
+    backgroundColor: '#f8fafc',
+    borderRadius: 2,
+    border: '1px solid rgba(15, 23, 42, 0.06)',
+};
+
+// Monospace values (DIDs, endpoints, keys) sit in a tinted pill so they read as
+// data rather than prose, and wrap instead of stretching the layout.
+const codePill = {
+    fontFamily: MONO,
+    fontSize: '0.8125rem',
+    backgroundColor: '#f1f5f9',
+    border: '1px solid rgba(15, 23, 42, 0.06)',
+    borderRadius: 1,
+    px: 0.75,
+    py: 0.25,
+    wordBreak: 'break-all',
+};
+
+function Card({ title, children, action, accent }: { title: string, children: React.ReactNode, action?: React.ReactNode, accent?: string }) {
     return (
-        <Box sx={{
-            backgroundColor: '#f8f9fa',
-            borderRadius: 2,
-            p: 3,
-            mb: 3,
-            border: '1px solid #e9ecef',
-        }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2, mb: 2 }}>
-                <Typography variant="h6" sx={{ m: 0 }}>{title}</Typography>
+        <Box sx={{ ...surface, mb: 2.5, overflow: 'hidden' }}>
+            <Box sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 2,
+                px: 3,
+                py: 1.75,
+                borderBottom: '1px solid rgba(15, 23, 42, 0.06)',
+                ...(accent ? { boxShadow: `inset 3px 0 0 ${accent}` } : {}),
+            }}>
+                <Typography sx={{
+                    fontSize: '0.75rem',
+                    fontWeight: 700,
+                    letterSpacing: '0.08em',
+                    textTransform: 'uppercase',
+                    color: '#64748b',
+                }}>
+                    {title}
+                </Typography>
                 {action}
             </Box>
-            {children}
+            <Box sx={{ px: 3, py: 2 }}>
+                {children}
+            </Box>
         </Box>
     );
 }
 
+// Status reads better as a tinted pill than a stock MUI chip, which brings its
+// own palette and sits oddly against the muted card header.
+const STATUS_TONES: Record<string, { fg: string, bg: string, border: string }> = {
+    success: { fg: '#047857', bg: '#ecfdf5', border: 'rgba(4, 120, 87, 0.2)' },
+    error: { fg: '#b91c1c', bg: '#fef2f2', border: 'rgba(185, 28, 28, 0.2)' },
+    neutral: { fg: '#475569', bg: '#f1f5f9', border: 'rgba(71, 85, 105, 0.2)' },
+};
+
+function StatusPill({ label, tone }: { label: string, tone: string }) {
+    const colors = STATUS_TONES[tone] || STATUS_TONES.neutral;
+
+    return (
+        <Box component="span" sx={{
+            display: 'inline-block',
+            fontSize: '0.75rem',
+            fontWeight: 700,
+            letterSpacing: '0.02em',
+            color: colors.fg,
+            backgroundColor: colors.bg,
+            border: `1px solid ${colors.border}`,
+            borderRadius: 999,
+            px: 1.25,
+            py: 0.375,
+        }}>
+            {label}
+        </Box>
+    );
+}
+
+function CountChip({ count }: { count: number }) {
+    return (
+        <Box sx={{
+            minWidth: 24,
+            height: 24,
+            px: 1,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: 999,
+            backgroundColor: '#f1f5f9',
+            color: '#475569',
+            fontSize: '0.75rem',
+            fontWeight: 700,
+        }}>
+            {count}
+        </Box>
+    );
+}
+
+// Label and value sit in a two-column grid so values line up down the card, and
+// collapse to stacked rows on narrow screens rather than wrapping raggedly.
 function Field({ label, value, mono = false }: { label: string, value: React.ReactNode, mono?: boolean }) {
     return (
-        <Box sx={{ display: 'flex', gap: 2, py: 0.75, alignItems: 'baseline', flexWrap: 'wrap' }}>
-            <Typography variant="body2" sx={{ color: '#666', minWidth: 120, flexShrink: 0 }}>
+        <Box sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', sm: '150px minmax(0, 1fr)' },
+            gap: { xs: 0.25, sm: 2 },
+            py: 1.25,
+            alignItems: 'baseline',
+            borderBottom: '1px solid rgba(15, 23, 42, 0.05)',
+            '&:last-of-type': { borderBottom: 'none', pb: 0 },
+            '&:first-of-type': { pt: 0 },
+        }}>
+            <Typography sx={{ fontSize: '0.8125rem', color: '#64748b', fontWeight: 500 }}>
                 {label}
             </Typography>
             <Typography
-                variant="body2"
                 component="div"
                 sx={{
-                    wordBreak: 'break-all',
-                    ...(mono ? { fontFamily: 'Monaco, Consolas, monospace' } : {}),
+                    fontSize: '0.9375rem',
+                    color: '#0f172a',
+                    minWidth: 0,
+                    wordBreak: 'break-word',
+                    ...(mono ? { ...codePill, display: 'inline-block' } : {}),
                 }}
             >
                 {value}
@@ -328,31 +435,51 @@ function Field({ label, value, mono = false }: { label: string, value: React.Rea
 
 function EndpointValue({ uri }: { uri: string }) {
     if (!uri) {
-        return <Typography variant="body2" sx={{ color: '#999' }}>none</Typography>;
+        return <Typography component="span" sx={{ color: '#94a3b8', fontSize: '0.9375rem' }}>none</Typography>;
     }
 
     if (isOnionUri(uri)) {
         return (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-                <span style={{ fontFamily: 'Monaco, Consolas, monospace' }}>{uri}</span>
-                <Chip label="Tor" size="small" variant="outlined" />
+                <Box component="span" sx={codePill}>{uri}</Box>
+                <Box component="span" sx={{
+                    fontSize: '0.6875rem',
+                    fontWeight: 700,
+                    letterSpacing: '0.06em',
+                    textTransform: 'uppercase',
+                    color: '#9a6b00',
+                    backgroundColor: '#fef3c7',
+                    border: '1px solid rgba(154, 107, 0, 0.2)',
+                    borderRadius: 999,
+                    px: 1,
+                    py: 0.25,
+                }}>
+                    Tor
+                </Box>
             </Box>
         );
     }
 
     if (!isFollowableUri(uri)) {
-        return <span style={{ fontFamily: 'Monaco, Consolas, monospace' }}>{uri}</span>;
+        return <Box component="span" sx={codePill}>{uri}</Box>;
     }
 
     return (
-        <a
+        <Box
+            component="a"
             href={uri}
             target="_blank"
             rel="noopener noreferrer"
-            style={{ fontFamily: 'Monaco, Consolas, monospace', color: '#1976d2' }}
+            sx={{
+                ...codePill,
+                display: 'inline-block',
+                color: '#1d4ed8',
+                textDecoration: 'none',
+                '&:hover': { backgroundColor: '#e0e7ff', textDecoration: 'none' },
+            }}
         >
             {uri}
-        </a>
+        </Box>
     );
 }
 
@@ -1648,7 +1775,7 @@ function ViewIdentity() {
                     <Typography variant="h6" sx={{ color: '#e74c3c', mb: 2 }}>
                         {error}
                     </Typography>
-                    <Button component={Link} to="/directory" variant="outlined">
+                    <Button component={Link} to="/directory" variant="outlined" sx={{ textTransform: 'none', borderRadius: 2 }}>
                         ← Back to Directory
                     </Button>
                 </Box>
@@ -1676,58 +1803,118 @@ function ViewIdentity() {
 
     return (
         <div className="App">
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 2, mb: 3 }}>
-                <Avatar
-                    src={`${api.defaults.baseURL}/name/${name}/avatar`}
-                    alt={name}
-                    sx={{ width: 64, height: 64, fontSize: '1.75rem' }}
-                >
-                    {name?.[0]?.toUpperCase()}
-                </Avatar>
-                <Link to="/" style={{ textDecoration: 'none' }}>
-                    <Typography variant="h3" component="h1" sx={{ fontWeight: 700, color: '#1a1a1a' }}>
-                        {name}@{serviceDomain}
-                    </Typography>
-                </Link>
-            </Box>
-
             <Box sx={{ maxWidth: 800, mx: 'auto' }}>
-                <Box sx={{
-                    backgroundColor: '#f8f9fa',
-                    borderRadius: 2,
-                    p: 3,
-                    mb: 3,
-                    border: '1px solid #e9ecef',
-                    textAlign: 'center'
-                }}>
-                    {did && aliasWalletUrl && (
-                        <Box>
-                            <a href={aliasWalletUrl} target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'none' }}>
-                                <QRCodeSVG value={aliasWalletUrl} />
-                            </a>
-                        </Box>
-                    )}
-                    {did && (
-                        <Box>
-                            <Typography variant="body1" sx={{ fontFamily: 'monospace', color: '#666', wordBreak: 'break-all', mt: 2 }}>
-                                {did}
+                {/* The handle and DID are the page's subject, so they get a
+                    distinct treatment rather than another panel in the stack. */}
+                <Box sx={{ ...surface, mb: 2.5, overflow: 'hidden' }}>
+                    <Box sx={{
+                        background: 'linear-gradient(135deg, #2c3e50 0%, #46637f 100%)',
+                        px: 3,
+                        py: 3.5,
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 2.5,
+                        flexWrap: 'wrap',
+                    }}>
+                        <Avatar
+                            src={`${api.defaults.baseURL}/name/${name}/avatar`}
+                            alt={name}
+                            sx={{
+                                width: 72,
+                                height: 72,
+                                fontSize: '2rem',
+                                border: '3px solid rgba(255, 255, 255, 0.25)',
+                                boxShadow: '0 8px 20px -8px rgba(0, 0, 0, 0.5)',
+                            }}
+                        >
+                            {name?.[0]?.toUpperCase()}
+                        </Avatar>
+                        <Box sx={{ minWidth: 0 }}>
+                            <Typography component="h1" sx={{
+                                fontWeight: 700,
+                                fontSize: { xs: '1.5rem', sm: '2rem' },
+                                color: '#fff',
+                                lineHeight: 1.15,
+                                wordBreak: 'break-word',
+                            }}>
+                                {name}
+                                <Box component="span" sx={{ color: 'rgba(255, 255, 255, 0.55)', fontWeight: 500 }}>
+                                    @{serviceDomain}
+                                </Box>
                             </Typography>
-                            <Button
-                                variant="outlined"
-                                size="small"
-                                sx={{ mt: 1.5, textTransform: 'none' }}
-                                onClick={() => copyDid(did)}
-                                disabled={didCopied}
-                            >
-                                {didCopied ? 'Copied' : 'Copy DID'}
-                            </Button>
+                            <Typography sx={{
+                                mt: 0.5,
+                                fontSize: '0.75rem',
+                                fontWeight: 600,
+                                letterSpacing: '0.08em',
+                                textTransform: 'uppercase',
+                                color: 'rgba(255, 255, 255, 0.6)',
+                            }}>
+                                Decentralized identity
+                            </Typography>
+                        </Box>
+                    </Box>
+
+                    {did && (
+                        <Box sx={{
+                            px: 3,
+                            py: 3,
+                            display: 'flex',
+                            gap: 3,
+                            alignItems: 'center',
+                            flexWrap: 'wrap',
+                            justifyContent: { xs: 'center', sm: 'flex-start' },
+                        }}>
+                            {aliasWalletUrl && (
+                                <Box
+                                    component="a"
+                                    href={aliasWalletUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    sx={{
+                                        ...inset,
+                                        p: 1.5,
+                                        lineHeight: 0,
+                                        flexShrink: 0,
+                                        transition: 'box-shadow 120ms ease',
+                                        '&:hover': { boxShadow: '0 8px 24px -12px rgba(15, 23, 42, 0.4)' },
+                                    }}
+                                >
+                                    <QRCodeSVG value={aliasWalletUrl} size={116} />
+                                </Box>
+                            )}
+                            <Box sx={{ minWidth: 0, flex: 1 }}>
+                                <Typography sx={{
+                                    fontSize: '0.75rem',
+                                    fontWeight: 700,
+                                    letterSpacing: '0.08em',
+                                    textTransform: 'uppercase',
+                                    color: '#64748b',
+                                    mb: 1,
+                                }}>
+                                    Identifier
+                                </Typography>
+                                <Box sx={{ ...codePill, display: 'block', fontSize: '0.8125rem', p: 1.25 }}>
+                                    {did}
+                                </Box>
+                                <Button
+                                    variant="outlined"
+                                    size="small"
+                                    sx={{ mt: 1.5, textTransform: 'none', borderRadius: 2 }}
+                                    onClick={() => copyDid(did)}
+                                    disabled={didCopied}
+                                >
+                                    {didCopied ? 'Copied' : 'Copy DID'}
+                                </Button>
+                            </Box>
                         </Box>
                     )}
                 </Box>
 
                 <Card
                     title="Service Endpoints"
-                    action={<Chip label={services.length} size="small" variant="outlined" />}
+                    accent="#3b82f6"
+                    action={<CountChip count={services.length} />}
                 >
                     {services.length === 0 ? (
                         <Typography variant="body2" sx={{ color: '#666' }}>
@@ -1744,24 +1931,19 @@ function ViewIdentity() {
                                 <Box
                                     key={service.id || index}
                                     sx={{
-                                        backgroundColor: '#fff',
-                                        borderRadius: 1,
-                                        border: '1px solid #e9ecef',
+                                        ...inset,
                                         p: 2,
-                                        mb: index === services.length - 1 ? 0 : 2,
+                                        mb: index === services.length - 1 ? 0 : 1.5,
                                     }}
                                 >
                                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1, flexWrap: 'wrap' }}>
-                                        <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+                                        <Typography sx={{ fontWeight: 700, fontSize: '0.9375rem', color: '#0f172a' }}>
                                             {serviceLabel(service.type)}
                                         </Typography>
                                         {serviceFragment(service.id) && (
-                                            <Chip
-                                                label={serviceFragment(service.id)}
-                                                size="small"
-                                                variant="outlined"
-                                                sx={{ fontFamily: 'Monaco, Consolas, monospace' }}
-                                            />
+                                            <Box component="span" sx={{ ...codePill, fontSize: '0.75rem', color: '#475569' }}>
+                                                {serviceFragment(service.id)}
+                                            </Box>
                                         )}
                                     </Box>
                                     <Field label="Endpoint" value={<EndpointValue uri={uri} />} />
@@ -1784,7 +1966,8 @@ function ViewIdentity() {
 
                 <Card
                     title="Keys"
-                    action={<Chip label={verificationMethods.length} size="small" variant="outlined" />}
+                    accent="#8b5cf6"
+                    action={<CountChip count={verificationMethods.length} />}
                 >
                     {verificationMethods.length === 0 ? (
                         <Typography variant="body2" sx={{ color: '#666' }}>
@@ -1806,20 +1989,19 @@ function ViewIdentity() {
                 {credentials.length > 0 && (
                     <Card
                         title="Credentials"
-                        action={<Chip label={credentials.length} size="small" variant="outlined" />}
+                        accent="#10b981"
+                        action={<CountChip count={credentials.length} />}
                     >
                         {credentials.map(([credentialDid, credential]: [string, any], index: number) => (
                             <Box
                                 key={credentialDid}
                                 sx={{
-                                    backgroundColor: '#fff',
-                                    borderRadius: 1,
-                                    border: '1px solid #e9ecef',
+                                    ...inset,
                                     p: 2,
-                                    mb: index === credentials.length - 1 ? 0 : 2,
+                                    mb: index === credentials.length - 1 ? 0 : 1.5,
                                 }}
                             >
-                                <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1 }}>
+                                <Typography sx={{ fontWeight: 700, fontSize: '0.9375rem', color: '#0f172a', mb: 1 }}>
                                     {credentialType(credential)}
                                 </Typography>
 
@@ -1827,7 +2009,7 @@ function ViewIdentity() {
                                     <Field key={key} label={humanizeKey(key)} value={formatClaim(value)} />
                                 ))}
 
-                                <Box sx={{ borderTop: '1px solid #e9ecef', mt: 1.5, pt: 1.5 }}>
+                                <Box sx={{ borderTop: '1px solid rgba(15, 23, 42, 0.08)', mt: 2, pt: 1.5 }}>
                                     <Field
                                         label="Issued by"
                                         value={<IssuerValue issuer={credential?.issuer} nameByDid={nameByDid} serviceDomain={serviceDomain} />}
@@ -1845,12 +2027,12 @@ function ViewIdentity() {
                 )}
 
                 {nostr?.npub && (
-                    <Card title="Nostr">
+                    <Card title="Nostr" accent="#a855f7">
                         <Field label="npub" value={nostr.npub} mono />
                     </Card>
                 )}
 
-                <Card title="Document">
+                <Card title="Document" accent="#64748b">
                     {didDocument.controller && (
                         <Field label="Controller" value={didDocument.controller} mono />
                     )}
@@ -1870,19 +2052,19 @@ function ViewIdentity() {
                         label="Status"
                         value={
                             metadata.deactivated
-                                ? <Chip label="Deactivated" size="small" color="error" />
+                                ? <StatusPill label="Deactivated" tone="error" />
                                 : metadata.confirmed
-                                    ? <Chip label="Confirmed" size="small" color="success" />
-                                    : <Chip label="Pending confirmation" size="small" />
+                                    ? <StatusPill label="Confirmed" tone="success" />
+                                    : <StatusPill label="Pending confirmation" tone="neutral" />
                         }
                     />
                 </Card>
 
-                <Box sx={{ mt: 3, display: 'flex', gap: 2, justifyContent: 'center', flexWrap: 'wrap' }}>
+                <Box sx={{ mt: 1, mb: 2, display: 'flex', gap: 1.5, justifyContent: 'center', flexWrap: 'wrap' }}>
                     <Button component={Link} to="/directory" variant="outlined">
                         ← Back to Directory
                     </Button>
-                    <Button component={Link} to={`/member/${name}`} variant="outlined">
+                    <Button component={Link} to={`/member/${name}`} variant="outlined" sx={{ textTransform: 'none', borderRadius: 2 }}>
                         Raw DID Document
                     </Button>
                     {did && explorerUrl && (
@@ -1891,6 +2073,7 @@ function ViewIdentity() {
                             href={buildExplorerUrl(explorerUrl, did)}
                             target="_blank"
                             variant="outlined"
+                            sx={{ textTransform: 'none', borderRadius: 2 }}
                         >
                             View on Archon Explorer
                         </Button>

--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -52,6 +52,12 @@ function App() {
     );
 }
 
+// The explorer host comes from the node's own config, so a self-hosted
+// deployment links to its own explorer instead of the public instance.
+function buildExplorerUrl(explorerUrl: string, did: string) {
+    return `${explorerUrl.replace(/\/$/, '')}/search?did=${encodeURIComponent(did)}`;
+}
+
 function buildWalletUrl(walletUrl: string, params: Record<string, string>) {
     try {
         const url = new URL(walletUrl);
@@ -76,6 +82,7 @@ function useMemberData(name: string | undefined) {
     const [error, setError] = useState<string>('');
     const [serviceDomain, setServiceDomain] = useState<string>('');
     const [walletUrl, setWalletUrl] = useState<string>('');
+    const [explorerUrl, setExplorerUrl] = useState<string>('');
 
     useEffect(() => {
         const fetchMember = async () => {
@@ -83,6 +90,7 @@ function useMemberData(name: string | undefined) {
                 const configResponse = await api.get('/config');
                 setServiceDomain(configResponse.data.serviceDomain);
                 setWalletUrl(configResponse.data.walletUrl);
+                setExplorerUrl(configResponse.data.explorerUrl || '');
 
                 const response = await api.get(`/member/${name}`);
                 setMemberData(response.data);
@@ -100,7 +108,7 @@ function useMemberData(name: string | undefined) {
         }
     }, [name]);
 
-    return { memberData, loading, error, serviceDomain, walletUrl };
+    return { memberData, loading, error, serviceDomain, walletUrl, explorerUrl };
 }
 
 // A credential's issuer is a bare DID. When that DID belongs to a member of
@@ -1500,7 +1508,7 @@ function ViewCredential() {
 
 function ViewMember() {
     const { name } = useParams<{ name: string }>();
-    const { memberData, loading, error, serviceDomain, walletUrl } = useMemberData(name);
+    const { memberData, loading, error, serviceDomain, walletUrl, explorerUrl } = useMemberData(name);
     const { didCopied, copyDid } = useCopyDid();
 
     if (loading) {
@@ -1603,10 +1611,10 @@ function ViewMember() {
                         `id`, so the old `memberData?.id` always linked to ?did=undefined.
                         Rendered conditionally so a missing DID hides the button rather
                         than producing another dead link. */}
-                    {memberData?.didDocument?.id && (
+                    {memberData?.didDocument?.id && explorerUrl && (
                         <Button
                             component="a"
-                            href={`https://explorer.archon.technology/search?did=${memberData.didDocument.id}`}
+                            href={buildExplorerUrl(explorerUrl, memberData.didDocument.id)}
                             target="_blank"
                             variant="outlined"
                         >
@@ -1624,7 +1632,7 @@ function ViewMember() {
 // `/member/:name` remains the transparency/audit view, and each links to the other.
 function ViewIdentity() {
     const { name } = useParams<{ name: string }>();
-    const { memberData, loading, error, serviceDomain, walletUrl } = useMemberData(name);
+    const { memberData, loading, error, serviceDomain, walletUrl, explorerUrl } = useMemberData(name);
     const { didCopied, copyDid } = useCopyDid();
     const nameByDid = useNameByDid();
 
@@ -1877,10 +1885,10 @@ function ViewIdentity() {
                     <Button component={Link} to={`/member/${name}`} variant="outlined">
                         Raw DID Document
                     </Button>
-                    {did && (
+                    {did && explorerUrl && (
                         <Button
                             component="a"
-                            href={`https://explorer.archon.technology/search?did=${did}`}
+                            href={buildExplorerUrl(explorerUrl, did)}
                             target="_blank"
                             variant="outlined"
                         >

--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -7,7 +7,7 @@ import {
     Routes,
     Route,
 } from "react-router-dom";
-import { Alert, Avatar, Box, Button, CircularProgress, Dialog, DialogActions, DialogContent, TextField, Typography } from '@mui/material';
+import { Alert, Avatar, Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, TextField, Typography } from '@mui/material';
 import { Table, TableBody, TableRow, TableCell } from '@mui/material';
 import axios from 'axios';
 import { format, differenceInDays } from 'date-fns';
@@ -43,6 +43,7 @@ function App() {
                 <Route path="/owner" element={<ViewOwner />} />
                 <Route path="/profile/:did" element={<ViewProfile />} />
                 <Route path="/member/:name" element={<ViewMember />} />
+                <Route path="/id/:name" element={<ViewIdentity />} />
                 <Route path="/credential" element={<ViewCredential />} />
                 <Route path="*" element={<NotFound />} />
             </Routes>
@@ -63,6 +64,197 @@ function buildWalletUrl(walletUrl: string, params: Record<string, string>) {
     catch {
         return null;
     }
+}
+
+// Shared by the two member views: `/member/:name` (raw document) and
+// `/id/:name` (cards). Both need the same payload plus the service config that
+// supplies the handle domain and wallet deep-link base.
+function useMemberData(name: string | undefined) {
+    const [memberData, setMemberData] = useState<any>(null);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string>('');
+    const [serviceDomain, setServiceDomain] = useState<string>('');
+    const [walletUrl, setWalletUrl] = useState<string>('');
+
+    useEffect(() => {
+        const fetchMember = async () => {
+            try {
+                const configResponse = await api.get('/config');
+                setServiceDomain(configResponse.data.serviceDomain);
+                setWalletUrl(configResponse.data.walletUrl);
+
+                const response = await api.get(`/member/${name}`);
+                setMemberData(response.data);
+            }
+            catch (err: any) {
+                setError(err.response?.data?.error || 'Member not found');
+            }
+            finally {
+                setLoading(false);
+            }
+        };
+
+        if (name) {
+            fetchMember();
+        }
+    }, [name]);
+
+    return { memberData, loading, error, serviceDomain, walletUrl };
+}
+
+function useCopyDid() {
+    const [didCopied, setDidCopied] = useState<boolean>(false);
+
+    async function copyDid(text: string) {
+        try {
+            await navigator.clipboard.writeText(text);
+            setDidCopied(true);
+        }
+        catch (copyError: any) {
+            window.alert('Failed to copy text: ' + copyError);
+        }
+    }
+
+    return { didCopied, copyDid };
+}
+
+// A service entry's endpoint is either a plain URI or the DIDComm object form
+// carrying routing keys. Everything downstream wants the URI.
+function serviceEndpointUri(endpoint: any): string {
+    if (typeof endpoint === 'string') {
+        return endpoint;
+    }
+
+    return endpoint?.uri || '';
+}
+
+// Only linkify schemes a browser can actually follow. Anything else (did:, a
+// bare host, an unrecognised scheme) renders as text so the page never emits a
+// link that silently does nothing.
+function isFollowableUri(uri: string): boolean {
+    return /^(https?|mailto):/i.test(uri);
+}
+
+// Onion endpoints are common in practice (Drawbridge publishes its Lightning
+// and DIDComm endpoints over Tor). They are valid but unreachable from an
+// ordinary browser, so label them instead of offering a link that just errors.
+function isOnionUri(uri: string): boolean {
+    try {
+        return new URL(uri).hostname.endsWith('.onion');
+    }
+    catch {
+        return false;
+    }
+}
+
+const SERVICE_LABELS: Record<string, string> = {
+    DIDCommMessaging: 'DIDComm Messaging',
+    Email: 'Email',
+    Lightning: 'Lightning',
+};
+
+function serviceLabel(type: string): string {
+    return SERVICE_LABELS[type] || type || 'Service';
+}
+
+// The fragment identifies the entry within the document (`did:cid:abc#lightning`).
+function serviceFragment(id: string): string {
+    const hash = (id || '').indexOf('#');
+    return hash === -1 ? '' : id.slice(hash);
+}
+
+// `type` is an ordered array whose first entry is the generic
+// "VerifiableCredential"; the specific type, when present, comes after it.
+function credentialType(credential: any): string {
+    const types = credential?.type;
+
+    if (!Array.isArray(types) || types.length === 0) {
+        return 'Verifiable Credential';
+    }
+
+    const specific = types.filter((type: string) => type !== 'VerifiableCredential');
+
+    return specific.length > 0 ? specific.join(', ') : 'Verifiable Credential';
+}
+
+// Document timestamps come straight from the gatekeeper; render the raw value
+// rather than "Invalid Date" if one is ever malformed.
+function formatTimestamp(time: string): string {
+    const date = new Date(time);
+
+    if (isNaN(date.getTime())) {
+        return time;
+    }
+
+    return format(date, 'MMM d, yyyy h:mm a');
+}
+
+function Card({ title, children, action }: { title: string, children: React.ReactNode, action?: React.ReactNode }) {
+    return (
+        <Box sx={{
+            backgroundColor: '#f8f9fa',
+            borderRadius: 2,
+            p: 3,
+            mb: 3,
+            border: '1px solid #e9ecef',
+        }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2, mb: 2 }}>
+                <Typography variant="h6" sx={{ m: 0 }}>{title}</Typography>
+                {action}
+            </Box>
+            {children}
+        </Box>
+    );
+}
+
+function Field({ label, value, mono = false }: { label: string, value: React.ReactNode, mono?: boolean }) {
+    return (
+        <Box sx={{ display: 'flex', gap: 2, py: 0.75, alignItems: 'baseline', flexWrap: 'wrap' }}>
+            <Typography variant="body2" sx={{ color: '#666', minWidth: 120, flexShrink: 0 }}>
+                {label}
+            </Typography>
+            <Typography
+                variant="body2"
+                component="div"
+                sx={{
+                    wordBreak: 'break-all',
+                    ...(mono ? { fontFamily: 'Monaco, Consolas, monospace' } : {}),
+                }}
+            >
+                {value}
+            </Typography>
+        </Box>
+    );
+}
+
+function EndpointValue({ uri }: { uri: string }) {
+    if (!uri) {
+        return <Typography variant="body2" sx={{ color: '#999' }}>none</Typography>;
+    }
+
+    if (isOnionUri(uri)) {
+        return (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                <span style={{ fontFamily: 'Monaco, Consolas, monospace' }}>{uri}</span>
+                <Chip label="Tor" size="small" variant="outlined" />
+            </Box>
+        );
+    }
+
+    if (!isFollowableUri(uri)) {
+        return <span style={{ fontFamily: 'Monaco, Consolas, monospace' }}>{uri}</span>;
+    }
+
+    return (
+        <a
+            href={uri}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ fontFamily: 'Monaco, Consolas, monospace', color: '#1976d2' }}
+        >
+            {uri}
+        </a>
+    );
 }
 
 function Header({ title, showTagline = false }: { title: string, showTagline?: boolean }) {
@@ -1053,45 +1245,8 @@ function ViewCredential() {
 
 function ViewMember() {
     const { name } = useParams<{ name: string }>();
-    const [memberData, setMemberData] = useState<any>(null);
-    const [loading, setLoading] = useState<boolean>(true);
-    const [error, setError] = useState<string>('');
-    const [serviceDomain, setServiceDomain] = useState<string>('');
-    const [walletUrl, setWalletUrl] = useState<string>('');
-    const [didCopied, setDidCopied] = useState<boolean>(false);
-
-    useEffect(() => {
-        const fetchMember = async () => {
-            try {
-                const configResponse = await api.get('/config');
-                setServiceDomain(configResponse.data.serviceDomain);
-                setWalletUrl(configResponse.data.walletUrl);
-
-                const response = await api.get(`/member/${name}`);
-                setMemberData(response.data);
-            }
-            catch (err: any) {
-                setError(err.response?.data?.error || 'Member not found');
-            }
-            finally {
-                setLoading(false);
-            }
-        };
-
-        if (name) {
-            fetchMember();
-        }
-    }, [name]);
-
-    async function copyDid(text: string) {
-        try {
-            await navigator.clipboard.writeText(text);
-            setDidCopied(true);
-        }
-        catch (copyError: any) {
-            window.alert('Failed to copy text: ' + copyError);
-        }
-    }
+    const { memberData, loading, error, serviceDomain, walletUrl } = useMemberData(name);
+    const { didCopied, copyDid } = useCopyDid();
 
     if (loading) {
         return <LoadingShell title={`${name}@${serviceDomain}`} />;
@@ -1197,6 +1352,276 @@ function ViewMember() {
                     >
                         View on Archon Explorer
                     </Button>
+                </Box>
+            </Box>
+        </div>
+    );
+}
+
+// Card-based rendering of the same payload `/member/:name` shows as raw JSON.
+// The two pages are deliberately parallel: this one is the readable surface,
+// `/member/:name` remains the transparency/audit view, and each links to the other.
+function ViewIdentity() {
+    const { name } = useParams<{ name: string }>();
+    const { memberData, loading, error, serviceDomain, walletUrl } = useMemberData(name);
+    const { didCopied, copyDid } = useCopyDid();
+
+    if (loading) {
+        return <LoadingShell title={`${name}@${serviceDomain}`} />;
+    }
+
+    if (error) {
+        return (
+            <div className="App">
+                <Header title="Identity Not Found" />
+                <Box sx={{ maxWidth: 600, mx: 'auto', textAlign: 'center' }}>
+                    <Typography variant="h6" sx={{ color: '#e74c3c', mb: 2 }}>
+                        {error}
+                    </Typography>
+                    <Button component={Link} to="/members" variant="outlined">
+                        ← Back to Directory
+                    </Button>
+                </Box>
+            </div>
+        );
+    }
+
+    const didDocument = memberData?.didDocument || {};
+    const metadata = memberData?.didDocumentMetadata || {};
+    const registration = memberData?.didDocumentRegistration || {};
+    const did = didDocument.id || '';
+    const services = didDocument.service || [];
+    const verificationMethods = didDocument.verificationMethod || [];
+    const documentData = memberData?.didDocumentData || {};
+    // The manifest is a map of credential DID -> verifiable credential.
+    const credentials = Object.entries(documentData.manifest || {});
+    const nostr = documentData.nostr;
+
+    const aliasWalletUrl = did && walletUrl
+        ? buildWalletUrl(walletUrl, {
+            alias: `${name}@${serviceDomain}`,
+            did,
+        })
+        : null;
+
+    return (
+        <div className="App">
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 2, mb: 3 }}>
+                <Avatar
+                    src={`${api.defaults.baseURL}/name/${name}/avatar`}
+                    alt={name}
+                    sx={{ width: 64, height: 64, fontSize: '1.75rem' }}
+                >
+                    {name?.[0]?.toUpperCase()}
+                </Avatar>
+                <Link to="/" style={{ textDecoration: 'none' }}>
+                    <Typography variant="h3" component="h1" sx={{ fontWeight: 700, color: '#1a1a1a' }}>
+                        {name}@{serviceDomain}
+                    </Typography>
+                </Link>
+            </Box>
+
+            <Box sx={{ maxWidth: 800, mx: 'auto' }}>
+                <Box sx={{
+                    backgroundColor: '#f8f9fa',
+                    borderRadius: 2,
+                    p: 3,
+                    mb: 3,
+                    border: '1px solid #e9ecef',
+                    textAlign: 'center'
+                }}>
+                    {registration.type && (
+                        <Chip
+                            label={registration.type === 'agent' ? 'Agent' : 'Asset'}
+                            size="small"
+                            sx={{ mb: 2, textTransform: 'capitalize' }}
+                        />
+                    )}
+                    {did && aliasWalletUrl && (
+                        <Box>
+                            <a href={aliasWalletUrl} target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'none' }}>
+                                <QRCodeSVG value={aliasWalletUrl} />
+                            </a>
+                        </Box>
+                    )}
+                    {did && (
+                        <Box>
+                            <Typography variant="body1" sx={{ fontFamily: 'monospace', color: '#666', wordBreak: 'break-all', mt: 2 }}>
+                                {did}
+                            </Typography>
+                            <Button
+                                variant="outlined"
+                                size="small"
+                                sx={{ mt: 1.5, textTransform: 'none' }}
+                                onClick={() => copyDid(did)}
+                                disabled={didCopied}
+                            >
+                                {didCopied ? 'Copied' : 'Copy DID'}
+                            </Button>
+                        </Box>
+                    )}
+                </Box>
+
+                <Card
+                    title="Service Endpoints"
+                    action={<Chip label={services.length} size="small" variant="outlined" />}
+                >
+                    {services.length === 0 ? (
+                        <Typography variant="body2" sx={{ color: '#666' }}>
+                            This identity publishes no service endpoints.
+                        </Typography>
+                    ) : (
+                        services.map((service: any, index: number) => {
+                            const endpoint = service.serviceEndpoint;
+                            const uri = serviceEndpointUri(endpoint);
+                            const routingKeys = typeof endpoint === 'object' ? endpoint?.routingKeys || [] : [];
+                            const accept = typeof endpoint === 'object' ? endpoint?.accept || [] : [];
+
+                            return (
+                                <Box
+                                    key={service.id || index}
+                                    sx={{
+                                        backgroundColor: '#fff',
+                                        borderRadius: 1,
+                                        border: '1px solid #e9ecef',
+                                        p: 2,
+                                        mb: index === services.length - 1 ? 0 : 2,
+                                    }}
+                                >
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1, flexWrap: 'wrap' }}>
+                                        <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+                                            {serviceLabel(service.type)}
+                                        </Typography>
+                                        {serviceFragment(service.id) && (
+                                            <Chip
+                                                label={serviceFragment(service.id)}
+                                                size="small"
+                                                variant="outlined"
+                                                sx={{ fontFamily: 'Monaco, Consolas, monospace' }}
+                                            />
+                                        )}
+                                    </Box>
+                                    <Field label="Endpoint" value={<EndpointValue uri={uri} />} />
+                                    {accept.length > 0 && (
+                                        <Field label="Accepts" value={accept.join(', ')} mono />
+                                    )}
+                                    {routingKeys.length > 0 && (
+                                        <Field
+                                            label="Routing keys"
+                                            value={routingKeys.map((key: string) => (
+                                                <Box key={key} sx={{ fontFamily: 'Monaco, Consolas, monospace' }}>{key}</Box>
+                                            ))}
+                                        />
+                                    )}
+                                </Box>
+                            );
+                        })
+                    )}
+                </Card>
+
+                <Card
+                    title="Keys"
+                    action={<Chip label={verificationMethods.length} size="small" variant="outlined" />}
+                >
+                    {verificationMethods.length === 0 ? (
+                        <Typography variant="body2" sx={{ color: '#666' }}>
+                            No verification methods published.
+                        </Typography>
+                    ) : (
+                        verificationMethods.map((method: any, index: number) => (
+                            <Box key={method.id || index} sx={{ mb: index === verificationMethods.length - 1 ? 0 : 2 }}>
+                                <Field label="Method" value={serviceFragment(method.id) || method.id} mono />
+                                <Field label="Type" value={method.type || 'unknown'} />
+                                {method.publicKeyJwk?.crv && (
+                                    <Field label="Curve" value={method.publicKeyJwk.crv} mono />
+                                )}
+                            </Box>
+                        ))
+                    )}
+                </Card>
+
+                {credentials.length > 0 && (
+                    <Card
+                        title="Credentials"
+                        action={<Chip label={credentials.length} size="small" variant="outlined" />}
+                    >
+                        {credentials.map(([credentialDid, credential]: [string, any], index: number) => (
+                            <Box
+                                key={credentialDid}
+                                sx={{
+                                    backgroundColor: '#fff',
+                                    borderRadius: 1,
+                                    border: '1px solid #e9ecef',
+                                    p: 2,
+                                    mb: index === credentials.length - 1 ? 0 : 2,
+                                }}
+                            >
+                                <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1 }}>
+                                    {credentialType(credential)}
+                                </Typography>
+                                <Field label="Issuer" value={credential?.issuer || 'unknown'} mono />
+                                {credential?.validFrom && (
+                                    <Field label="Issued" value={formatTimestamp(credential.validFrom)} />
+                                )}
+                                {credential?.validUntil && (
+                                    <Field label="Expires" value={formatTimestamp(credential.validUntil)} />
+                                )}
+                            </Box>
+                        ))}
+                    </Card>
+                )}
+
+                {nostr?.npub && (
+                    <Card title="Nostr">
+                        <Field label="npub" value={nostr.npub} mono />
+                    </Card>
+                )}
+
+                <Card title="Document">
+                    {didDocument.controller && (
+                        <Field label="Controller" value={didDocument.controller} mono />
+                    )}
+                    {registration.registry && (
+                        <Field label="Registry" value={registration.registry} />
+                    )}
+                    {metadata.created && (
+                        <Field label="Created" value={formatTimestamp(metadata.created)} />
+                    )}
+                    {metadata.updated && (
+                        <Field label="Updated" value={formatTimestamp(metadata.updated)} />
+                    )}
+                    {metadata.version !== undefined && (
+                        <Field label="Version" value={metadata.version} />
+                    )}
+                    <Field
+                        label="Status"
+                        value={
+                            metadata.deactivated
+                                ? <Chip label="Deactivated" size="small" color="error" />
+                                : metadata.confirmed
+                                    ? <Chip label="Confirmed" size="small" color="success" />
+                                    : <Chip label="Pending confirmation" size="small" />
+                        }
+                    />
+                </Card>
+
+                <Box sx={{ mt: 3, display: 'flex', gap: 2, justifyContent: 'center', flexWrap: 'wrap' }}>
+                    <Button component={Link} to="/members" variant="outlined">
+                        ← Back to Directory
+                    </Button>
+                    <Button component={Link} to={`/member/${name}`} variant="outlined">
+                        Raw DID Document
+                    </Button>
+                    {did && (
+                        <Button
+                            component="a"
+                            href={`https://explorer.archon.technology/search?did=${did}`}
+                            target="_blank"
+                            variant="outlined"
+                        >
+                            View on Archon Explorer
+                        </Button>
+                    )}
                 </Box>
             </Box>
         </div>

--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -1430,13 +1430,6 @@ function ViewIdentity() {
                     border: '1px solid #e9ecef',
                     textAlign: 'center'
                 }}>
-                    {registration.type && (
-                        <Chip
-                            label={registration.type === 'agent' ? 'Agent' : 'Asset'}
-                            size="small"
-                            sx={{ mb: 2, textTransform: 'capitalize' }}
-                        />
-                    )}
                     {did && aliasWalletUrl && (
                         <Box>
                             <a href={aliasWalletUrl} target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'none' }}>

--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -85,27 +85,56 @@ function useMemberData(name: string | undefined) {
     const [explorerUrl, setExplorerUrl] = useState<string>('');
 
     useEffect(() => {
+        if (!name) {
+            return;
+        }
+
+        // A credential's issuer links to another /id/:name, which is the same
+        // route — React keeps this component mounted and only the param
+        // changes. Without resetting, the previous identity's document stays on
+        // screen under the new URL; without the guard, a slower earlier fetch
+        // can resolve last and overwrite the identity actually being viewed.
+        let active = true;
+
+        setLoading(true);
+        setError('');
+        setMemberData(null);
+
         const fetchMember = async () => {
             try {
                 const configResponse = await api.get('/config');
+
+                if (!active) {
+                    return;
+                }
+
                 setServiceDomain(configResponse.data.serviceDomain);
                 setWalletUrl(configResponse.data.walletUrl);
                 setExplorerUrl(configResponse.data.explorerUrl || '');
 
                 const response = await api.get(`/member/${name}`);
-                setMemberData(response.data);
+
+                if (active) {
+                    setMemberData(response.data);
+                }
             }
             catch (err: any) {
-                setError(err.response?.data?.error || 'Member not found');
+                if (active) {
+                    setError(err.response?.data?.error || 'Member not found');
+                }
             }
             finally {
-                setLoading(false);
+                if (active) {
+                    setLoading(false);
+                }
             }
         };
 
-        if (name) {
-            fetchMember();
-        }
+        fetchMember();
+
+        return () => {
+            active = false;
+        };
     }, [name]);
 
     return { memberData, loading, error, serviceDomain, walletUrl, explorerUrl };
@@ -142,8 +171,16 @@ function useNameByDid() {
     return nameByDid;
 }
 
-function useCopyDid() {
+// `resetKey` clears the copied state when the page switches to a different
+// subject. The button latches to "Copied" and disables itself, and this
+// component survives /id/:name -> /id/:other navigation, so without this the
+// next identity opens with its copy button already spent.
+function useCopyDid(resetKey?: string) {
     const [didCopied, setDidCopied] = useState<boolean>(false);
+
+    useEffect(() => {
+        setDidCopied(false);
+    }, [resetKey]);
 
     async function copyDid(text: string) {
         try {
@@ -1688,7 +1725,7 @@ function ViewCredential() {
 function ViewMember() {
     const { name } = useParams<{ name: string }>();
     const { memberData, loading, error, serviceDomain, walletUrl, explorerUrl } = useMemberData(name);
-    const { didCopied, copyDid } = useCopyDid();
+    const { didCopied, copyDid } = useCopyDid(name);
 
     if (loading) {
         return <LoadingShell title={`${name}@${serviceDomain}`} />;
@@ -1702,7 +1739,7 @@ function ViewMember() {
                     <Typography variant="h6" sx={{ color: '#e74c3c', mb: 2 }}>
                         {error}
                     </Typography>
-                    <Button component={Link} to="/members" variant="outlined">
+                    <Button component={Link} to="/directory" variant="outlined">
                         ← Back to Directory
                     </Button>
                 </Box>
@@ -1783,7 +1820,7 @@ function ViewMember() {
                 </Box>
 
                 <Box sx={{ mt: 3, display: 'flex', gap: 2, justifyContent: 'center' }}>
-                    <Button component={Link} to="/members" variant="outlined">
+                    <Button component={Link} to="/directory" variant="outlined">
                         ← Back to Directory
                     </Button>
                     {/* The DID lives at didDocument.id — the payload has no top-level
@@ -1812,7 +1849,7 @@ function ViewMember() {
 function ViewIdentity() {
     const { name } = useParams<{ name: string }>();
     const { memberData, loading, error, serviceDomain, walletUrl, explorerUrl } = useMemberData(name);
-    const { didCopied, copyDid } = useCopyDid();
+    const { didCopied, copyDid } = useCopyDid(name);
     const nameByDid = useNameByDid();
 
     if (loading) {

--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -44,6 +44,7 @@ function App() {
                 <Route path="/profile/:did" element={<ViewProfile />} />
                 <Route path="/member/:name" element={<ViewMember />} />
                 <Route path="/id/:name" element={<ViewIdentity />} />
+                <Route path="/directory" element={<ViewDirectory />} />
                 <Route path="/credential" element={<ViewCredential />} />
                 <Route path="*" element={<NotFound />} />
             </Routes>
@@ -908,6 +909,143 @@ function ViewMembers() {
     )
 }
 
+// The public directory. `/members` covers the same ground but gates on
+// `/check-auth` and bounces anonymous visitors home, so it cannot be linked to
+// from a public identity page. Every endpoint used here is unauthenticated.
+function ViewDirectory() {
+    const [directory, setDirectory] = useState<DirectoryEntry[]>([]);
+    const [lastUpdated, setLastUpdated] = useState<string>('');
+    const [serviceDomain, setServiceDomain] = useState<string>('');
+    const [serviceName, setServiceName] = useState<string>('Directory');
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string>('');
+
+    useEffect(() => {
+        const fetchDirectory = async () => {
+            try {
+                const configResponse = await api.get('/config');
+                setServiceDomain(configResponse.data.serviceDomain);
+                setServiceName(configResponse.data.serviceName || 'Directory');
+
+                const registryResponse = await api.get('/registry');
+                setLastUpdated(registryResponse.data.updated || '');
+
+                const entries: DirectoryEntry[] = Object.entries(registryResponse.data.names || {})
+                    .map(([name, did]) => ({ name, did: did as string }));
+
+                entries.sort((a, b) => a.name.localeCompare(b.name));
+                setDirectory(entries);
+            }
+            catch (err: any) {
+                setError(err.response?.data?.error || 'Directory unavailable');
+            }
+            finally {
+                setLoading(false);
+            }
+        };
+
+        fetchDirectory();
+    }, []);
+
+    if (loading) {
+        return <LoadingShell title="Directory" />;
+    }
+
+    if (error) {
+        return (
+            <div className="App">
+                <Header title="Directory" />
+                <Box sx={{ maxWidth: 600, mx: 'auto', textAlign: 'center' }}>
+                    <Typography variant="h6" sx={{ color: '#e74c3c', mb: 2 }}>
+                        {error}
+                    </Typography>
+                    <Button component={Link} to="/" variant="outlined">
+                        ← Back to Home
+                    </Button>
+                </Box>
+            </div>
+        );
+    }
+
+    return (
+        <div className="App">
+            <Header title="Directory" />
+
+            <Box sx={{ maxWidth: 800, mx: 'auto' }}>
+                <Box sx={{ mb: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+                    <Typography variant="body2" sx={{ color: '#666' }}>
+                        {directory.length} registered {directory.length === 1 ? 'identity' : 'identities'} on {serviceName}
+                    </Typography>
+                    {lastUpdated && (
+                        <Typography variant="body2" sx={{ color: '#888' }}>
+                            Last updated: {formatTimestamp(lastUpdated)}
+                        </Typography>
+                    )}
+                </Box>
+
+                {directory.length === 0 ? (
+                    <Box sx={{
+                        backgroundColor: '#f8f9fa',
+                        borderRadius: 2,
+                        p: 4,
+                        border: '1px solid #e9ecef',
+                        textAlign: 'center',
+                    }}>
+                        <Typography variant="body1" sx={{ color: '#666' }}>
+                            No names have been registered yet.
+                        </Typography>
+                    </Box>
+                ) : (
+                    <Table sx={{ backgroundColor: '#fff', borderRadius: 2, overflow: 'hidden' }}>
+                        <TableBody>
+                            {directory.map((entry) => (
+                                <TableRow key={entry.did} sx={{ '&:hover': { backgroundColor: '#f8f9fa' } }}>
+                                    <TableCell sx={{ fontWeight: 600, fontSize: '1.1rem', color: '#2c3e50' }}>
+                                        <Link
+                                            to={`/id/${entry.name}`}
+                                            style={{ textDecoration: 'none', color: 'inherit' }}
+                                        >
+                                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                                                <Avatar
+                                                    src={`${api.defaults.baseURL}/name/${entry.name}/avatar`}
+                                                    alt={entry.name}
+                                                    sx={{ width: 36, height: 36 }}
+                                                >
+                                                    {entry.name[0]?.toUpperCase()}
+                                                </Avatar>
+                                                {entry.name}@{serviceDomain}
+                                            </Box>
+                                        </Link>
+                                    </TableCell>
+                                    <TableCell sx={{ color: '#666', fontFamily: 'monospace', fontSize: '0.85rem' }}>
+                                        {entry.did.substring(0, 20)}...{entry.did.substring(entry.did.length - 8)}
+                                    </TableCell>
+                                    <TableCell align="right">
+                                        <Button
+                                            component={Link}
+                                            to={`/id/${entry.name}`}
+                                            size="small"
+                                            variant="outlined"
+                                        >
+                                            View Identity
+                                        </Button>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                )}
+
+                <Box sx={{ mt: 3, textAlign: 'center' }}>
+                    <Button component={Link} to="/" variant="text">
+                        ← Back to Home
+                    </Button>
+                </Box>
+            </Box>
+        </div>
+    );
+}
+
 function ViewOwner() {
     const [adminInfo, setAdminInfo] = useState<any>(null);
     const [publishing, setPublishing] = useState(false);
@@ -1487,7 +1625,7 @@ function ViewIdentity() {
                     <Typography variant="h6" sx={{ color: '#e74c3c', mb: 2 }}>
                         {error}
                     </Typography>
-                    <Button component={Link} to="/members" variant="outlined">
+                    <Button component={Link} to="/directory" variant="outlined">
                         ← Back to Directory
                     </Button>
                 </Box>
@@ -1718,7 +1856,7 @@ function ViewIdentity() {
                 </Card>
 
                 <Box sx={{ mt: 3, display: 'flex', gap: 2, justifyContent: 'center', flexWrap: 'wrap' }}>
-                    <Button component={Link} to="/members" variant="outlined">
+                    <Button component={Link} to="/directory" variant="outlined">
                         ← Back to Directory
                     </Button>
                     <Button component={Link} to={`/member/${name}`} variant="outlined">

--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -102,6 +102,37 @@ function useMemberData(name: string | undefined) {
     return { memberData, loading, error, serviceDomain, walletUrl };
 }
 
+// A credential's issuer is a bare DID. When that DID belongs to a member of
+// this service the handle is far more informative, so invert the public name
+// registry to look it up. A failed fetch is not worth surfacing — the DID is
+// still shown, it just stays unresolved.
+function useNameByDid() {
+    const [nameByDid, setNameByDid] = useState<Record<string, string>>({});
+
+    useEffect(() => {
+        const fetchRegistry = async () => {
+            try {
+                const response = await api.get('/registry');
+                const names = response.data?.names || {};
+                const inverted: Record<string, string> = {};
+
+                for (const [name, did] of Object.entries(names)) {
+                    inverted[did as string] = name;
+                }
+
+                setNameByDid(inverted);
+            }
+            catch {
+                setNameByDid({});
+            }
+        };
+
+        fetchRegistry();
+    }, []);
+
+    return nameByDid;
+}
+
 function useCopyDid() {
     const [didCopied, setDidCopied] = useState<boolean>(false);
 
@@ -163,18 +194,77 @@ function serviceFragment(id: string): string {
     return hash === -1 ? '' : id.slice(hash);
 }
 
-// `type` is an ordered array whose first entry is the generic
-// "VerifiableCredential"; the specific type, when present, comes after it.
+// Naming a credential is best-effort. In practice `type` is often the bare
+// ["VerifiableCredential"] and `credentialSchema.id` is an opaque DID, so the
+// most specific name usually sits in the subject's own `credentialType` claim.
 function credentialType(credential: any): string {
-    const types = credential?.type;
+    const claimed = credential?.credentialSubject?.credentialType;
 
-    if (!Array.isArray(types) || types.length === 0) {
-        return 'Verifiable Credential';
+    if (typeof claimed === 'string' && claimed) {
+        return claimed;
     }
 
+    const types = Array.isArray(credential?.type) ? credential.type : [];
     const specific = types.filter((type: string) => type !== 'VerifiableCredential');
 
     return specific.length > 0 ? specific.join(', ') : 'Verifiable Credential';
+}
+
+// `credentialSubject` has no fixed shape — it carries whatever the issuer
+// asserted. Claims are rendered generically rather than per-schema so a
+// credential type this page has never seen still displays its contents.
+function humanizeKey(key: string): string {
+    const spaced = key
+        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+        .replace(/[_-]+/g, ' ')
+        .trim();
+
+    return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
+}
+
+function formatClaim(value: any): string {
+    if (value === null || value === undefined || value === '') {
+        return '—';
+    }
+
+    if (typeof value === 'boolean') {
+        return value ? 'yes' : 'no';
+    }
+
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return 'none';
+        }
+
+        return value.every(item => typeof item !== 'object' || item === null)
+            ? value.join(', ')
+            : JSON.stringify(value);
+    }
+
+    if (typeof value === 'object') {
+        // One level of nesting reads better inline than as raw JSON.
+        return Object.entries(value)
+            .map(([key, nested]) => `${humanizeKey(key)}: ${formatClaim(nested)}`)
+            .join(' · ');
+    }
+
+    // Claims routinely carry ISO timestamps (`registeredAt`, `issuedAt`). Match
+    // the full date-time form only — a plain `2026-01-31` is already readable,
+    // and parsing it would shift it by the viewer's timezone offset.
+    if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}T[\d:.]+(Z|[+-]\d{2}:?\d{2})$/.test(value)) {
+        return formatTimestamp(value);
+    }
+
+    return String(value);
+}
+
+// `id` is the subject DID, which is the member whose page this is, and
+// `credentialType` is already shown as the card's title.
+const HIDDEN_CLAIMS = ['id', 'credentialType'];
+
+function credentialClaims(credential: any): Array<[string, any]> {
+    return Object.entries(credential?.credentialSubject || {})
+        .filter(([key]) => !HIDDEN_CLAIMS.includes(key));
 }
 
 // Document timestamps come straight from the gatekeeper; render the raw value
@@ -254,6 +344,24 @@ function EndpointValue({ uri }: { uri: string }) {
         >
             {uri}
         </a>
+    );
+}
+
+function IssuerValue({ issuer, nameByDid, serviceDomain }: { issuer?: string, nameByDid: Record<string, string>, serviceDomain: string }) {
+    if (!issuer) {
+        return <span>unknown</span>;
+    }
+
+    const issuerName = nameByDid[issuer];
+
+    if (!issuerName) {
+        return <span style={{ fontFamily: 'Monaco, Consolas, monospace' }}>{issuer}</span>;
+    }
+
+    return (
+        <Link to={`/id/${issuerName}`} style={{ color: '#1976d2' }}>
+            {issuerName}@{serviceDomain}
+        </Link>
     );
 }
 
@@ -1365,6 +1473,7 @@ function ViewIdentity() {
     const { name } = useParams<{ name: string }>();
     const { memberData, loading, error, serviceDomain, walletUrl } = useMemberData(name);
     const { didCopied, copyDid } = useCopyDid();
+    const nameByDid = useNameByDid();
 
     if (loading) {
         return <LoadingShell title={`${name}@${serviceDomain}`} />;
@@ -1552,13 +1661,23 @@ function ViewIdentity() {
                                 <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1 }}>
                                     {credentialType(credential)}
                                 </Typography>
-                                <Field label="Issuer" value={credential?.issuer || 'unknown'} mono />
-                                {credential?.validFrom && (
-                                    <Field label="Issued" value={formatTimestamp(credential.validFrom)} />
-                                )}
-                                {credential?.validUntil && (
-                                    <Field label="Expires" value={formatTimestamp(credential.validUntil)} />
-                                )}
+
+                                {credentialClaims(credential).map(([key, value]) => (
+                                    <Field key={key} label={humanizeKey(key)} value={formatClaim(value)} />
+                                ))}
+
+                                <Box sx={{ borderTop: '1px solid #e9ecef', mt: 1.5, pt: 1.5 }}>
+                                    <Field
+                                        label="Issued by"
+                                        value={<IssuerValue issuer={credential?.issuer} nameByDid={nameByDid} serviceDomain={serviceDomain} />}
+                                    />
+                                    {credential?.validFrom && (
+                                        <Field label="Issued" value={formatTimestamp(credential.validFrom)} />
+                                    )}
+                                    {credential?.validUntil && (
+                                        <Field label="Expires" value={formatTimestamp(credential.validUntil)} />
+                                    )}
+                                </Box>
                             </Box>
                         ))}
                     </Card>

--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -1203,8 +1203,15 @@ function ViewDirectory() {
                                             @{serviceDomain}
                                         </Box>
                                     </Typography>
-                                    <Box component="span" sx={{ ...codePill, mt: 0.5, fontSize: '0.75rem', color: '#64748b' }}>
-                                        {entry.did.substring(0, 20)}…{entry.did.substring(entry.did.length - 8)}
+                                    <Box component="span" sx={{
+                                        ...codePill,
+                                        display: 'inline-block',
+                                        maxWidth: '100%',
+                                        mt: 0.5,
+                                        fontSize: '0.75rem',
+                                        color: '#64748b',
+                                    }}>
+                                        {entry.did}
                                     </Box>
                                 </Box>
                                 <Box

--- a/docker/compose/drawbridge.yml
+++ b/docker/compose/drawbridge.yml
@@ -15,6 +15,9 @@ services:
       - ARCHON_GATEKEEPER_URL=http://gatekeeper:4224
       - ARCHON_HERALD_KEYMASTER_URL=${ARCHON_HERALD_KEYMASTER_URL-http://keymaster:4226}
       - ARCHON_HERALD_WALLET_URL=${ARCHON_HERALD_WALLET_URL:-http://localhost:4228}
+      # Single-dash default so an explicitly empty value survives and hides the
+      # explorer links, rather than being replaced by the fallback.
+      - ARCHON_HERALD_EXPLORER_URL=${ARCHON_HERALD_EXPLORER_URL-https://explorer.archon.technology}
       - ARCHON_HERALD_WALLET_PASSPHRASE=${ARCHON_HERALD_WALLET_PASSPHRASE:-}
       - ARCHON_HERALD_DB=${ARCHON_HERALD_DB:-json}
       - ARCHON_REDIS_URL=redis://redis:6379

--- a/services/herald/server/src/config.ts
+++ b/services/herald/server/src/config.ts
@@ -10,6 +10,13 @@ export const DRAWBRIDGE_PORT = Number(process.env.ARCHON_DRAWBRIDGE_PORT) || 422
 export const DRAWBRIDGE_PUBLIC_HOST = process.env.ARCHON_DRAWBRIDGE_PUBLIC_HOST || `http://localhost:${DRAWBRIDGE_PORT}`;
 export const GATEKEEPER_URL = process.env.ARCHON_GATEKEEPER_URL || 'http://localhost:4224';
 export const WALLET_URL = process.env.ARCHON_HERALD_WALLET_URL || 'https://wallet.archon.technology';
+// This URL is followed by the visitor's browser, so it must be reachable from
+// the public internet. The node's own explorer cannot be the default: it is
+// profile-gated, bound to port 4000, and proxied by neither Drawbridge nor
+// nginx, so there is no address to advertise — and `localhost:4000` would
+// resolve to each visitor's own machine. Operators running a reachable
+// explorer should set this to it. Set it empty to hide the links entirely.
+export const EXPLORER_URL = process.env.ARCHON_HERALD_EXPLORER_URL ?? 'https://explorer.archon.technology';
 export const HERALD_DATABASE_TYPE = process.env.ARCHON_HERALD_DB || 'json';
 export const DATA_DIR = process.env.ARCHON_HERALD_DATA_DIR || '/app/server/data';
 export const IPFS_API_URL = process.env.ARCHON_HERALD_IPFS_API_URL || 'http://localhost:5001/api/v0';

--- a/services/herald/server/src/routes.ts
+++ b/services/herald/server/src/routes.ts
@@ -9,6 +9,7 @@ import type { DatabaseInterface, User } from './db/interfaces.js';
 import type { EmailBridge } from './email-bridge.js';
 import { createOAuthRoutes } from './oauth/index.js';
 import {
+    EXPLORER_URL,
     IPFS_API_URL,
     IPNS_KEY_NAME,
     MEMBERSHIP_SCHEMA_DID,
@@ -339,6 +340,7 @@ export function createHeraldRoutes(ctx: HeraldContext): {
             serviceDomain: SERVICE_DOMAIN,
             publicUrl: PUBLIC_URL,
             walletUrl: WALLET_URL,
+            explorerUrl: EXPLORER_URL,
         });
     });
 

--- a/services/herald/server/src/routes.ts
+++ b/services/herald/server/src/routes.ts
@@ -1165,7 +1165,10 @@ export function createHeraldRoutes(ctx: HeraldContext): {
                     {
                         rel: 'http://webfinger.net/rel/profile-page',
                         type: 'text/html',
-                        href: `${PUBLIC_URL}/name/${name}`,
+                        // Must match a route the client actually serves. `/name/:name`
+                        // is not one — it fell through to the SPA's catch-all and
+                        // redirected to the home page.
+                        href: `${PUBLIC_URL}/id/${name}`,
                     },
                     {
                         rel: 'https://w3id.org/did',

--- a/tests/herald/routes.test.ts
+++ b/tests/herald/routes.test.ts
@@ -313,6 +313,21 @@ describe('herald webfinger', () => {
         ]));
         expect(response.body.links[0].href).toContain('/api/name/alice');
     });
+
+    it('points profile-page at a route the client serves', async () => {
+        const db = createDb({ 'did:cid:alice': { name: 'alice' } });
+        const { app } = mount({ db });
+
+        const response = await request(app).get('/.well-known/webfinger?resource=acct:alice@archon.test');
+
+        const profilePage = response.body.links.find(
+            (link: any) => link.rel === 'http://webfinger.net/rel/profile-page');
+
+        // Regression guard: this used to be `/name/alice`, which the client has no
+        // route for — following it landed on the home page instead of the profile.
+        expect(profilePage.href).toContain('/id/alice');
+        expect(profilePage.href).not.toContain('/name/alice');
+    });
 });
 
 describe('herald session login', () => {

--- a/tests/herald/routes.test.ts
+++ b/tests/herald/routes.test.ts
@@ -94,6 +94,17 @@ describe('herald public endpoints', () => {
         });
     });
 
+    it('advertises an explorer the visitor can actually reach', async () => {
+        const { app } = mount();
+
+        const response = await request(app).get('/api/config');
+
+        // The client renders this as a link in the visitor's browser, so a
+        // loopback default would resolve to the visitor's own machine.
+        expect(response.body.explorerUrl).toBeDefined();
+        expect(response.body.explorerUrl).not.toMatch(/localhost|127\.0\.0\.1/);
+    });
+
     it('builds the name registry from users that have a name', async () => {
         const db = createDb({
             'did:cid:alice': { name: 'alice' },


### PR DESCRIPTION
## Summary

Adds `/id/:name`, a card-based rendering of the same payload `/member/:name` already serves. `/member/:name` is **unchanged** — it remains the raw-JSON transparency layer, and the two pages link to each other.

This is the readable-surface half of #528. It deliberately does not touch identity types, agent-specific service types, or verification proofs; see the evaluation on that issue for why the agent-specific parts are blocked on an MCP HTTP transport that doesn't exist yet.

## What it renders

| Card | Source |
| --- | --- |
| Header — avatar, handle, `agent`/`asset` badge, QR, DID + copy | `didDocument.id`, `didDocumentRegistration.type` |
| Service Endpoints — type label, `#fragment` chip, endpoint, `accept`/`routingKeys` | `didDocument.service` |
| Keys — fragment, type, curve | `didDocument.verificationMethod` |
| Credentials — type, issuer, issued/expires | `didDocumentData.manifest` |
| Nostr — npub | `didDocumentData.nostr` |
| Document — controller, registry, created/updated, version, status chip | `didDocumentMetadata` |

## Three details that came from live data, not the type definitions

I checked real payloads on a running node rather than working from `gatekeeper-types.ts` alone, which changed three decisions:

1. **Onion endpoints are the common case.** Drawbridge publishes Lightning and DIDComm endpoints over Tor. Linking those hands every non-Tor visitor a browser error, so `.onion` endpoints render as text with a "Tor" chip; clearnet endpoints (`https://…/invoice/…`) stay clickable.
2. **`verificationMethod.id` is inconsistent across documents** — it appears both as a bare `#key-1` and as a full `did:cid:…#key-agreement-1`. The fragment helper handles both.
3. **`didDocumentData` carries public verifiable credentials and nostr keys.** These are exactly the "verification proofs" surface #528 asked for, already present and previously visible only inside the JSON blob.

## Refactor

eslint's `sonarjs/no-identical-functions` flagged duplicated fetch and copy-DID logic between the two pages, so both now use `useMemberData`/`useCopyDid` hooks. **The output `ViewMember` renders is unchanged** — only its state plumbing moved.

## Testing

- `vite build` passes; `eslint` clean.
- Helper logic exercised against live payloads for three real members, plus edge cases: object-form endpoints, missing URIs, bare fragments, `did:` scheme, malformed timestamps, untyped credentials. All correct.
- The repo has no React test infrastructure, so the visual layout has not been rendered in a browser and wants a look before merge.

## Follow-up, not included

`/id/:name` is currently reachable only by typing the URL — `/id` links to `/member`, but the directory and `/member` both still point at `/member`. Making it discoverable means changing a page this PR intentionally leaves alone, so it is left as a separate decision.

Part of #528.
