### PR TITLE
deps: Move all images from Debian bullseye to bookworm

### DIFF
--- a/docker/Dockerfile.cli
+++ b/docker/Dockerfile.cli
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.didcomm
+++ b/docker/Dockerfile.didcomm
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.drawbridge
+++ b/docker/Dockerfile.drawbridge
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.ethereum
+++ b/docker/Dockerfile.ethereum
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3 make g++ \

--- a/docker/Dockerfile.ethereum-wallet
+++ b/docker/Dockerfile.ethereum-wallet
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 WORKDIR /app
 

--- a/docker/Dockerfile.explorer
+++ b/docker/Dockerfile.explorer
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.filecoin
+++ b/docker/Dockerfile.filecoin
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 WORKDIR /app
 

--- a/docker/Dockerfile.filecoin-wallet
+++ b/docker/Dockerfile.filecoin-wallet
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 WORKDIR /app
 

--- a/docker/Dockerfile.gatekeeper-client
+++ b/docker/Dockerfile.gatekeeper-client
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.gatekeeper-rust
+++ b/docker/Dockerfile.gatekeeper-rust
@@ -1,4 +1,4 @@
-FROM rust:1.90-bullseye AS builder
+FROM rust:1.90-bookworm AS builder
 
 WORKDIR /build
 COPY rust/services/gatekeeper/Cargo.toml ./Cargo.toml
@@ -6,7 +6,7 @@ COPY rust/services/gatekeeper/Cargo.lock ./Cargo.lock
 COPY rust/services/gatekeeper/src ./src
 RUN cargo build --release
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates wget \

--- a/docker/Dockerfile.gatekeeper-ts
+++ b/docker/Dockerfile.gatekeeper-ts
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends wget \

--- a/docker/Dockerfile.herald-client
+++ b/docker/Dockerfile.herald-client
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 WORKDIR /app/apps/herald-client
 

--- a/docker/Dockerfile.keymaster-client
+++ b/docker/Dockerfile.keymaster-client
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.keymaster-ts
+++ b/docker/Dockerfile.keymaster-ts
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.lightning-mediator
+++ b/docker/Dockerfile.lightning-mediator
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.pinning
+++ b/docker/Dockerfile.pinning
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 WORKDIR /app
 

--- a/docker/Dockerfile.react-wallet
+++ b/docker/Dockerfile.react-wallet
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.satoshi
+++ b/docker/Dockerfile.satoshi
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.satoshi-wallet
+++ b/docker/Dockerfile.satoshi-wallet
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.solana
+++ b/docker/Dockerfile.solana
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3 make g++ \

--- a/docker/Dockerfile.solana-wallet
+++ b/docker/Dockerfile.solana-wallet
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 WORKDIR /app
 

--- a/docker/Dockerfile.zcash
+++ b/docker/Dockerfile.zcash
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3 make g++ \

--- a/docker/Dockerfile.zcash-wallet
+++ b/docker/Dockerfile.zcash-wallet
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 WORKDIR /app
 

--- a/services/herald/Dockerfile
+++ b/services/herald/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bullseye-slim
+FROM node:22.15.0-bookworm-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Closes #881.

## Why

The hyperswarm mediator moved to bookworm in #880 after a production hotfix: `sodium-native` 5 raised its prebuilt binding's floor to `GLIBC_2.33`, which `node:*-bullseye` (Debian 11, glibc 2.31) cannot satisfy, and the container exited 1 five seconds after start.

That fix was scoped to the affected image because it was urgent. **Every other image stayed on bullseye**, so the same break was waiting on the next dependency bump that raises a glibc floor. It arrives through a routine Dependabot PR and fails at *container start*, not at build time — so CI stays green and only production notices. The failure is disguised too: `require-addon` catches the `dlopen` error and reports `MODULE_NOT_FOUND`, pointing at a missing file when the `.node` is present and merely unloadable.

## Change

| | From | To |
|---|---|---|
| 23 node images | `node:22.15.0-bullseye-slim` | `node:22.15.0-bookworm-slim` |
| gatekeeper-rust builder | `rust:1.90-bullseye` | `rust:1.90-bookworm` |
| gatekeeper-rust runtime | `debian:bullseye-slim` | `debian:bookworm-slim` |

The Rust stages move **together** deliberately: the builder produces the binary the runtime loads, so a builder newer than its runtime would reintroduce exactly this failure across the stage boundary.

`git grep bullseye` now returns nothing repo-wide.

## Risk that didn't materialise

The issue flagged apt differences on Debian 12 as the main risk. Every package these images install — `python3`, `make`, `g++`, `wget`, `ca-certificates`, `build-essential` — exists in bookworm, and both local builds confirmed it.

## Verification: images *start*, not just build

The issue asks for this specifically, because a green build is what missed the original outage. I built and ran the two riskiest images:

**gatekeeper-rust** (cross-stage binary, the glibc-sensitive case)
- glibc 2.36, and `ldd` reports **zero** unresolved shared libraries
- the binary runs — prints `Starting Archon Gatekeeper v0.12.0 …` — then stops on an absent redis

Worth noting the trap here: its first run exited 1, which reads like the bookworm move broke it. The logs showed a missing `ARCHON_ADMIN_API_KEY`, then a missing redis — both legitimate. An exit code alone would have been misleading, in the opposite direction this time.

**gatekeeper-ts** (native dependencies, same shape as the sodium-native failure)
- `sqlite3` and `@ipshipyard/node-datachannel` both load
- container reaches `running` and stays there

CI builds the remaining images across the matrix.

## Node stays at 22.15.0

Debian 13 (trixie) is current stable, but the official node images only publish trixie variants from about **22.22.x** — so reaching it is a Node upgrade, not a base-image swap. That's a larger change touching 24 Dockerfiles, 9 workflow pins, and `package.json` `engines` (pinned `22.15.x`, so it fails the engines check unless bumped in the same commit). Worth doing next, deliberately not bundled with a remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)