### PR TITLE
ci: Make native-module installs resilient to prebuild fetch failures

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -70,6 +70,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "22.15.0"
+
       - name: Prefetch native prebuilds
         run: node scripts/prefetch-prebuilds.mjs
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -65,6 +65,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      # Required for the GitHub Actions layer cache below: the default docker
+      # driver cannot export cache, only the docker-container driver can.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
+
+      - name: Prefetch native prebuilds
+        run: node scripts/prefetch-prebuilds.mjs
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
@@ -91,6 +99,11 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             GIT_COMMIT=${{ github.sha }}
+          # Scoped per image so the 15 matrix legs don't evict each other. These
+          # are single-stage builds, so mode=min still covers the `npm ci` layer
+          # and keeps us well inside the repo's 10GB Actions cache budget.
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.image }}
 
       - name: Run Anchore vulnerability scanner
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -95,6 +95,11 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: false
+          # The buildx docker-container driver keeps the result in its own
+          # cache, so the image has to be loaded into the docker daemon for the
+          # Anchore scan below to find it. Valid here because this is a
+          # single-platform build.
+          load: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
+      - name: Prefetch native prebuilds
+        run: node scripts/prefetch-prebuilds.mjs
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,6 +72,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "22.15.0"
+
       - name: Prefetch native prebuilds
         run: node scripts/prefetch-prebuilds.mjs
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "22.15.0"
+
       - name: Prefetch native prebuilds
         run: node scripts/prefetch-prebuilds.mjs
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
+      - name: Prefetch native prebuilds
+        run: node scripts/prefetch-prebuilds.mjs
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:

--- a/docker/Dockerfile.cli
+++ b/docker/Dockerfile.cli
@@ -8,6 +8,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 # Install dependencies
 RUN npm ci
 RUN npm run build

--- a/docker/Dockerfile.didcomm
+++ b/docker/Dockerfile.didcomm
@@ -9,6 +9,12 @@ COPY package*.json ./
 COPY packages/ ./packages/
 
 # Install dependencies and build the workspace packages (@didcid/*)
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 RUN npm ci
 RUN npm run build
 

--- a/docker/Dockerfile.drawbridge
+++ b/docker/Dockerfile.drawbridge
@@ -8,6 +8,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 # Install dependencies
 RUN npm ci
 RUN npm run build

--- a/docker/Dockerfile.ethereum
+++ b/docker/Dockerfile.ethereum
@@ -9,6 +9,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 RUN npm ci
 RUN npm run build
 

--- a/docker/Dockerfile.ethereum-wallet
+++ b/docker/Dockerfile.ethereum-wallet
@@ -5,6 +5,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 RUN npm ci
 RUN npm run build
 

--- a/docker/Dockerfile.explorer
+++ b/docker/Dockerfile.explorer
@@ -8,6 +8,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 # Install dependencies
 RUN npm ci
 RUN npm run build

--- a/docker/Dockerfile.filecoin
+++ b/docker/Dockerfile.filecoin
@@ -5,6 +5,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 RUN npm ci
 RUN npm run build
 

--- a/docker/Dockerfile.filecoin-wallet
+++ b/docker/Dockerfile.filecoin-wallet
@@ -5,6 +5,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 RUN npm ci
 RUN npm run build
 

--- a/docker/Dockerfile.gatekeeper-client
+++ b/docker/Dockerfile.gatekeeper-client
@@ -8,6 +8,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 # Install dependencies
 RUN npm ci
 RUN npm run build

--- a/docker/Dockerfile.gatekeeper-ts
+++ b/docker/Dockerfile.gatekeeper-ts
@@ -12,6 +12,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 # Install dependencies
 RUN npm ci
 RUN npm run build

--- a/docker/Dockerfile.herald-client
+++ b/docker/Dockerfile.herald-client
@@ -3,6 +3,12 @@ FROM node:22.15.0-bullseye-slim
 WORKDIR /app/apps/herald-client
 
 COPY apps/herald-client/package*.json ./
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 RUN npm ci
 
 COPY apps/herald-client ./

--- a/docker/Dockerfile.hyperswarm
+++ b/docker/Dockerfile.hyperswarm
@@ -11,6 +11,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 # Install dependencies
 RUN npm ci
 RUN npm run build

--- a/docker/Dockerfile.keymaster-client
+++ b/docker/Dockerfile.keymaster-client
@@ -8,6 +8,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 # Install dependencies
 RUN npm ci
 RUN npm run build

--- a/docker/Dockerfile.keymaster-ts
+++ b/docker/Dockerfile.keymaster-ts
@@ -8,6 +8,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 # Install dependencies
 RUN npm ci
 RUN npm run build

--- a/docker/Dockerfile.lightning-mediator
+++ b/docker/Dockerfile.lightning-mediator
@@ -8,6 +8,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 # Install dependencies
 RUN npm ci
 RUN npm run build

--- a/docker/Dockerfile.pinning
+++ b/docker/Dockerfile.pinning
@@ -5,6 +5,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 RUN npm ci
 RUN npm run build
 

--- a/docker/Dockerfile.react-wallet
+++ b/docker/Dockerfile.react-wallet
@@ -8,6 +8,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 # Install dependencies
 RUN npm ci
 RUN npm run build

--- a/docker/Dockerfile.satoshi
+++ b/docker/Dockerfile.satoshi
@@ -8,6 +8,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 # Install dependencies
 RUN npm ci
 RUN npm run build

--- a/docker/Dockerfile.satoshi-wallet
+++ b/docker/Dockerfile.satoshi-wallet
@@ -8,6 +8,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 # Install dependencies
 RUN npm ci
 RUN npm run build

--- a/docker/Dockerfile.solana
+++ b/docker/Dockerfile.solana
@@ -9,6 +9,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 RUN npm ci
 RUN npm run build
 

--- a/docker/Dockerfile.solana-wallet
+++ b/docker/Dockerfile.solana-wallet
@@ -5,6 +5,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 RUN npm ci
 RUN npm run build
 

--- a/docker/Dockerfile.zcash
+++ b/docker/Dockerfile.zcash
@@ -9,6 +9,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 RUN npm ci
 RUN npm run build
 

--- a/docker/Dockerfile.zcash-wallet
+++ b/docker/Dockerfile.zcash-wallet
@@ -5,6 +5,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 RUN npm ci
 RUN npm run build
 

--- a/prebuilds/.gitignore
+++ b/prebuilds/.gitignore
@@ -1,0 +1,2 @@
+# Populated by scripts/prefetch-prebuilds.mjs; contents are not committed.
+*.tar.gz

--- a/prebuilds/.gitignore
+++ b/prebuilds/.gitignore
@@ -1,2 +1,4 @@
 # Populated by scripts/prefetch-prebuilds.mjs; contents are not committed.
 *.tar.gz
+# Interrupted downloads can leave these behind.
+*.tmp

--- a/scripts/prefetch-prebuilds.mjs
+++ b/scripts/prefetch-prebuilds.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Prefetch native-module prebuilt binaries into ./prebuilds so that Docker
+// builds never have to reach the network for them.
+//
+// Why this exists: prebuild-install fetches these tarballs from GitHub release
+// assets with a single request and no retry (see prebuild-install/download.js).
+// A transient connection reset there fails `npm ci`, and the source-build
+// fallback can't rescue it because the node:*-slim base images have no Python
+// or C++ toolchain. prebuild-install checks a local prebuilds directory before
+// both its cache and the network, so seeding that directory removes the
+// network from the critical path entirely.
+//
+// This is best-effort: if a download fails, we warn and carry on. The build
+// then behaves exactly as it does today (fetch at npm-ci time) rather than
+// failing early on something that is only meant to be an accelerator.
+
+import { createWriteStream } from 'node:fs';
+import { mkdir, readFile, rename, rm } from 'node:fs/promises';
+import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
+import path from 'node:path';
+
+// Packages whose install scripts call prebuild-install. `napi` is the N-API
+// build version prebuild-install resolves for Node 22 (the highest entry in the
+// package's own `binary.napi_versions`); if a future bump changes it, the
+// download 404s and we fall back to fetching at npm-ci time.
+const TARGETS = [
+    { name: 'sqlite3', repo: 'TryGhost/node-sqlite3', napi: 6 },
+    { name: '@ipshipyard/node-datachannel', repo: 'ipshipyard/js-node-datachannel', napi: 8 },
+];
+
+const PLATFORM = process.env.PREBUILD_PLATFORM || 'linux';
+// Both arches, because the publish workflows build linux/amd64,linux/arm64.
+const ARCHES = (process.env.PREBUILD_ARCH || 'x64,arm64').split(',');
+const OUT_DIR = path.resolve(process.env.PREBUILD_DIR || 'prebuilds');
+const RETRIES = 5;
+
+async function resolveVersion(lock, name) {
+    const entry = lock.packages?.[`node_modules/${name}`];
+    return entry?.version;
+}
+
+// Mirrors prebuild-install's default URL template in util.js: the scope is
+// stripped from the package name, and the tag is `v` + version.
+function assetFor({ name, repo, napi }, version, arch) {
+    const bare = name.replace(/^@[^/]+\//, '');
+    const file = `${bare}-v${version}-napi-v${napi}-${PLATFORM}-${arch}.tar.gz`;
+    return { file, url: `https://github.com/${repo}/releases/download/v${version}/${file}` };
+}
+
+async function download(url, dest) {
+    let lastErr;
+    for (let attempt = 1; attempt <= RETRIES; attempt++) {
+        const tmp = `${dest}.tmp`;
+        try {
+            const res = await fetch(url, { redirect: 'follow' });
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            await pipeline(Readable.fromWeb(res.body), createWriteStream(tmp));
+            await rename(tmp, dest);
+            return;
+        } catch (err) {
+            lastErr = err;
+            await rm(tmp, { force: true });
+            if (attempt < RETRIES) {
+                const delay = 2 ** attempt * 1000;
+                console.warn(`  attempt ${attempt} failed (${err.message}), retrying in ${delay}ms`);
+                await new Promise((r) => setTimeout(r, delay));
+            }
+        }
+    }
+    throw lastErr;
+}
+
+const lock = JSON.parse(await readFile('package-lock.json', 'utf8'));
+await mkdir(OUT_DIR, { recursive: true });
+
+let failed = 0;
+for (const target of TARGETS) {
+    const version = await resolveVersion(lock, target.name);
+    if (!version) {
+        console.warn(`! ${target.name} not found in package-lock.json, skipping`);
+        continue;
+    }
+
+    for (const arch of ARCHES) {
+        const { file, url } = assetFor(target, version, arch);
+        try {
+            await download(url, path.join(OUT_DIR, file));
+            console.log(`✓ ${file}`);
+        } catch (err) {
+            failed++;
+            console.warn(`! failed to prefetch ${file}: ${err.message}`);
+            console.warn('  build will fall back to fetching this at npm-ci time');
+        }
+    }
+}
+
+console.log(failed ? `prefetch finished with ${failed} failure(s)` : 'prefetch complete');

--- a/scripts/prefetch-prebuilds.mjs
+++ b/scripts/prefetch-prebuilds.mjs
@@ -48,6 +48,17 @@ function assetFor({ name, repo, napi }, version, arch) {
     return { file, url: `https://github.com/${repo}/releases/download/v${version}/${file}` };
 }
 
+// Versions come from package-lock.json, so a separator in a version string
+// would let the computed filename escape OUT_DIR. That lockfile is already
+// trusted (npm ci runs install scripts from it), but containment is cheap.
+function resolveInside(dir, file) {
+    const full = path.resolve(dir, file);
+    if (full !== path.join(dir, path.basename(full)) || !full.startsWith(dir + path.sep)) {
+        throw new Error(`refusing to write outside ${dir}: ${file}`);
+    }
+    return full;
+}
+
 async function download(url, dest) {
     let lastErr;
     for (let attempt = 1; attempt <= RETRIES; attempt++) {
@@ -55,6 +66,10 @@ async function download(url, dest) {
         try {
             const res = await fetch(url, { redirect: 'follow' });
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            // A fetch response can legally carry a null body; without this the
+            // Readable.fromWeb below throws something opaque instead of being
+            // reported and retried like any other failure.
+            if (!res.body) throw new Error('empty response body');
             await pipeline(Readable.fromWeb(res.body), createWriteStream(tmp));
             await rename(tmp, dest);
             return;
@@ -85,7 +100,7 @@ for (const target of TARGETS) {
     for (const arch of ARCHES) {
         const { file, url } = assetFor(target, version, arch);
         try {
-            await download(url, path.join(OUT_DIR, file));
+            await download(url, resolveInside(OUT_DIR, file));
             console.log(`✓ ${file}`);
         } catch (err) {
             failed++;

--- a/services/herald/Dockerfile
+++ b/services/herald/Dockerfile
@@ -5,6 +5,12 @@ WORKDIR /app
 COPY package*.json ./
 COPY packages/ ./packages/
 
+# Seed prebuild-install with natively-fetched binaries (scripts/prefetch-prebuilds.mjs).
+# Empty in local builds, which falls back to prebuild-install's network fetch.
+COPY prebuilds/ /prebuilds/
+ENV npm_config_sqlite3_local_prebuilds=/prebuilds \
+    npm_config_ipshipyard_node_datachannel_local_prebuilds=/prebuilds
+
 RUN npm ci
 RUN npm run build
 


### PR DESCRIPTION
## Problem

Docker image builds have been failing across the matrix — currently blocking Dependabot PRs #877 and #878:

```
npm error prebuild-install warn install socket hang up
ERROR: failed to solve: process "/bin/sh -c npm ci" did not complete successfully
```

`prebuild-install` fetches prebuilt native binaries from GitHub release assets with **a single request and no retry** (see its `download.js`; there is no `--tries` option). One transient connection reset fails `npm ci`.

The source-build fallback that both affected packages declare can't rescue it — all 24 Dockerfiles use `node:22.15.0-bullseye-slim`, which has no Python or C++ toolchain, so the builds die on `gyp ERR! find Python`.

Two real dependencies are affected:
- `sqlite3` — direct dep of `@didcid/gatekeeper` and `@didcid/keymaster`
- `@ipshipyard/node-datachannel` — transitive via `helia` → `@libp2p/webrtc` (a hard dep, so it can't simply be dropped)

Nothing cached the result either: the image builds had no layer cache and no workflow used npm caching, so a single push fired ~30 identical anonymous downloads of the same two tarballs from one runner IP range.

## Fix

**1. Layer cache.** `cache-from`/`cache-to: type=gha` on `docker-build.yml`, scoped per image so the 15 matrix legs don't evict each other. Needs `setup-buildx-action` (the default docker driver can't export cache); pinned to the SHA already used in two other workflows. `mode=min` suffices — every Dockerfile here is single-stage.

Most PRs don't touch the root lockfile, so their `npm ci` layer becomes a cache hit and never reaches the network. #878 is exactly this shape: it touches only `apps/react-wallet/*`, so all four of its failures were avoidable.

**2. Vendored prebuilds**, covering the case Layer 1 can't — PRs that *do* change the root lockfile, like #877. `scripts/prefetch-prebuilds.mjs` resolves versions from `package-lock.json` (so it tracks bumps rather than hardcoding), reconstructs prebuild-install's URL template, and downloads x64 + arm64 with retries. prebuild-install checks a local prebuilds directory *before* both its cache and the network, so the Dockerfiles copy that directory in and point at it via env var.

The prefetch is deliberately best-effort: on failure it warns and the build falls back to fetching at npm-ci time, so the accelerator can never itself break a build. Tarballs are gitignored; the directory is tracked so `COPY prebuilds/` resolves in local builds too.

## Verification

Running prebuild-install inside a `--network none` container:

- **with** the env var → `found local prebuild` → `Successfully installed prebuilt binary!`
- **without** it → falls through to `GET https://github.com/...` and fails, reproducing the CI error exactly

The scoped-package variable name (`npm_config_ipshipyard_node_datachannel_local_prebuilds`) follows prebuild-install's own prefix mangling in `util.js` and was confirmed the same way.

`docker/Dockerfile.gatekeeper-ts` builds clean end-to-end, and both native modules load in the resulting image with binaries unpacked in place. `eslint` passes.

## Notes

- No retry loop around `npm ci` — it wouldn't have helped here anyway (the outage spanned 35+ minutes across two attempts). Easy to add as insurance if wanted.
- Follow-up worth considering: all 24 Dockerfiles repeat the same `COPY package*.json` + `npm ci`. Collapsing that into a shared base image would remove the duplicate installs entirely and make Layer 2 largely unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)