### PR TITLE
deps: Upgrade Node to 22.23.2 and move images to Debian trixie

### DIFF
--- a/.github/workflows/android-debug-build-release.yml
+++ b/.github/workflows/android-debug-build-release.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - name: Use Node 22.15.0
+      - name: Use Node 22.23.2
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: "22.15.0"
+          node-version: "22.23.2"
 
       - name: Pin npm 10.9.2
         run: npm install --global npm@10.9.2

--- a/.github/workflows/android-debug-build.yml
+++ b/.github/workflows/android-debug-build.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - name: Use Node 22.15.0
+      - name: Use Node 22.23.2
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: "22.15.0"
+          node-version: "22.23.2"
 
       - name: Pin npm 10.9.2
         run: npm install --global npm@10.9.2

--- a/.github/workflows/build-browser-extension.yml
+++ b/.github/workflows/build-browser-extension.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - name: Use Node 22.15.0
+      - name: Use Node 22.23.2
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: '22.15.0'
+          node-version: '22.23.2'
 
       - name: Pin npm 10.9.2
         run: npm install --global npm@10.9.2

--- a/.github/workflows/build-explorer.yml
+++ b/.github/workflows/build-explorer.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - name: Use Node 22.15.0
+      - name: Use Node 22.23.2
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: '22.15.0'
+          node-version: '22.23.2'
 
       - name: Pin npm 10.9.2
         run: npm install --global npm@10.9.2

--- a/.github/workflows/build-react-wallet-webapp.yml
+++ b/.github/workflows/build-react-wallet-webapp.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - name: Use Node 22.15.0
+      - name: Use Node 22.23.2
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: '22.15.0'
+          node-version: '22.23.2'
 
       - name: Pin npm 10.9.2
         run: npm install --global npm@10.9.2

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: "22.15.0"
+          node-version: "22.23.2"
 
       - name: Pin npm 10.9.2
         run: npm install --global npm@10.9.2
@@ -95,7 +95,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: "22.15.0"
+          node-version: "22.23.2"
 
       - name: Pin npm 10.9.2
         run: npm install --global npm@10.9.2

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: "22.15.0"
+          node-version: "22.23.2"
 
       - name: Prefetch native prebuilds
         run: node scripts/prefetch-prebuilds.mjs

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: "22.15.0"
+          node-version: "22.23.2"
 
       - name: Prefetch native prebuilds
         run: node scripts/prefetch-prebuilds.mjs

--- a/.github/workflows/npm-package-publish.yml
+++ b/.github/workflows/npm-package-publish.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: "22.15.0"
+          node-version: "22.23.2"
           registry-url: "https://registry.npmjs.org"
 
       - name: Pin npm 10.9.2

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: "22.15.0"
+          node-version: "22.23.2"
 
       - name: Prefetch native prebuilds
         run: node scripts/prefetch-prebuilds.mjs

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
-          node-version: "22.15.0"
+          node-version: "22.23.2"
 
       - name: Pin npm 10.9.2
         run: npm install --global npm@10.9.2

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For protocol internals and rationale, see the [white paper](docs/WHITEPAPER.md).
 Recommended system requirements:
 
 - GNU/Linux OS with [docker](https://www.docker.com/) for containerized operation
-- node 22.15.0 and npm 10.9.2 for manual and local operation
+- node 22.23.2 and npm 10.9.2 for manual and local operation
 - minimum of 8Gb RAM if operating a full trustless node
 
 ```

--- a/docker/Dockerfile.cli
+++ b/docker/Dockerfile.cli
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.didcomm
+++ b/docker/Dockerfile.didcomm
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.drawbridge
+++ b/docker/Dockerfile.drawbridge
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.ethereum
+++ b/docker/Dockerfile.ethereum
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3 make g++ \

--- a/docker/Dockerfile.ethereum-wallet
+++ b/docker/Dockerfile.ethereum-wallet
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 WORKDIR /app
 

--- a/docker/Dockerfile.explorer
+++ b/docker/Dockerfile.explorer
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.filecoin
+++ b/docker/Dockerfile.filecoin
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 WORKDIR /app
 

--- a/docker/Dockerfile.filecoin-wallet
+++ b/docker/Dockerfile.filecoin-wallet
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 WORKDIR /app
 

--- a/docker/Dockerfile.gatekeeper-client
+++ b/docker/Dockerfile.gatekeeper-client
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.gatekeeper-rust
+++ b/docker/Dockerfile.gatekeeper-rust
@@ -1,4 +1,4 @@
-FROM rust:1.90-bookworm AS builder
+FROM rust:1.90-trixie AS builder
 
 WORKDIR /build
 COPY rust/services/gatekeeper/Cargo.toml ./Cargo.toml
@@ -6,7 +6,7 @@ COPY rust/services/gatekeeper/Cargo.lock ./Cargo.lock
 COPY rust/services/gatekeeper/src ./src
 RUN cargo build --release
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates wget \

--- a/docker/Dockerfile.gatekeeper-ts
+++ b/docker/Dockerfile.gatekeeper-ts
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends wget \

--- a/docker/Dockerfile.herald-client
+++ b/docker/Dockerfile.herald-client
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 WORKDIR /app/apps/herald-client
 

--- a/docker/Dockerfile.hyperswarm
+++ b/docker/Dockerfile.hyperswarm
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 # Install Python and other dependencies
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.keymaster-client
+++ b/docker/Dockerfile.keymaster-client
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.keymaster-ts
+++ b/docker/Dockerfile.keymaster-ts
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.lightning-mediator
+++ b/docker/Dockerfile.lightning-mediator
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.pinning
+++ b/docker/Dockerfile.pinning
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 WORKDIR /app
 

--- a/docker/Dockerfile.react-wallet
+++ b/docker/Dockerfile.react-wallet
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.satoshi
+++ b/docker/Dockerfile.satoshi
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.satoshi-wallet
+++ b/docker/Dockerfile.satoshi-wallet
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 # Set the working directory
 WORKDIR /app

--- a/docker/Dockerfile.solana
+++ b/docker/Dockerfile.solana
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3 make g++ \

--- a/docker/Dockerfile.solana-wallet
+++ b/docker/Dockerfile.solana-wallet
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 WORKDIR /app
 

--- a/docker/Dockerfile.zcash
+++ b/docker/Dockerfile.zcash
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3 make g++ \

--- a/docker/Dockerfile.zcash-wallet
+++ b/docker/Dockerfile.zcash-wallet
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 WORKDIR /app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "typescript": "^5.8.2"
       },
       "engines": {
-        "node": "22.15.x",
+        "node": "22.23.x",
         "npm": "10.9.x"
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "packageManager": "npm@10.9.2",
   "engines": {
-    "node": "22.15.x",
+    "node": "22.23.x",
     "npm": "10.9.x"
   },
   "workspaces": [

--- a/services/herald/Dockerfile
+++ b/services/herald/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bookworm-slim
+FROM node:22.23.2-trixie-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Re-lands #891 against `main`.

## What went wrong

#891 was opened with its base set to the #890 branch, to keep the stacked diff readable. #890 was then merged **without deleting its branch**, so GitHub never retargeted #891 — and merging #891 put the change on `feat/bookworm-base-images` instead of `main`. The work was intact but unreachable from `main`.

This branch carries the **identical tree**, taken directly from that branch (`git diff` against it is empty), onto `main`. Nothing was reconstructed by hand.

## The change (unchanged from #891)

| What | To |
|---|---|
| 24 Dockerfile `FROM` lines | `node:22.23.2-trixie-slim` |
| Rust gatekeeper builder / runtime | `rust:1.90-trixie` / `debian:trixie-slim` |
| 9 workflow `node-version` pins (+5 step labels) | 22.23.2 |
| `package.json` engines | `22.23.x` |
| `package-lock.json` engines | `22.23.x` |
| README | 22.23.2 |

#890 took the images to bookworm as remediation, which was as far as the Node pin reached: official node images only publish trixie variants from about **22.22.x**, so Debian 13 was unreachable at 22.15.0. Node 22.15.0 was also well behind its own line (22.x is at 22.23.2).

The Rust stages move in lockstep — a builder newer than its runtime reintroduces the glibc failure across the stage boundary.

`package-lock.json` mirrors the root `engines` block, and the `lockfile-consistency` gate fails when a dependency-relevant field changes in a manifest without the lockfile changing. Both moved.

npm is deliberately untouched (trixie ships 10.9.8, satisfying the unchanged `10.9.x`), and `engines` won't break local dev — there's no `engine-strict` in `.npmrc`.

## Verification

Carried over from #891, where both images were built and **started**, not just built:

- **gatekeeper-rust** — glibc 2.41, zero unresolved shared libraries, binary runs and stops only on an absent redis
- **gatekeeper-ts** — Node 22.23.2, npm 10.9.8, `sqlite3` and `@ipshipyard/node-datachannel` both load, container stays running

CI re-runs the full matrix here.

## After merging

Both stale branches can be deleted: `feat/bookworm-base-images` and `feat/node-22.23-trixie`.

Closes #881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)