### PR TITLE
fix: Move hyperswarm mediator to bookworm for glibc 2.33+

### DIFF
--- a/docker/Dockerfile.hyperswarm
+++ b/docker/Dockerfile.hyperswarm
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 # Install Python and other dependencies
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Incident

The hyperswarm-mediator node has been **down ~24h**. PR #876 (`375ceaf2`, merged Aug 10) bumped hyperswarm 4.8.2 → 4.17.0, pulling `sodium-native` ^4.0.0 → ^5.0.1. CI pushed a new image (`b5be5a2703ce`, Aug 12 13:15 UTC); the container recreated on it at 13:18 UTC and died 5s later with exit 1. No restart policy, so it stayed down.

## Cause

`sodium-native` 5.1.0 ships a prebuilt binding requiring **GLIBC_2.33**. The image base `node:22.15.0-bullseye-slim` is Debian 11 with **glibc 2.31**:

```
Error: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found
       (required by .../sodium-native/prebuilds/linux-x64/sodium-native.node)
```

The logs show `MODULE_NOT_FOUND`, which is misleading — `require-addon` catches the `dlopen` failure and reports the addon as missing. The `.node` file is present in the image; the real error only surfaces when loading it directly.

There's no source-compile fallback either: sodium-native 5 builds with cmake, and this Dockerfile installs `python3 make g++` but not cmake.

## Fix

Base image → `node:22.15.0-bookworm-slim` (Debian 12, glibc 2.36).

Verified by reproducing the `dlopen` failure on bullseye and confirming `sodium-native` loads cleanly on bookworm.

**Scope is this one image.** `sodium-native` is absent from the root lockfile and appears only in `services/mediators/hyperswarm/package-lock.json`, which matches the single affected node.

## Alternatives considered

- **Pin `sodium-native` back to 4.x** — fights the dependency bump instead of fixing the mismatch.
- **Install cmake for a source build** — works, but adds a slow compile to every build to avoid a base image that is approaching EOL.

## Follow-ups (deliberately not in this PR)

- **No restart policy** on the container. The crash was a bad image; the 24h outage length was the missing policy. Worth fixing independently.
- **All 24 Dockerfiles are on bullseye.** This class of break will recur as upstream packages raise their glibc floor. A repo-wide bookworm bump is the real remedy but is far too broad for an urgent hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)