### PR TITLE
docs+test: trace where the entropy comes from, and guard the no-fallback property

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -94,17 +94,32 @@ DIDComm X25519 keys **are** seed-derived: `generateX25519Jwk` takes 32 bytes of 
 
 ### Randomness source
 
-All paths draw from the platform CSPRNG through `@noble/hashes` `randomBytes`, which uses `crypto.getRandomValues`, falls back to Node's `crypto.randomBytes`, and **throws if neither is available**:
+Every path reaches `crypto.getRandomValues`, but **through two independent implementations**, not one:
+
+| generator | RNG | reached via |
+| --- | --- | --- |
+| Mnemonic, salts, passphrase IV | `@noble/hashes` `randomBytes` | `bip39.generateMnemonic()`, `generateRandomSalt()` |
+| Vault keypair | `@noble/secp256k1`'s own `randomBytes` | `secp.utils.randomPrivateKey()` |
+
+`@noble/secp256k1` does not use `@noble/hashes` for this — it ships its own. The two are separate packages on separate version lines, so **a dependency bump can change one and leave the other untouched**. (A single install can also contain more than one resolved copy of `@noble/hashes`; `@noble/curves` nests its own.) Anything asserting a property of "the RNG" has to assert it of both.
+
+Both refuse to degrade, by different mechanisms:
 
 ```js
+// @noble/hashes — captures globalThis.crypto at module load
 throw new Error('crypto.getRandomValues must be defined');
+
+// @noble/secp256k1 — reads globalThis.crypto at call time, then dereferences it
+const cr = () => globalThis?.crypto;
 ```
 
-There is no silent degradation to `Math.random()` on any path, in either the Node or browser build. This is the property most worth preserving — a weak-RNG regression is invisible in tests and catastrophic in production.
+There is no silent degradation to `Math.random()` on any path, in either the Node or browser build. This is the property most worth preserving — a weak-RNG regression is invisible in tests and catastrophic in production, so `tests/cipher/rng.test.ts` asserts it of both implementations, in both directions: that each draws from `crypto.getRandomValues`, and that each throws rather than returning anything when no CSPRNG exists.
+
+Note what those tests deliberately do **not** do. A degraded RNG still produces output that looks random, so neither statistical testing nor any assertion about the shape of a generated mnemonic would catch a substitution. Only provenance and the absence of a fallback are worth asserting.
 
 ### Where the entropy ultimately comes from
 
-`crypto.getRandomValues` is where Archon's responsibility ends, but it is not where the randomness originates. The full chain on a Linux node:
+`crypto.getRandomValues` is where Archon's responsibility ends, but it is not where the randomness originates. Below it, both implementations above converge on one chain — on a Linux node:
 
 ```
 bip39.generateMnemonic() · randomPrivateKey() · generateRandomSalt()
@@ -173,7 +188,7 @@ Given the curve-matching argument above, this is defensible. It would only be wo
 | Derivation | `m/44'/0'/{account}'/0/{index}`, deterministic |
 | Chain wallets | same mnemonic, BIP-44/84 coin paths, fetched from Keymaster |
 | Vault keys | ~256 bits, independent, **not** seed-recoverable |
-| RNG | platform CSPRNG; throws rather than degrading |
+| RNG | two implementations (`@noble/hashes`, `@noble/secp256k1`); both throw rather than degrading |
 | Entropy origin | thermal noise (RDSEED, interrupt timing) → kernel CSPRNG → OpenSSL DRBG |
 | Main RNG risk | cloned VM images / shipped seed files |
 | Mnemonic at rest | PBKDF2-SHA512 100k iters + AES-GCM |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -102,6 +102,57 @@ throw new Error('crypto.getRandomValues must be defined');
 
 There is no silent degradation to `Math.random()` on any path, in either the Node or browser build. This is the property most worth preserving — a weak-RNG regression is invisible in tests and catastrophic in production.
 
+### Where the entropy ultimately comes from
+
+`crypto.getRandomValues` is where Archon's responsibility ends, but it is not where the randomness originates. The full chain on a Linux node:
+
+```
+bip39.generateMnemonic() · randomPrivateKey() · generateRandomSalt()
+  ↓ @noble/hashes randomBytes
+crypto.getRandomValues                       Web Crypto
+  ↓ Node routes this to OpenSSL RAND_bytes
+OpenSSL 3.x CTR-DRBG (AES-256-CTR)           periodically reseeded
+  ↓ seeded via the OS entropy syscall
+getrandom(2)                                 BCryptGenRandom / getentropy elsewhere
+  ↓
+Linux kernel CSPRNG (ChaCha20)
+  ↑ seeded and continuously reseeded from
+interrupt timing jitter · RDSEED/RDRAND · bootloader/EFI seed · seed file across reboots
+  ↑ which in turn originate in
+thermal noise in silicon · timing variance between physically independent clocks
+```
+
+Note which branch actually runs: `@noble/hashes` tries `crypto.getRandomValues` first and only falls back to Node's `crypto.randomBytes` if it is absent. Since Node 19 exposes `globalThis.crypto`, **the first branch is the one taken** on every supported Node version and in browsers; the fallback is legacy compatibility that current deployments never reach.
+
+#### The bottom of the chain is physics
+
+Everything above is transport. A DRBG expands entropy, a seed file carries it across a reboot, `getrandom(2)` hands it over — none of them *create* any. Follow the inputs down and they terminate in two physical processes:
+
+**Thermal noise in silicon.** `RDSEED` is backed by an on-die entropy source: a circuit deliberately driven into a metastable state, whose settling direction is decided by Johnson–Nyquist noise — the random thermal motion of charge carriers in the transistors. That raw output is biased, so the hardware conditions it (Intel's design runs it through AES-CBC-MAC) before `RDSEED` returns it. The randomness is manufactured by heat, not by an algorithm.
+
+**Timing variance between independent physical systems.** The kernel timestamps hardware interrupts with the CPU cycle counter and mixes in the low bits. Those bits are unpredictable because the events and the clock measuring them are physically decoupled: a network packet's arrival is determined by events on another machine, a disk completion by mechanical and thermal conditions in the drive, and the sampling clock itself drifts against them through oscillator phase noise — which is, again, thermal. Related jitter-entropy designs measure variance in the CPU's own execution timing, arising from cache state, frequency scaling, and the same underlying noise.
+
+So the honest answer to "where does the entropy ultimately come from" is: **thermal noise in physical hardware**, sampled either directly by a dedicated circuit or indirectly through timing. It bottoms out in statistical mechanics — and at the smallest scale, quantum effects — not in any part of the software stack.
+
+Two caveats worth stating:
+
+- **This host is a WSL2 VM with no `hw_random` device** (`rng_available` is `none`), so the kernel's hardware-RNG framework contributes nothing here. On such systems the arch-random path (`RDSEED` on this i7-14700F) and interrupt timing carry the load. A cloud VM typically also gets `virtio-rng`, which is the *host's* entropy passed through — it does not generate any, which is why a cloned guest is dangerous.
+- **"Random" here means physically unpredictable, not provably indeterminate.** The security claim is that no attacker can model thermal fluctuations in your specific silicon well enough to predict the output — not a metaphysical claim about determinism.
+
+Three consequences worth understanding:
+
+**The CPU's hardware RNG is an input, not the source.** Linux mixes `RDSEED`/`RDRAND` into the pool rather than emitting them directly, so a backdoored CPU RNG cannot by itself determine what Archon gets. (With `random.trust_cpu`, which many distributions enable, that hardware output is additionally *credited* toward initial seeding — it still passes through the ChaCha20 construction.)
+
+**Containers do not have their own entropy.** A dockerised node shares the host kernel's CSPRNG rather than having one of its own. The quality of every key Archon generates is therefore a property of the **host**, so that is where this is hardened, not in the image.
+
+**The real risk is a cloned or freshly-booted image.** This is the one failure mode that could actually make Archon keys predictable, and it happens before any Archon code runs:
+
+- A VM cloned from a snapshot taken *after* the CRNG was seeded starts life with the same CRNG state as every other clone. Two nodes from one golden image can generate the same mnemonic.
+- A golden image that ships a `/var/lib/systemd/random-seed` (or equivalent) hands every instance the same seed file.
+- An embedded or minimal system booting with no seed file and little interrupt activity can sit with an uninitialised CRNG.
+
+`getrandom(2)` blocking until initialisation is the protection against the third case, and it is why nothing here silently falls back to weak randomness. It is **not** protection against the first two — a cloned seeded state looks perfectly initialised. If you build node images, generate identities after first boot, not in the image, and strip any seed file from the template.
+
 ### Mnemonic at rest
 
 The mnemonic is stored encrypted, never in plaintext: PBKDF2-HMAC-SHA512 at **100,000 iterations** (`PBKDF2_ITERATIONS` overrides it) over a 16-byte random salt, then AES-GCM with a 12-byte random IV.
@@ -123,5 +174,7 @@ Given the curve-matching argument above, this is defensible. It would only be wo
 | Chain wallets | same mnemonic, BIP-44/84 coin paths, fetched from Keymaster |
 | Vault keys | ~256 bits, independent, **not** seed-recoverable |
 | RNG | platform CSPRNG; throws rather than degrading |
+| Entropy origin | thermal noise (RDSEED, interrupt timing) → kernel CSPRNG → OpenSSL DRBG |
+| Main RNG risk | cloned VM images / shipped seed files |
 | Mnemonic at rest | PBKDF2-SHA512 100k iters + AES-GCM |
 | TS / Python parity | both fixed at 128 bits |

--- a/tests/cipher/rng.test.ts
+++ b/tests/cipher/rng.test.ts
@@ -1,0 +1,93 @@
+import { jest } from '@jest/globals';
+
+// Guards the property SECURITY.md calls the most important one to preserve:
+// key material comes from the platform CSPRNG, and the code throws rather than
+// quietly substituting something weaker.
+//
+// This is not hypothetical. The July 2026 Coldcard incident was exactly this
+// failure — a build-configuration error silently bound seed generation to a
+// deterministic fallback PRNG instead of the hardware RNG, cutting real entropy
+// to roughly 40 bits. It went unnoticed for five years because degraded output
+// still looks random. Statistical tests would not have caught it, and neither
+// would any assertion about the shape of a generated mnemonic. The only useful
+// things to assert are where the bytes come from, and that there is no fallback
+// to fall into.
+//
+// Note there are TWO independent RNG implementations behind these calls:
+// mnemonics and salts go through `@noble/hashes` `randomBytes`, while vault
+// keypairs go through `@noble/secp256k1`, which ships its own. They are
+// separate packages on separate version lines, so a bump can change one and not
+// the other — hence a test for each.
+
+describe('key material comes from the platform CSPRNG', () => {
+    it('draws mnemonic entropy from crypto.getRandomValues', async () => {
+        const { default: CipherNode } = await import('@didcid/cipher/node');
+        const cipher = new CipherNode();
+        const spy = jest.spyOn(globalThis.crypto, 'getRandomValues');
+
+        try {
+            const mnemonic = cipher.generateMnemonic();
+
+            // Read the count before restoring — mockRestore() clears the record.
+            expect(spy.mock.calls.length).toBeGreaterThan(0);
+            // 12 words is 128 bits, the strength SECURITY.md documents.
+            expect(mnemonic.split(' ')).toHaveLength(12);
+        }
+        finally {
+            spy.mockRestore();
+        }
+    });
+
+    it('draws vault keypair entropy from crypto.getRandomValues', async () => {
+        const { default: CipherNode } = await import('@didcid/cipher/node');
+        const cipher = new CipherNode();
+        const spy = jest.spyOn(globalThis.crypto, 'getRandomValues');
+
+        try {
+            cipher.generateRandomJwk();
+
+            expect(spy.mock.calls.length).toBeGreaterThan(0);
+        }
+        finally {
+            spy.mockRestore();
+        }
+    });
+});
+
+describe('there is no weak RNG to fall back to', () => {
+    it('vault keypair generation throws when no platform CSPRNG is available', async () => {
+        const { default: CipherNode } = await import('@didcid/cipher/node');
+        const cipher = new CipherNode();
+        // @noble/secp256k1 reads globalThis.crypto at call time, so removing it
+        // here exercises the real code path rather than a mocked module.
+        const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'crypto')!;
+
+        delete (globalThis as any).crypto;
+
+        try {
+            // The failure mode to prevent is this returning a key instead of
+            // throwing. A silent fallback is undetectable in production.
+            expect(() => cipher.generateRandomJwk()).toThrow();
+        }
+        finally {
+            Object.defineProperty(globalThis, 'crypto', descriptor);
+        }
+    });
+
+    // Kept last and nested: the module mock replaces the crypto module for any
+    // subsequent import in this file's registry.
+    describe('hashes RNG', () => {
+        afterAll(() => {
+            jest.resetModules();
+        });
+
+        it('throws instead of degrading when no platform CSPRNG is available', async () => {
+            jest.unstable_mockModule('@noble/hashes/crypto', () => ({ crypto: undefined }));
+            jest.resetModules();
+
+            const { randomBytes } = await import('@noble/hashes/utils');
+
+            expect(() => randomBytes(32)).toThrow(/getRandomValues must be defined/);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Two related changes to how Archon's randomness is documented and defended.

1. **`SECURITY.md`** traced the RNG as far as `crypto.getRandomValues` and stopped — that names the API Archon calls, not where the randomness is created. This adds the rest of the chain, down to the physical layer.
2. **A regression test** for the property that document calls "the property most worth preserving", which nothing asserted.

The second was prompted by the [July 2026 Coldcard incident](https://thehackernews.com/2026/08/coldcard-hardware-wallet-flaw-linked-to.html), which is the worked example of exactly this failure.

## 1. Where the entropy comes from

```
bip39.generateMnemonic() · randomPrivateKey() · generateRandomSalt()
  ↓ @noble/hashes randomBytes
crypto.getRandomValues
  ↓ Node routes this to OpenSSL RAND_bytes
OpenSSL 3.x CTR-DRBG (AES-256-CTR)
  ↓ getrandom(2)
Linux kernel CSPRNG (ChaCha20)
  ↑ interrupt timing · RDSEED/RDRAND · EFI seed · seed file across reboots
  ↑ which in turn originate in
thermal noise in silicon · timing variance between physically independent clocks
```

None of the middle of that chain *creates* entropy — a DRBG expands it, a seed file carries it across a reboot, a syscall hands it over. Following the inputs down, they terminate in two physical processes:

- **Thermal noise in silicon.** `RDSEED` is backed by a circuit deliberately driven into a metastable state whose settling direction is decided by Johnson–Nyquist noise. Raw output is biased, so the hardware conditions it (Intel's design uses AES-CBC-MAC) before returning it.
- **Timing variance between physically independent systems.** The kernel timestamps interrupts with the cycle counter and mixes in the low bits. Those are unpredictable because the event and the clock measuring it are decoupled, and the sampling oscillator drifts against them through phase noise — thermal again.

Also documented: the CPU's hardware RNG is an input rather than the source; containers share the host CSPRNG, so key quality is a host property; and the one failure mode that could actually make Archon keys predictable is a **cloned or freshly-booted image**, which `getrandom(2)` blocking does *not* protect against because a cloned seeded state looks initialised.

## 2. The regression test

The Coldcard root cause was a build-configuration error that silently bound seed generation to a deterministic fallback PRNG instead of the hardware RNG, cutting real entropy to ~40 bits. It survived five years because degraded output still looks random.

That rules out the intuitive defences. Statistical tests would not have caught it, and neither would any assertion about the shape of a generated mnemonic. The only useful things to assert are **where the bytes come from** and **that there is no fallback to fall into** — so `tests/cipher/rng.test.ts` asserts exactly those, in both directions:

- mnemonic and vault-key generation each draw from `crypto.getRandomValues`
- each path throws, rather than returning anything, when no CSPRNG exists

### Finding: there are two independent RNGs, not one

Writing the test surfaced something the doc did not capture. Mnemonics and salts go through `@noble/hashes` `randomBytes`; **vault keypairs go through `@noble/secp256k1`, which ships its own** (`index.js:90`) and never touch `@noble/hashes` at all. Separate packages on separate version lines, so a dependency bump can change one and leave the other. A single install can also resolve more than one copy of `@noble/hashes`, since `@noble/curves` nests its own.

Both currently refuse to degrade, but by different mechanisms — `@noble/hashes` captures `globalThis.crypto` at module load and throws; `@noble/secp256k1` reads it at call time and dereferences it. Each now has its own test, and `SECURITY.md` documents both rather than the single chain it previously described.

This only came to light because the vault test kept passing while the RNG in `@noble/hashes` was mutated — including the copy nested under `@noble/curves`.

### Verified non-vacuous, not assumed

A Coldcard-style deterministic PRNG was patched over the RNG in all four locations (three `@noble/hashes` copies plus `@noble/secp256k1`) and the suite re-run: **all four tests fail**. Restoring the dependencies (confirmed zero residue) returns them to green.

Worth recording: an earlier draft using `delete globalThis.crypto` plus `jest.resetModules()` **passed vacuously** — the ESM module cache kept noble's original crypto capture, so the throw path was never reached. The working version uses `jest.unstable_mockModule` for the hashes path, and a plain delete for secp, whose `cr()` is a call-time lookup.

## Testing

- `tests/cipher/` — 63 passing, 5 suites.
- The `randomBytes(48)` / FIPS 186 B.4.1 claim already in `SECURITY.md` was re-checked against the installed `@noble/secp256k1` 2.3.0 (`randomBytes(L + 16)`, `L = 32`) and still holds — only the attribution of *which* `randomBytes` was wrong.
- eslint clean.
- Mutation-tested as described above.

## Not included

One follow-up from the same review, deliberately left out:

- A **warning on mnemonic import** naming the affected Coldcard firmware window (Mk2/Mk3, v4.x–v5.0.3). `newWallet(mnemonic?)` accepts a user-supplied seed with only BIP-39 *checksum* validation — a weak seed is a valid seed — and per `SECURITY.md` that one seed then controls every DID and every chain wallet on the node. That is a behaviour change rather than documentation, so it belongs in its own PR.
