### PR TITLE
ci: Stop prebuilds/.gitignore from invalidating the npm ci layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ dids.db-journal
 **/.npmrc
 !/.npmrc
 rust/services/gatekeeper/target/
+
+# Prefetched native prebuilds (scripts/prefetch-prebuilds.mjs); binaries are not committed.
+/prebuilds/*.tar.gz
+/prebuilds/*.tmp

--- a/prebuilds/.gitignore
+++ b/prebuilds/.gitignore
@@ -1,4 +1,0 @@
-# Populated by scripts/prefetch-prebuilds.mjs; contents are not committed.
-*.tar.gz
-# Interrupted downloads can leave these behind.
-*.tmp


### PR DESCRIPTION
## Problem

#879 added `COPY prebuilds/ /prebuilds/` immediately before `npm ci` in every image, so that layer's cache key covers **everything in the directory** — including the `.gitignore` that lived there.

That made the ignore file a cache-buster. Editing it in the final commit of #879 (adding a `*.tmp` rule) invalidated the `npm ci` layer across all 15 images, for a file no build ever reads. Confirmed in that run's logs: `COPY packages/` hit `CACHED`, `COPY prebuilds/` missed, and `npm ci` re-ran for real.

## Fix

Move the ignore rules to the root `.gitignore` and keep the directory present with a `.gitkeep`. The tracked file is now empty and never changes, so the copied layer's cache key depends only on the tarballs — which *should* invalidate it, when dependency versions change.

## Why not `.dockerignore`

Excluding `prebuilds/.gitignore` via `.dockerignore` was the other obvious option and is a smaller diff. It leaves the directory with **no files in the build context**, though, and while that builds fine under the legacy builder, BuildKit is stricter about `COPY` sources matching nothing — and buildx wasn't available locally to verify. Since CI builds with buildx, that's an untested assumption in the path that matters. The `.gitkeep` keeps the directory non-empty under any builder and sidesteps the question.

## Verification

- Ignore rules confirmed: a stray `*.tar.gz` and a `*.tar.gz.tmp` in `prebuilds/` are both invisible to git.
- `scripts/prefetch-prebuilds.mjs` still populates all four tarballs, and `git status` stays clean afterwards.

Note this does not change what #879 actually fixed — the prefetch (Layer 2) worked on every run, with zero `socket hang up`. This is about the layer cache (Layer 1) delivering the speedup it was added for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)