### PR TITLE
docs: note did:cid's DIF-recommended status in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![unit-test](https://github.com/archetech/archon/actions/workflows/unit-test.yml/badge.svg)](https://github.com/archetech/archon/actions/workflows/unit-test.yml) [![Coverage Status](https://coveralls.io/repos/github/archetech/archon/badge.svg?branch=main)](https://coveralls.io/github/archetech/archon?branch=main)
+[![unit-test](https://github.com/archetech/archon/actions/workflows/unit-test.yml/badge.svg)](https://github.com/archetech/archon/actions/workflows/unit-test.yml) [![Coverage Status](https://coveralls.io/repos/github/archetech/archon/badge.svg?branch=main)](https://coveralls.io/github/archetech/archon?branch=main) [![DIF Recommended](https://img.shields.io/badge/DIF-recommended%20DID%20method-5b4b8a)](https://github.com/decentralized-identity/did-methods/blob/main/dif-recommended/findings-did-cid.md)
 
 # Archon
 
-Archon is a peer-to-peer decentralized identity platform built on the W3C **DID (Decentralized Identifier)** standard, and a reference implementation of the `did:cid` method. It lets anyone create, control, and resolve self-sovereign identities without a central authority — and without paying per-operation fees for routine use.
+Archon is a peer-to-peer decentralized identity platform built on the W3C **DID (Decentralized Identifier)** standard, and the reference implementation of [`did:cid`](https://github.com/decentralized-identity/did-methods/blob/main/dif-recommended/findings-did-cid.md), a **DIF-recommended** DID method. It lets anyone create, control, and resolve self-sovereign identities without a central authority — and without paying per-operation fees for routine use.
 
 The protocol separates **DID creation** from **DID updates**: creation is instant and free, since a DID is derived from the content-address (CID) of its initial document in IPFS; updates are anchored to one or more pluggable registries (Hyperswarm for gossip-based propagation, Bitcoin mainnet/signet/testnet4 for blockchain-anchored consensus, with room for more). This split gives Archon the unusual combination of zero-cost identity creation with cryptographically verifiable, consensus-driven history.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Archon
 
-Archon is a peer-to-peer decentralized identity platform built on the W3C **DID (Decentralized Identifier)** standard, and the reference implementation of [`did:cid`](https://github.com/decentralized-identity/did-methods/tree/main/dif-recommended), a **DIF-recommended** DID method. It lets anyone create, control, and resolve self-sovereign identities without a central authority — and without paying per-operation fees for routine use.
+Archon is a peer-to-peer decentralized identity platform built on the W3C **DID (Decentralized Identifier)** standard, and the reference implementation of `did:cid`, a [**DIF-recommended** DID method](https://github.com/decentralized-identity/did-methods/tree/main/dif-recommended). It lets anyone create, control, and resolve self-sovereign identities without a central authority — and without paying per-operation fees for routine use.
 
 The protocol separates **DID creation** from **DID updates**: creation is instant and free, since a DID is derived from the content-address (CID) of its initial document in IPFS; updates are anchored to one or more pluggable registries (Hyperswarm for gossip-based propagation, Bitcoin mainnet/signet/testnet4 for blockchain-anchored consensus, with room for more). This split gives Archon the unusual combination of zero-cost identity creation with cryptographically verifiable, consensus-driven history.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Archon
 
-Archon is a peer-to-peer decentralized identity platform built on the W3C **DID (Decentralized Identifier)** standard, and the reference implementation of [`did:cid`](https://github.com/decentralized-identity/did-methods/blob/main/dif-recommended/findings-did-cid.md), a **DIF-recommended** DID method. It lets anyone create, control, and resolve self-sovereign identities without a central authority — and without paying per-operation fees for routine use.
+Archon is a peer-to-peer decentralized identity platform built on the W3C **DID (Decentralized Identifier)** standard, and the reference implementation of [`did:cid`](https://github.com/decentralized-identity/did-methods/tree/main/dif-recommended), a **DIF-recommended** DID method. It lets anyone create, control, and resolve self-sovereign identities without a central authority — and without paying per-operation fees for routine use.
 
 The protocol separates **DID creation** from **DID updates**: creation is instant and free, since a DID is derived from the content-address (CID) of its initial document in IPFS; updates are anchored to one or more pluggable registries (Hyperswarm for gossip-based propagation, Bitcoin mainnet/signet/testnet4 for blockchain-anchored consensus, with room for more). This split gives Archon the unusual combination of zero-cost identity creation with cryptographically verifiable, consensus-driven history.
 


### PR DESCRIPTION
## Summary

`did:cid` was granted [DIF-recommended status](https://github.com/decentralized-identity/did-methods/blob/main/dif-recommended/findings-did-cid.md) on 2026-08-03, after a 60-day formal review that closed on 2026-07-26. Nothing in the repo said so.

The [findings document](https://github.com/decentralized-identity/did-methods/blob/main/dif-recommended/findings-did-cid.md) cites **Archon v0.11.0** as the reviewed specification version, and credits the W3C registry listing, test-suite coverage, and the TypeScript, Python and Rust implementations.

## Changes

**Badge**, appended to the existing row:

```markdown
[![DIF Recommended](https://img.shields.io/badge/DIF-recommended%20DID%20method-5b4b8a)](https://github.com/decentralized-identity/did-methods/blob/main/dif-recommended/findings-did-cid.md)
```

**Opening line**, from:

> …and a reference implementation of the `did:cid` method.

to:

> …and the reference implementation of [`did:cid`](https://github.com/decentralized-identity/did-methods/blob/main/dif-recommended/findings-did-cid.md), a **DIF-recommended** DID method.

## Two deliberate choices

**"a DIF-recommended DID method", not "one of three".** Three is accurate today — with `did:webplus` and `did:webvh` — but it dates as more methods are ratified, and the README shouldn't need editing when that happens.

**The badge is self-minted, and that is why the prose carries the claim too.** DIF publishes no official badge, and `did:webvh`, which holds the same status, has none in its README — so there is no convention to match. A hand-made shield sitting beside machine-generated CI badges is the weaker form of a third-party endorsement, since a reader can't tell them apart at a glance. Both the badge and the prose link to the findings document, so the claim is one click from verification.

## Testing

Docs only. Both URLs verified to return 200 — the shields.io image and the findings document.

## Not included

Two items the findings list as outstanding, neither tracked in this repo: Universal Resolver driver integration (DIF PR #573) and the DID Traits comparison (PR #70). Worth their own issues — note UR support is one of the eleven listed requirements, so it is a commitment still open rather than a nice-to-have.