### PR TITLE
feat: Restore CLI command parity in scripts/archon-cli.js

### DIFF
--- a/scripts/archon-cli.js
+++ b/scripts/archon-cli.js
@@ -16,6 +16,12 @@ let keymaster;
 
 const UPDATE_OK = "OK";
 const UPDATE_FAILED = "Update failed";
+const LIGHTNING_ZAP_STATUS_CHECKS = 3;
+const LIGHTNING_ZAP_STATUS_DELAY_MS = 1000;
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 program
     .version(pkg.version)
@@ -1589,6 +1595,647 @@ program
             console.error(error.error || error.message || error);
         }
     });
+
+
+program
+    .command('update-credential <did> <file>')
+    .description('Update an issued credential')
+    .action(async (did, file) => {
+        try {
+            const vc = JSON.parse(fs.readFileSync(file).toString());
+            const ok = await keymaster.updateCredential(did, vc);
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('list-addresses')
+    .description('List wallet addresses')
+    .action(async () => {
+        try {
+            const addresses = await keymaster.listAddresses();
+
+            if (Object.keys(addresses).length) {
+                console.log(JSON.stringify(addresses, null, 4));
+            }
+            else {
+                console.log('No addresses defined');
+            }
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('get-address <domain>')
+    .description('Get the current address for a domain')
+    .action(async (domain) => {
+        try {
+            const address = await keymaster.getAddress(domain);
+
+            if (address) {
+                console.log(JSON.stringify(address, null, 4));
+            }
+            else {
+                console.log(`${domain} not found`);
+            }
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('import-address <domain>')
+    .description('Import any existing address for the current ID from a domain')
+    .action(async (domain) => {
+        try {
+            const addresses = await keymaster.importAddress(domain);
+
+            if (Object.keys(addresses).length) {
+                console.log(JSON.stringify(addresses, null, 4));
+            }
+            else {
+                console.log('No addresses imported');
+            }
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('check-address <address>')
+    .description('Check whether an address is available')
+    .action(async (address) => {
+        try {
+            const result = await keymaster.checkAddress(address);
+
+            if (result.status === 'available') {
+                console.log(`${result.address} is available`);
+            }
+            else if (result.status === 'claimed') {
+                console.log(`${result.address} is claimed by ${result.did}`);
+            }
+            else if (result.status === 'unsupported') {
+                console.log(`${result.address} domain does not appear to support names`);
+            }
+            else {
+                console.log(`${result.address} domain is unreachable`);
+            }
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('add-address <address>')
+    .description('Claim an address for the current ID')
+    .action(async (address) => {
+        try {
+            await keymaster.addAddress(address);
+            console.log(UPDATE_OK);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('remove-address <address>')
+    .description('Remove an address for the current ID')
+    .action(async (address) => {
+        try {
+            await keymaster.removeAddress(address);
+            console.log(UPDATE_OK);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('publish-address [address] [id]')
+    .description('Publish a stored address for a DID')
+    .action(async (address, id) => {
+        try {
+            await keymaster.publishAddress(address, id);
+            console.log(UPDATE_OK);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('unpublish-address [id]')
+    .description('Remove the published address from a DID')
+    .action(async (id) => {
+        try {
+            await keymaster.unpublishAddress(id);
+            console.log(UPDATE_OK);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+// Nostr commands
+
+
+program
+    .command('import-nostr <nsec> [id]')
+    .description('Import nostr keys for an agent DID from an nsec private key')
+    .action(async (nsec, id) => {
+        try {
+            const nostr = await keymaster.importNostr(nsec, id);
+            console.log(JSON.stringify(nostr, null, 4));
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('add-lightning [id]')
+    .description('Create a Lightning wallet for a DID')
+    .action(async (id) => {
+        try {
+            const config = await keymaster.addLightning(id);
+            console.log(JSON.stringify(config, null, 4));
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('remove-lightning [id]')
+    .description('Remove Lightning wallet from a DID')
+    .action(async (id) => {
+        try {
+            await keymaster.removeLightning(id);
+            console.log(UPDATE_OK);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('lightning-balance [id]')
+    .description('Check Lightning wallet balance')
+    .action(async (id) => {
+        try {
+            const balance = await keymaster.getLightningBalance(id);
+            console.log(`${balance.balance} sats`);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('lightning-decode <bolt11>')
+    .description('Decode a Lightning BOLT11 invoice')
+    .action(async (bolt11) => {
+        try {
+            const info = await keymaster.decodeLightningInvoice(bolt11);
+            console.log(JSON.stringify(info, null, 4));
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('lightning-invoice <amount> <memo> [id]')
+    .description('Create a Lightning invoice to receive sats')
+    .action(async (amount, memo, id) => {
+        try {
+            const invoice = await keymaster.createLightningInvoice(parseInt(amount), memo, id);
+            console.log(JSON.stringify(invoice, null, 4));
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('lightning-pay <bolt11> [id]')
+    .description('Pay a Lightning invoice')
+    .action(async (bolt11, id) => {
+        try {
+            const payment = await keymaster.payLightningInvoice(bolt11, id);
+            console.log(JSON.stringify(payment, null, 4));
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('lightning-check <paymentHash> [id]')
+    .description('Check status of a Lightning payment')
+    .action(async (paymentHash, id) => {
+        try {
+            const status = await keymaster.checkLightningPayment(paymentHash, id);
+            console.log(JSON.stringify(status, null, 4));
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('publish-lightning [id]')
+    .description('Publish Lightning service endpoint for a DID')
+    .action(async (id) => {
+        try {
+            await keymaster.publishLightning(id);
+            console.log(UPDATE_OK);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('unpublish-lightning [id]')
+    .description('Remove Lightning service endpoint from a DID')
+    .action(async (id) => {
+        try {
+            await keymaster.unpublishLightning(id);
+            console.log(UPDATE_OK);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('lightning-zap <recipient> <amount> [memo]')
+    .description('Send sats via Lightning (DID, alias, or Lightning Address)')
+    .action(async (recipient, amount, memo) => {
+        try {
+            const result = await keymaster.zapLightning(recipient, parseInt(amount), memo);
+            let status = await keymaster.checkLightningPayment(result.paymentHash);
+
+            for (let attempt = 1; attempt < LIGHTNING_ZAP_STATUS_CHECKS && !status.paid; attempt++) {
+                await sleep(LIGHTNING_ZAP_STATUS_DELAY_MS);
+                status = await keymaster.checkLightningPayment(result.paymentHash);
+            }
+
+            console.log(JSON.stringify({
+                ...result,
+                paid: status.paid,
+                status: status.status,
+                preimage: status.preimage,
+            }, null, 4));
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('lightning-payments [id]')
+    .description('Show Lightning payment history')
+    .action(async (id) => {
+        try {
+            const payments = await keymaster.getLightningPayments(id);
+            if (payments.length === 0) {
+                console.log('No payments found.');
+                return;
+            }
+            for (const p of payments) {
+                const d = p.time ? new Date(p.time) : null;
+                const date = d ? `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, '0')}/${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}` : '—';
+                const fee = p.fee > 0 ? ` (fee: ${p.fee})` : '';
+                const memo = p.memo ? ` "${p.memo}"` : '';
+                const status = p.pending ? ' [pending]' : '';
+                console.log(`${date}  ${p.amount} sats${fee}${memo}${status}`);
+            }
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+// Group commands
+
+
+program
+    .command('add-poll-voter <poll> <member>')
+    .description('Add a voter to the poll')
+    .action(async (poll, member) => {
+        try {
+            const ok = await keymaster.addPollVoter(poll, member);
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('remove-poll-voter <poll> <member>')
+    .description('Remove a voter from the poll')
+    .action(async (poll, member) => {
+        try {
+            const ok = await keymaster.removePollVoter(poll, member);
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('list-poll-voters <poll>')
+    .description('List eligible voters in the poll')
+    .action(async (poll) => {
+        try {
+            const members = await keymaster.listPollVoters(poll);
+            console.log(JSON.stringify(members, null, 4));
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('send-poll <poll>')
+    .description('Send a poll notice to all voters')
+    .action(async (poll) => {
+        try {
+            const did = await keymaster.sendPoll(poll);
+            console.log(did);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('send-ballot <ballot> <poll>')
+    .description('Send a ballot to the poll owner')
+    .action(async (ballot, poll) => {
+        try {
+            const did = await keymaster.sendBallot(ballot, poll);
+            console.log(did);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('view-ballot <ballot>')
+    .description('View ballot details')
+    .action(async (ballot) => {
+        try {
+            const result = await keymaster.viewBallot(ballot);
+            console.log(JSON.stringify(result, null, 4));
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('create-dmail <file>')
+    .description('Create a new dmail from a JSON file')
+    .option('-a, --alias <alias>', 'DID alias')
+    .option('-r, --registry <registry>', 'registry to use')
+    .action(async (file, options) => {
+        try {
+            const { alias, registry } = options;
+            const message = JSON.parse(fs.readFileSync(file).toString());
+            const did = await keymaster.createDmail(message, { alias, registry });
+            console.log(did);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('update-dmail <did> <file>')
+    .description('Update an existing dmail from a JSON file')
+    .action(async (did, file) => {
+        try {
+            const message = JSON.parse(fs.readFileSync(file).toString());
+            const ok = await keymaster.updateDmail(did, message);
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('send-dmail <did>')
+    .description('Send a dmail and return the notice DID')
+    .action(async (did) => {
+        try {
+            const notice = await keymaster.sendDmail(did);
+            if (notice) {
+                console.log(notice);
+            } else {
+                console.error('Send failed');
+            }
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('get-dmail <did>')
+    .description('Get a dmail message by DID')
+    .action(async (did) => {
+        try {
+            const message = await keymaster.getDmailMessage(did);
+            if (message) {
+                console.log(JSON.stringify(message, null, 4));
+            } else {
+                console.error('Dmail not found');
+            }
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('list-dmail')
+    .description('List dmails for current ID')
+    .action(async () => {
+        try {
+            const dmails = await keymaster.listDmail();
+            console.log(JSON.stringify(dmails, null, 4));
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('file-dmail <did> <tags>')
+    .description('Assign tags to a dmail (comma-separated, e.g. inbox,unread)')
+    .action(async (did, tags) => {
+        try {
+            const tagList = tags.split(',').map((t) => t.trim());
+            const ok = await keymaster.fileDmail(did, tagList);
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('refresh-dmail')
+    .description('Check for new dmails and clean up expired notices')
+    .action(async () => {
+        try {
+            const ok = await keymaster.refreshNotices();
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('import-dmail <did>')
+    .description('Import a dmail into inbox with unread tag')
+    .action(async (did) => {
+        try {
+            const ok = await keymaster.importDmail(did);
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('remove-dmail <did>')
+    .description('Delete a dmail')
+    .action(async (did) => {
+        try {
+            const ok = await keymaster.removeDmail(did);
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('add-dmail-attachment <did> <file>')
+    .description('Add a file attachment to a dmail')
+    .action(async (did, file) => {
+        try {
+            const data = fs.readFileSync(file);
+            const name = path.basename(file);
+            const ok = await keymaster.addDmailAttachment(did, name, data);
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('remove-dmail-attachment <did> <name>')
+    .description('Remove an attachment from a dmail')
+    .action(async (did, name) => {
+        try {
+            const ok = await keymaster.removeDmailAttachment(did, name);
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('get-dmail-attachment <did> <name> <file>')
+    .description('Save a dmail attachment to a file')
+    .action(async (did, name, file) => {
+        try {
+            const data = await keymaster.getDmailAttachment(did, name);
+            if (data) {
+                fs.writeFileSync(file, data);
+                console.log(`Data written to ${file}`);
+            } else {
+                console.error(`Attachment ${name} not found`);
+            }
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+
+program
+    .command('list-dmail-attachments <did>')
+    .description('List attachments of a dmail')
+    .action(async (did) => {
+        try {
+            const attachments = await keymaster.listDmailAttachments(did);
+            console.log(JSON.stringify(attachments, null, 4));
+        }
+        catch (error) {
+            console.error(error.error || error.message || error);
+        }
+    });
+
+// DIDComm v2 commands
 
 async function run() {
     const keymasterURL = process.env.ARCHON_KEYMASTER_URL || 'http://localhost:4226';

--- a/tests/keymaster/cli-parity.test.ts
+++ b/tests/keymaster/cli-parity.test.ts
@@ -1,27 +1,64 @@
 import { readFileSync } from 'fs';
 import path from 'path';
 
-// The repo ships two CLI entry points: the package CLI (packages/keymaster/src/cli.ts)
-// and the standalone script (scripts/archon-cli.js). They have drifted apart in
-// general -- the script is missing whole families (dmail, lightning, address,
-// nostr) -- so this does not assert wholesale parity.
+// AGENTS.md requires the three CLIs to stay in parity:
 //
-// It does assert parity for DIDComm, because that surface is mirrored in both
-// and a command added to one but not the other stays invisible until a user of
-// the other entry point goes looking for it. That is exactly how `ack-didcomm`
-// and `receive-didcomm --no-ack` were first missed.
+//   packages/keymaster/src/cli.ts        (library-backed)
+//   python/keymaster/src/keymaster/cli.py (library-backed, pure-Python port)
+//   scripts/archon-cli.js                (service-backed; this is the `archon` command)
+//
+// That rule used to be enforced by memory alone, and scripts/archon-cli.js had
+// drifted 40 commands behind before anyone noticed. These tests enforce it
+// instead.
+
+// Commands that are deliberately not mirrored, with the reason. Anything else
+// appearing on one CLI and not the others is a failure, not an exception.
+const SCRIPT_ONLY = new Set([
+    // Times round trips through the Keymaster *service*. The other two CLIs use
+    // the library directly and so have no service round trip to measure.
+    'perf-test',
+]);
 
 function readSource(relativePath: string): string {
     return readFileSync(path.join(process.cwd(), relativePath), 'utf-8');
 }
 
-function didcommCommands(source: string): string[] {
-    const matches = source.matchAll(/\.command\('([a-z0-9-]*didcomm[a-z0-9-]*)/g);
-    return [...matches].map(match => match[1]).sort();
+const packageCli = readSource('packages/keymaster/src/cli.ts');
+const scriptCli = readSource('scripts/archon-cli.js');
+const pythonCli = readSource('python/keymaster/src/keymaster/cli.py');
+
+// commander: .command('name <required> [optional]')
+function commanderSignatures(source: string): Map<string, string> {
+    const signatures = new Map<string, string>();
+    for (const match of source.matchAll(/\.command\('([^']+)'/g)) {
+        const [name, ...args] = match[1].split(' ');
+        signatures.set(name, args.join(' '));
+    }
+    return signatures;
+}
+
+// argparse: add("name", "description", handler)
+function pythonCommands(source: string): string[] {
+    return [...source.matchAll(/\badd\("([a-z0-9-]+)"/g)].map(match => match[1]).sort();
+}
+
+function commandNames(source: string): string[] {
+    return [...commanderSignatures(source).keys()].sort();
+}
+
+// Argument shape, not argument names: '<did> <registry>' and '<id> <registry>'
+// describe the same interface, and one CLI calling it `did` where another calls
+// it `id` is cosmetic. A differing count, or required where the other is
+// optional, is not.
+function argumentShape(args: string): string {
+    return args
+        .split(' ')
+        .filter(Boolean)
+        .map(arg => (arg.startsWith('<') ? '<>' : arg.startsWith('[') ? '[]' : arg))
+        .join(' ');
 }
 
 function optionsFor(source: string, command: string): string[] {
-    // Everything between this .command(...) and the next one is its definition.
     const start = source.indexOf(`.command('${command}`);
     if (start === -1) {
         return [];
@@ -33,21 +70,25 @@ function optionsFor(source: string, command: string): string[] {
         .sort();
 }
 
-describe('DIDComm CLI parity between entry points', () => {
-    const packageCli = readSource('packages/keymaster/src/cli.ts');
-    const scriptCli = readSource('scripts/archon-cli.js');
+describe('CLI parity across entry points', () => {
+    const expected = commandNames(packageCli).filter(name => !SCRIPT_ONLY.has(name));
 
-    it('exposes the same DIDComm commands in both CLIs', () => {
-        const fromPackage = didcommCommands(packageCli);
-
-        expect(fromPackage.length).toBeGreaterThan(0);
-        expect(didcommCommands(scriptCli)).toEqual(fromPackage);
+    it('has commands to compare', () => {
+        expect(expected.length).toBeGreaterThan(100);
     });
 
-    it('exposes the same options on each DIDComm command in both CLIs', () => {
+    it('exposes the same commands in the script CLI as the package CLI', () => {
+        expect(commandNames(scriptCli).filter(name => !SCRIPT_ONLY.has(name))).toEqual(expected);
+    });
+
+    it('exposes the same commands in the Python CLI as the package CLI', () => {
+        expect(pythonCommands(pythonCli).filter(name => !SCRIPT_ONLY.has(name))).toEqual(expected);
+    });
+
+    it('declares the same options on each command in both JS CLIs', () => {
         const mismatches: string[] = [];
 
-        for (const command of didcommCommands(packageCli)) {
+        for (const command of expected) {
             const fromPackage = optionsFor(packageCli, command);
             const fromScript = optionsFor(scriptCli, command);
 
@@ -57,5 +98,32 @@ describe('DIDComm CLI parity between entry points', () => {
         }
 
         expect(mismatches).toEqual([]);
+    });
+
+    it('takes the same argument shape on each command in both JS CLIs', () => {
+        const fromPackage = commanderSignatures(packageCli);
+        const fromScript = commanderSignatures(scriptCli);
+        const mismatches: string[] = [];
+
+        for (const command of expected) {
+            const packageShape = argumentShape(fromPackage.get(command) ?? '');
+            const scriptShape = argumentShape(fromScript.get(command) ?? '');
+
+            if (packageShape !== scriptShape) {
+                mismatches.push(`${command}: package '${packageShape}' vs script '${scriptShape}'`);
+            }
+        }
+
+        expect(mismatches).toEqual([]);
+    });
+
+    it('does not let a script-only command quietly become a general exception', () => {
+        // If a SCRIPT_ONLY command ever does appear in the other CLIs, the
+        // exception is stale and should be deleted rather than left to hide drift.
+        for (const command of SCRIPT_ONLY) {
+            expect(commandNames(packageCli)).not.toContain(command);
+            expect(pythonCommands(pythonCli)).not.toContain(command);
+            expect(commandNames(scriptCli)).toContain(command);
+        }
     });
 });


### PR DESCRIPTION
Closes #885.

## Problem

`AGENTS.md` requires the three CLIs to stay in parity. Two of them did; the third didn't.

| CLI | before | after |
|---|---|---|
| `packages/keymaster/src/cli.ts` | 143 | 143 |
| `python/keymaster/src/keymaster/cli.py` | 143 | 143 |
| `scripts/archon-cli.js` | **104** | **144** |

The two library-backed CLIs had **exactly identical** command sets. `scripts/archon-cli.js` was missing 40.

That script is the user-facing `archon` command — `./archon` is just `docker compose exec -it cli node scripts/archon-cli.js "$@"` — so whole families were unreachable for anyone driving a node through it: **dmail**, **lightning** and **address** entirely, plus parts of **poll**, **nostr** and **credential**. The integration tests in `tests/cli/` run against this same entry point, so those commands had no coverage either.

This was found while adding `ack-didcomm` in #884, which went into two CLIs and was missed in the third with nothing to catch it.

## Change

**Port all 40 commands.** Every one already had a matching `KeymasterClient` method, so this was a backlog of unwritten wrappers rather than a capability gap. They're transcribed from `cli.ts` with the TypeScript annotations dropped, plus the `sleep` helper and the two zap-status constants `lightning-zap` needs.

**`perf-test` stays script-only**, now recorded as a deliberate exception with its reason: it times round trips through the Keymaster *service*, and the other two CLIs use the library directly so have no service round trip to measure.

**Widen the parity test** (`tests/keymaster/cli-parity.test.ts`, added in #884 covering only DIDComm) to every command, so the `AGENTS.md` rule is enforced by CI rather than by memory:

- identical command sets across all three CLIs
- identical options per command across the two JS CLIs
- identical argument *shape* per command across the two JS CLIs — comparing `<>` and `[]` rather than placeholder names, because `change-registry` calls the same argument `did` in one CLI and `id` in the other, which is cosmetic
- a guard that a script-only exception appearing in the other CLIs fails, so a stale exception can't quietly start hiding real drift

## Verification

- The widened test fails on a removed command, a removed option, and a changed argument shape — checked by actually removing each, not assumed.
- `commander` accepts all 144 command signatures (a malformed one throws at registration).
- `eslint` clean on the ported file, which is what catches a helper left behind in the port.
- 1163 passing across `tests/keymaster` + `tests/mcp-server`.

Nothing snapshots the CLI help text, so the 40 new commands don't disturb it: `tests/cli/help.test.ts` asserts `toContain` on a subset, and `tests/kc_help_reference.txt` turns out to be referenced by nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)