### PR TITLE
feat(wallet): Modern theme and layout primitives across the wallet UI

### DIFF
--- a/apps/browser-extension/src/components/BrowserContent.tsx
+++ b/apps/browser-extension/src/components/BrowserContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Box, Tab } from "@mui/material";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
 import {
@@ -23,9 +23,7 @@ import BrowserHeader from "./BrowserHeader";
 import JsonViewer from "./JsonViewer";
 import { useWalletContext } from "../contexts/WalletProvider";
 import { useUIContext } from "../contexts/UIContext";
-import { useThemeContext } from "../contexts/ContextProviders";
 import { useVariablesContext } from "../contexts/VariablesProvider";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
 import AliasedDIDs from "./AliasedDIDs";
 import AssetsTab from "./AssetsTab";
 import DmailTab from "./DmailTab";
@@ -41,15 +39,6 @@ function BrowserContent() {
     const { isBrowser, hasLightning } = useWalletContext();
     const { currentId, validId } = useVariablesContext();
     const { openBrowser, setOpenBrowser } = useUIContext();
-    const { darkMode } = useThemeContext();
-
-    const theme = useMemo(
-        () =>
-            createTheme({
-                palette: { mode: darkMode ? "dark" : "light" },
-            }),
-        [darkMode]
-    );
 
     const [activeTab, setActiveTab] = useState<string>("identities");
     const [activeSubTab, setActiveSubTab] = useState<string>("");
@@ -188,215 +177,213 @@ function BrowserContent() {
     };
 
     return (
-        <ThemeProvider theme={theme}>
-            <Box className="rootContainer">
-                <BrowserHeader menuOpen={menuOpen} toggleMenuOpen={toggleMenuOpen} />
-                <TabContext value={activeTab}>
-                    <Box
-                        className="layoutContainer"
-                        sx={{
-                            width: browserPageWidth,
-                            maxWidth: browserPageWidth,
-                            transition: "width 0.2s ease-in-out",
-                        }}
-                    >
-                        <Box className={`sidebar ${menuOpen ? "open" : ""}`}>
-                            <TabList orientation="vertical" onChange={handleTabChange} className="tabList">
+        <Box className="rootContainer">
+            <BrowserHeader menuOpen={menuOpen} toggleMenuOpen={toggleMenuOpen} />
+            <TabContext value={activeTab}>
+                <Box
+                    className="layoutContainer"
+                    sx={{
+                        width: browserPageWidth,
+                        maxWidth: browserPageWidth,
+                        transition: "width 0.2s ease-in-out",
+                    }}
+                >
+                    <Box className={`sidebar ${menuOpen ? "open" : ""}`}>
+                        <TabList orientation="vertical" onChange={handleTabChange} className="tabList">
+                            <Tab
+                                icon={<PermIdentity />}
+                                label={menuOpen ? "Identities" : ""}
+                                value="identities"
+                                iconPosition="start"
+                                className="sidebarTab"
+                                sx={{ gap: 0.25 }}
+                            />
+
+                            {displayComponent && (
                                 <Tab
-                                    icon={<PermIdentity />}
-                                    label={menuOpen ? "Identities" : ""}
-                                    value="identities"
+                                    icon={<Key />}
+                                    label={menuOpen ? "Auth" : ""}
+                                    value="auth"
                                     iconPosition="start"
                                     className="sidebarTab"
                                     sx={{ gap: 0.25 }}
                                 />
+                            )}
 
-                                {displayComponent && (
-                                    <Tab
-                                        icon={<Key />}
-                                        label={menuOpen ? "Auth" : ""}
-                                        value="auth"
-                                        iconPosition="start"
-                                        className="sidebarTab"
-                                        sx={{ gap: 0.25 }}
-                                    />
-                                )}
-
-                                {displayComponent && (
-                                    <Tab
-                                        icon={<Email />}
-                                        label={menuOpen ? "DMail" : ""}
-                                        value="dmail"
-                                        iconPosition="start"
-                                        className="sidebarTab"
-                                        sx={{ gap: 0.25 }}
-                                    />
-                                )}
-
-                                {displayComponent && (
-                                    <Tab
-                                        icon={<Badge />}
-                                        label={menuOpen ? "Credentials" : ""}
-                                        value="credentials"
-                                        iconPosition="start"
-                                        className="sidebarTab"
-                                        sx={{ gap: 0.25 }}
-                                    />
-                                )}
-
-                                {displayComponent && (
-                                    <Tab
-                                        icon={<List />}
-                                        label={menuOpen ? "Aliases" : ""}
-                                        value="aliases"
-                                        iconPosition="start"
-                                        className="sidebarTab"
-                                        sx={{ gap: 0.25 }}
-                                    />
-                                )}
-
-                                {displayComponent && (
-                                    <Tab
-                                        icon={<Poll />}
-                                        label={menuOpen ? "Polls" : ""}
-                                        value="polls"
-                                        iconPosition="start"
-                                        className="sidebarTab"
-                                        sx={{ gap: 0.25 }}
-                                    />
-                                )}
-
-                                {displayComponent && (
-                                    <Tab
-                                        icon={<Tune />}
-                                        label={menuOpen ? "Properties" : ""}
-                                        value="properties"
-                                        iconPosition="start"
-                                        className="sidebarTab"
-                                        sx={{ gap: 0.25 }}
-                                    />
-                                )}
-
-                                {displayComponent && hasLightning && (
-                                    <Tab
-                                        icon={<Bolt />}
-                                        label={menuOpen ? "Lightning" : ""}
-                                        value="lightning"
-                                        iconPosition="start"
-                                        className="sidebarTab"
-                                        sx={{ gap: 0.25 }}
-                                    />
-                                )}
-
-                                {displayComponent && (
-                                    <Tab
-                                        icon={<Token />}
-                                        label={menuOpen ? "Assets" : ""}
-                                        value="assets"
-                                        iconPosition="start"
-                                        className="sidebarTab"
-                                        sx={{ gap: 0.25 }}
-                                    />
-                                )}
-
+                            {displayComponent && (
                                 <Tab
-                                    icon={<AccountBalanceWallet />}
-                                    label={menuOpen ? "Wallet" : ""}
-                                    value="wallet"
+                                    icon={<Email />}
+                                    label={menuOpen ? "DMail" : ""}
+                                    value="dmail"
                                     iconPosition="start"
                                     className="sidebarTab"
                                     sx={{ gap: 0.25 }}
                                 />
+                            )}
 
+                            {displayComponent && (
                                 <Tab
-                                    icon={<ManageSearch />}
-                                    label={menuOpen ? "JSON Viewer" : ""}
-                                    value="viewer"
-                                    iconPosition="start"
-                                    className="sidebarTab"
-                                    sx={{ gap: 0.25, whiteSpace: "nowrap" }}
-                                />
-
-                                <Tab
-                                    icon={<Settings />}
-                                    label={menuOpen ? "Settings" : ""}
-                                    value="settings"
+                                    icon={<Badge />}
+                                    label={menuOpen ? "Credentials" : ""}
+                                    value="credentials"
                                     iconPosition="start"
                                     className="sidebarTab"
                                     sx={{ gap: 0.25 }}
                                 />
-                            </TabList>
-                        </Box>
-
-                        <Box className="browser-context">
-                            <TabPanel value="identities" sx={{ p: 0 }}>
-                                <IdentitiesTab />
-                            </TabPanel>
-
-                            {displayComponent && (
-                                <TabPanel value="auth" sx={{ p: 0 }}>
-                                    <AuthTab />
-                                </TabPanel>
                             )}
 
                             {displayComponent && (
-                                <TabPanel value="dmail" sx={{ p: 0 }}>
-                                    <DmailTab />
-                                </TabPanel>
+                                <Tab
+                                    icon={<List />}
+                                    label={menuOpen ? "Aliases" : ""}
+                                    value="aliases"
+                                    iconPosition="start"
+                                    className="sidebarTab"
+                                    sx={{ gap: 0.25 }}
+                                />
                             )}
 
                             {displayComponent && (
-                                <TabPanel value="credentials" sx={{ p: 0 }}>
-                                    <CredentialsTab subTab={activeSubTab} refresh={refresh} />
-                                </TabPanel>
+                                <Tab
+                                    icon={<Poll />}
+                                    label={menuOpen ? "Polls" : ""}
+                                    value="polls"
+                                    iconPosition="start"
+                                    className="sidebarTab"
+                                    sx={{ gap: 0.25 }}
+                                />
                             )}
 
                             {displayComponent && (
-                                <TabPanel value="aliases" sx={{ p: 0 }}>
-                                    <AliasedDIDs />
-                                </TabPanel>
-                            )}
-
-                            {displayComponent && (
-                                <TabPanel value="polls" sx={{ p: 0 }}>
-                                    <PollTab />
-                                </TabPanel>
-                            )}
-
-                            {displayComponent && (
-                                <TabPanel value="properties" sx={{ p: 0 }}>
-                                    <PropertiesTab />
-                                </TabPanel>
+                                <Tab
+                                    icon={<Tune />}
+                                    label={menuOpen ? "Properties" : ""}
+                                    value="properties"
+                                    iconPosition="start"
+                                    className="sidebarTab"
+                                    sx={{ gap: 0.25 }}
+                                />
                             )}
 
                             {displayComponent && hasLightning && (
-                                <TabPanel value="lightning" sx={{ p: 0 }}>
-                                    <LightningTab />
-                                </TabPanel>
+                                <Tab
+                                    icon={<Bolt />}
+                                    label={menuOpen ? "Lightning" : ""}
+                                    value="lightning"
+                                    iconPosition="start"
+                                    className="sidebarTab"
+                                    sx={{ gap: 0.25 }}
+                                />
                             )}
 
                             {displayComponent && (
-                                <TabPanel value="assets" sx={{ p: 0 }}>
-                                    <AssetsTab subTab={assetSubTab} />
-                                </TabPanel>
+                                <Tab
+                                    icon={<Token />}
+                                    label={menuOpen ? "Assets" : ""}
+                                    value="assets"
+                                    iconPosition="start"
+                                    className="sidebarTab"
+                                    sx={{ gap: 0.25 }}
+                                />
                             )}
 
-                            <TabPanel value="wallet" sx={{ p: 0 }}>
-                                <WalletTab />
-                            </TabPanel>
+                            <Tab
+                                icon={<AccountBalanceWallet />}
+                                label={menuOpen ? "Wallet" : ""}
+                                value="wallet"
+                                iconPosition="start"
+                                className="sidebarTab"
+                                sx={{ gap: 0.25 }}
+                            />
 
-                            <TabPanel value="viewer" sx={{ p: 0 }}>
-                                <JsonViewer browserTab="viewer" showResolveField={true} />
-                            </TabPanel>
+                            <Tab
+                                icon={<ManageSearch />}
+                                label={menuOpen ? "JSON Viewer" : ""}
+                                value="viewer"
+                                iconPosition="start"
+                                className="sidebarTab"
+                                sx={{ gap: 0.25, whiteSpace: "nowrap" }}
+                            />
 
-                            <TabPanel value="settings" sx={{ p: 0 }}>
-                                <SettingsTab />
-                            </TabPanel>
-                        </Box>
+                            <Tab
+                                icon={<Settings />}
+                                label={menuOpen ? "Settings" : ""}
+                                value="settings"
+                                iconPosition="start"
+                                className="sidebarTab"
+                                sx={{ gap: 0.25 }}
+                            />
+                        </TabList>
                     </Box>
-                </TabContext>
-            </Box>
-        </ThemeProvider>
+
+                    <Box className="browser-context">
+                        <TabPanel value="identities" sx={{ p: 0 }}>
+                            <IdentitiesTab />
+                        </TabPanel>
+
+                        {displayComponent && (
+                            <TabPanel value="auth" sx={{ p: 0 }}>
+                                <AuthTab />
+                            </TabPanel>
+                        )}
+
+                        {displayComponent && (
+                            <TabPanel value="dmail" sx={{ p: 0 }}>
+                                <DmailTab />
+                            </TabPanel>
+                        )}
+
+                        {displayComponent && (
+                            <TabPanel value="credentials" sx={{ p: 0 }}>
+                                <CredentialsTab subTab={activeSubTab} refresh={refresh} />
+                            </TabPanel>
+                        )}
+
+                        {displayComponent && (
+                            <TabPanel value="aliases" sx={{ p: 0 }}>
+                                <AliasedDIDs />
+                            </TabPanel>
+                        )}
+
+                        {displayComponent && (
+                            <TabPanel value="polls" sx={{ p: 0 }}>
+                                <PollTab />
+                            </TabPanel>
+                        )}
+
+                        {displayComponent && (
+                            <TabPanel value="properties" sx={{ p: 0 }}>
+                                <PropertiesTab />
+                            </TabPanel>
+                        )}
+
+                        {displayComponent && hasLightning && (
+                            <TabPanel value="lightning" sx={{ p: 0 }}>
+                                <LightningTab />
+                            </TabPanel>
+                        )}
+
+                        {displayComponent && (
+                            <TabPanel value="assets" sx={{ p: 0 }}>
+                                <AssetsTab subTab={assetSubTab} />
+                            </TabPanel>
+                        )}
+
+                        <TabPanel value="wallet" sx={{ p: 0 }}>
+                            <WalletTab />
+                        </TabPanel>
+
+                        <TabPanel value="viewer" sx={{ p: 0 }}>
+                            <JsonViewer browserTab="viewer" showResolveField={true} />
+                        </TabPanel>
+
+                        <TabPanel value="settings" sx={{ p: 0 }}>
+                            <SettingsTab />
+                        </TabPanel>
+                    </Box>
+                </Box>
+            </TabContext>
+        </Box>
     );
 }
 

--- a/apps/browser-extension/src/components/IdentitiesTab.tsx
+++ b/apps/browser-extension/src/components/IdentitiesTab.tsx
@@ -1,9 +1,11 @@
 import React, { ChangeEvent, useCallback, useEffect, useState } from "react";
 import JsonView from "@uiw/react-json-view";
+import { jsonViewTheme } from "./jsonViewTheme";
 import { useWalletContext } from "../contexts/WalletProvider";
 import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormControlLabel, FormLabel, MenuItem, Paper, Radio, RadioGroup, Select, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, TextField, Typography, useMediaQuery } from "@mui/material";
 import { Badge, Create, Image, Login, PermIdentity } from "@mui/icons-material";
 import { useUIContext } from "../contexts/UIContext";
+import { useThemeContext } from "../contexts/ContextProviders";
 import { useSnackbar } from "../contexts/SnackbarProvider";
 import WarningModal from "../modals/WarningModal";
 import TextInputModal from "../modals/TextInputModal";
@@ -84,6 +86,7 @@ function IdentitiesTab() {
     } = useWalletContext();
     const hideAddressAddedColumn = !isBrowser && isNarrowViewport;
     const { setError, setSuccess } = useSnackbar();
+    const { darkMode } = useThemeContext();
     const {
         refreshAll,
         resetCurrentID,
@@ -1088,7 +1091,7 @@ function IdentitiesTab() {
                                 <Paper variant="outlined" sx={{ p: 2, overflowX: "auto", width: '100%' }}>
                                     {currentIdDocs ? (
                                         <Box sx={{ width: '100%' }}>
-                                            <JsonView value={currentIdDocs} displayDataTypes={false} />
+                                            <JsonView value={currentIdDocs} displayDataTypes={false} style={jsonViewTheme(darkMode)} />
                                         </Box>
                                     ) : (
                                         <Typography variant="body2" color="text.secondary">

--- a/apps/browser-extension/src/components/JsonViewer.tsx
+++ b/apps/browser-extension/src/components/JsonViewer.tsx
@@ -5,6 +5,7 @@ import React, {
     useState
 } from "react";
 import JsonView from '@uiw/react-json-view';
+import { jsonViewTheme } from "./jsonViewTheme";
 import {
     Box,
     TextField,
@@ -19,6 +20,7 @@ import {
 } from "@mui/icons-material";
 import { useWalletContext } from "../contexts/WalletProvider";
 import { useUIContext } from "../contexts/UIContext";
+import { useThemeContext } from "../contexts/ContextProviders";
 import { useSnackbar } from "../contexts/SnackbarProvider";
 import { DidCidDocument } from "@didcid/gatekeeper/types";
 import VersionNavigator from "./VersionNavigator";
@@ -36,6 +38,7 @@ function JsonViewer({ browserTab, browserSubTab, showResolveField = false }: { b
     const { keymaster } = useWalletContext();
     const { setError } = useSnackbar();
     const { openBrowser, setOpenBrowser } = useUIContext();
+    const { darkMode } = useThemeContext();
     const [canDecrypt, setCanDecrypt] = useState(false);
     const [decryptedCache, setDecryptedCache] = useState<Record<string, unknown> | null>(null);
 
@@ -296,6 +299,7 @@ function JsonViewer({ browserTab, browserSubTab, showResolveField = false }: { b
                         <JsonView
                             value={aliasDocs}
                             shortenTextAfterLength={0}
+                            style={jsonViewTheme(darkMode)}
                         >
                             <JsonView.String
                                 render={(

--- a/apps/browser-extension/src/components/jsonViewTheme.ts
+++ b/apps/browser-extension/src/components/jsonViewTheme.ts
@@ -1,0 +1,11 @@
+import { githubDarkTheme } from "@uiw/react-json-view/githubDark";
+import { githubLightTheme } from "@uiw/react-json-view/githubLight";
+
+// @uiw/react-json-view ships its own palette and defaults to a light one, which
+// nothing in the MUI theme can reach. On a dark surface that leaves dark text on
+// a dark background. Pick the matching theme explicitly, and drop the viewer's
+// own background so it sits on whatever contains it.
+export function jsonViewTheme(isDark: boolean) {
+    const theme = isDark ? githubDarkTheme : githubLightTheme;
+    return { ...theme, backgroundColor: "transparent" };
+}

--- a/apps/react-wallet/package-lock.json
+++ b/apps/react-wallet/package-lock.json
@@ -18,6 +18,7 @@
         "@capawesome/capacitor-file-picker": "^7.2.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@fontsource-variable/inter": "^5.3.0",
         "@fontsource/roboto": "^5.3.0",
         "@mui/icons-material": "^7.3.9",
         "@mui/lab": "^7.0.1-beta.19",
@@ -1248,6 +1249,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@fontsource/roboto": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.3.0.tgz",
@@ -1935,9 +1945,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1955,9 +1962,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1975,9 +1979,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1995,9 +1996,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2015,9 +2013,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2035,9 +2030,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4914,9 +4906,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4938,9 +4927,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4962,9 +4948,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4986,9 +4969,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/apps/react-wallet/package-lock.json
+++ b/apps/react-wallet/package-lock.json
@@ -1249,15 +1249,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@fontsource-variable/inter": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.3.0.tgz",
-      "integrity": "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
     "node_modules/@fontsource/roboto": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.3.0.tgz",
@@ -1945,6 +1936,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1962,6 +1956,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1979,6 +1976,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1996,6 +1996,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2013,6 +2016,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2030,6 +2036,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4906,6 +4915,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4927,6 +4939,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4948,6 +4963,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4969,6 +4987,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7914,6 +7935,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     }
   }

--- a/apps/react-wallet/package.json
+++ b/apps/react-wallet/package.json
@@ -21,6 +21,7 @@
     "@capawesome/capacitor-file-picker": "^7.2.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@fontsource-variable/inter": "^5.3.0",
     "@fontsource/roboto": "^5.3.0",
     "@mui/icons-material": "^7.3.9",
     "@mui/lab": "^7.0.1-beta.19",

--- a/apps/react-wallet/src/BrowserContent.tsx
+++ b/apps/react-wallet/src/BrowserContent.tsx
@@ -42,7 +42,6 @@ import { useUIContext } from "./contexts/UIContext";
 import { useThemeContext } from "./contexts/ContextProviders";
 import { useWalletContext } from "./contexts/WalletProvider";
 import { useSafeArea } from "./contexts/SafeAreaContext";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
 import AliasedDIDs from "./components/AliasedDIDs";
 import AssetsTab from "./components/AssetsTab";
 import DmailTab from "./components/DmailTab";
@@ -68,16 +67,7 @@ function BrowserContent() {
         pendingSubTab,
         setPendingSubTab
     } = useUIContext();
-    const { darkMode } = useThemeContext();
     const { top: safeTop, bottom: safeBottom } = useSafeArea();
-
-    const theme = useMemo(
-        () =>
-            createTheme({
-                palette: { mode: darkMode ? "dark" : "light" },
-            }),
-        [darkMode]
-    );
 
     const assetTabs = ["groups", "schemas", "images", "files", "vaults"];
     const displayComponent = validId && currentId !== "";
@@ -241,411 +231,409 @@ function BrowserContent() {
     const sidebarWidthExpanded = 220;
 
     return (
-        <ThemeProvider theme={theme}>
+        <Box
+            sx={{
+                position: "fixed",
+                maxWidth: menuOpen
+                    ? BASE_CONTENT_WIDTH + sidebarWidthExpanded
+                    : BASE_CONTENT_WIDTH + sidebarWidthCollapsed,
+                transition: 'max-width 0.2s ease',
+                inset: 0,
+                pt: `${safeTop}px`,
+                display: "flex",
+                flexDirection: "column",
+                bgcolor: "background.default",
+            }}
+        >
             <Box
                 sx={{
-                    position: "fixed",
-                    maxWidth: menuOpen
-                        ? BASE_CONTENT_WIDTH + sidebarWidthExpanded
-                        : BASE_CONTENT_WIDTH + sidebarWidthCollapsed,
-                    transition: 'max-width 0.2s ease',
-                    inset: 0,
-                    pt: `${safeTop}px`,
+                    flex: 1,
+                    width: "100%",
+                    mx: "auto",
                     display: "flex",
                     flexDirection: "column",
-                    bgcolor: "background.default",
+                    minHeight: 0,
                 }}
             >
-                <Box
-                    sx={{
-                        flex: 1,
-                        width: "100%",
-                        mx: "auto",
-                        display: "flex",
-                        flexDirection: "column",
-                        minHeight: 0,
-                    }}
-                >
-                    <BrowserHeader
-                        menuOpen={isTabletUp ? menuOpen : false}
-                        toggleMenuOpen={isTabletUp ? toggleMenuOpen : undefined}
-                    />
+                <BrowserHeader
+                    menuOpen={isTabletUp ? menuOpen : false}
+                    toggleMenuOpen={isTabletUp ? toggleMenuOpen : undefined}
+                />
 
-                    <TabContext value={selectedTab}>
-                        {isTabletUp ? (
+                <TabContext value={selectedTab}>
+                    {isTabletUp ? (
+                        <Box
+                            sx={{
+                                display: "flex",
+                                flex: 1,
+                                minHeight: 0,
+                                overflow: "hidden",
+                            }}
+                        >
                             <Box
                                 sx={{
+                                    flexShrink: 0,
+                                    width: menuOpen
+                                        ? sidebarWidthExpanded
+                                        : sidebarWidthCollapsed,
+                                    transition: "width 0.2s ease",
+                                    borderRight: (t) =>
+                                        `1px solid ${t.palette.divider}`,
+                                    bgcolor: "background.paper",
+                                    py: 1,
                                     display: "flex",
-                                    flex: 1,
-                                    minHeight: 0,
-                                    overflow: "hidden",
                                 }}
                             >
-                                <Box
+                                <TabList
+                                    orientation="vertical"
+                                    onChange={handleSidebarTabChange}
                                     sx={{
-                                        flexShrink: 0,
-                                        width: menuOpen
-                                            ? sidebarWidthExpanded
-                                            : sidebarWidthCollapsed,
-                                        transition: "width 0.2s ease",
-                                        borderRight: (t) =>
-                                            `1px solid ${t.palette.divider}`,
-                                        bgcolor: "background.paper",
-                                        py: 1,
-                                        display: "flex",
-                                    }}
-                                >
-                                    <TabList
-                                        orientation="vertical"
-                                        onChange={handleSidebarTabChange}
-                                        sx={{
-                                            width: "100%",
-                                            "& .MuiTab-root": {
-                                                minHeight: 44,
-                                                maxHeight: 44,
-                                                justifyContent: "flex-start",
-                                                px: 2,
-                                            },
-                                            "& .MuiTab-root .MuiTab-iconWrapper":{
-                                                mr: 1.5 ,
-                                            },
-                                        }}
-                                    >
-                                        <Tab
-                                            icon={<Person />}
-                                            label={
-                                                menuOpen ? "Identities" : ""
-                                            }
-                                            value="identities"
-                                            iconPosition="start"
-                                        />
-
-                                        {displayComponent && (
-                                            <Tab
-                                                icon={<Key />}
-                                                label={menuOpen ? "Auth" : ""}
-                                                value="auth"
-                                                iconPosition="start"
-                                            />
-                                        )}
-
-                                        {displayComponent && (
-                                            <Tab
-                                                icon={<Email />}
-                                                label={menuOpen ? "DMail" : ""}
-                                                value="dmail"
-                                                iconPosition="start"
-                                            />
-                                        )}
-
-                                        {displayComponent && (
-                                            <Tab
-                                                icon={<Badge />}
-                                                label={
-                                                    menuOpen
-                                                        ? "Credentials"
-                                                        : ""
-                                                }
-                                                value="credentials"
-                                                iconPosition="start"
-                                            />
-                                        )}
-
-                                        {displayComponent && (
-                                            <Tab
-                                                icon={<ListIcon />}
-                                                label={
-                                                    menuOpen
-                                                        ? "Aliases"
-                                                        : ""
-                                                }
-                                                value="aliases"
-                                                iconPosition="start"
-                                            />
-                                        )}
-
-                                        {displayComponent && (
-                                            <Tab
-                                                icon={<Tune />}
-                                                label={
-                                                    menuOpen
-                                                        ? "Properties"
-                                                        : ""
-                                                }
-                                                value="properties"
-                                                iconPosition="start"
-                                            />
-                                        )}
-
-                                        {displayComponent && (
-                                            <Tab
-                                                icon={<Poll />}
-                                                label={
-                                                    menuOpen ? "Polls" : ""
-                                                }
-                                                value="polls"
-                                                iconPosition="start"
-                                            />
-                                        )}
-
-                                        {displayComponent && hasLightning && (
-                                            <Tab
-                                                icon={<Bolt />}
-                                                label={
-                                                    menuOpen ? "Lightning" : ""
-                                                }
-                                                value="lightning"
-                                                iconPosition="start"
-                                            />
-                                        )}
-
-                                        {displayComponent && (
-                                            <Tab
-                                                icon={<Token />}
-                                                label={
-                                                    menuOpen ? "Assets" : ""
-                                                }
-                                                value="assets"
-                                                iconPosition="start"
-                                            />
-                                        )}
-
-                                        <Tab
-                                            icon={<AccountBalanceWallet />}
-                                            label={
-                                                menuOpen ? "Wallet" : ""
-                                            }
-                                            value="wallet"
-                                            iconPosition="start"
-                                        />
-
-                                        <Tab
-                                            icon={<ManageSearch />}
-                                            label={
-                                                menuOpen
-                                                    ? "JSON Viewer"
-                                                    : ""
-                                            }
-                                            value="viewer"
-                                            iconPosition="start"
-                                            sx={{
-                                                whiteSpace: "nowrap",
-                                            }}
-                                        />
-
-                                        <Tab
-                                            icon={<Settings />}
-                                            label={
-                                                menuOpen ? "Settings" : ""
-                                            }
-                                            value="settings"
-                                            iconPosition="start"
-                                        />
-                                    </TabList>
-                                </Box>
-
-                                <Box
-                                    id="contentScroll"
-                                    sx={{
-                                        flex: 1,
-                                        minWidth: 0,
-                                        overflow: "auto",
-                                        px: 2,
-                                        py: 1,
-                                    }}
-                                >
-                                    {tabPanels}
-                                </Box>
-                            </Box>
-                        ) : (
-                            <>
-                                <Box
-                                    id="contentScroll"
-                                    sx={{
-                                        flex: 1,
-                                        overflow: "auto",
-                                        WebkitOverflowScrolling: "touch",
-                                        px: 1,
-                                        pb: `calc(${safeBottom}px + 56px)`,
-                                    }}
-                                >
-                                    {tabPanels}
-                                </Box>
-
-                                <BottomNavigation
-                                    value={bottomNavValue}
-                                    onChange={handleBottomNavChange}
-                                    showLabels
-                                    sx={{
-                                        position: "fixed",
-                                        left: 0,
-                                        right: 0,
-                                        bottom: 0,
-                                        pb: `${safeBottom}px`,
-                                        alignItems: "flex-start",
-                                        minHeight: 56,
-                                        bgcolor: "background.paper",
-                                        borderTop: (t) =>
-                                            `1px solid ${t.palette.divider}`,
-                                        zIndex: (t) => t.zIndex.appBar,
-                                        "& .MuiBottomNavigationAction-root": {
-                                            minWidth: "auto",
-                                            px: 0,
+                                        width: "100%",
+                                        "& .MuiTab-root": {
+                                            minHeight: 44,
+                                            maxHeight: 44,
+                                            justifyContent: "flex-start",
+                                            px: 2,
+                                        },
+                                        "& .MuiTab-root .MuiTab-iconWrapper":{
+                                            mr: 1.5 ,
                                         },
                                     }}
                                 >
-                                    <BottomNavigationAction
-                                        value="identities"
-                                        label="Identities"
+                                    <Tab
                                         icon={<Person />}
+                                        label={
+                                            menuOpen ? "Identities" : ""
+                                        }
+                                        value="identities"
+                                        iconPosition="start"
                                     />
-                                    <BottomNavigationAction
-                                        value="wallet"
-                                        label="Wallet"
+
+                                    {displayComponent && (
+                                        <Tab
+                                            icon={<Key />}
+                                            label={menuOpen ? "Auth" : ""}
+                                            value="auth"
+                                            iconPosition="start"
+                                        />
+                                    )}
+
+                                    {displayComponent && (
+                                        <Tab
+                                            icon={<Email />}
+                                            label={menuOpen ? "DMail" : ""}
+                                            value="dmail"
+                                            iconPosition="start"
+                                        />
+                                    )}
+
+                                    {displayComponent && (
+                                        <Tab
+                                            icon={<Badge />}
+                                            label={
+                                                menuOpen
+                                                    ? "Credentials"
+                                                    : ""
+                                            }
+                                            value="credentials"
+                                            iconPosition="start"
+                                        />
+                                    )}
+
+                                    {displayComponent && (
+                                        <Tab
+                                            icon={<ListIcon />}
+                                            label={
+                                                menuOpen
+                                                    ? "Aliases"
+                                                    : ""
+                                            }
+                                            value="aliases"
+                                            iconPosition="start"
+                                        />
+                                    )}
+
+                                    {displayComponent && (
+                                        <Tab
+                                            icon={<Tune />}
+                                            label={
+                                                menuOpen
+                                                    ? "Properties"
+                                                    : ""
+                                            }
+                                            value="properties"
+                                            iconPosition="start"
+                                        />
+                                    )}
+
+                                    {displayComponent && (
+                                        <Tab
+                                            icon={<Poll />}
+                                            label={
+                                                menuOpen ? "Polls" : ""
+                                            }
+                                            value="polls"
+                                            iconPosition="start"
+                                        />
+                                    )}
+
+                                    {displayComponent && hasLightning && (
+                                        <Tab
+                                            icon={<Bolt />}
+                                            label={
+                                                menuOpen ? "Lightning" : ""
+                                            }
+                                            value="lightning"
+                                            iconPosition="start"
+                                        />
+                                    )}
+
+                                    {displayComponent && (
+                                        <Tab
+                                            icon={<Token />}
+                                            label={
+                                                menuOpen ? "Assets" : ""
+                                            }
+                                            value="assets"
+                                            iconPosition="start"
+                                        />
+                                    )}
+
+                                    <Tab
                                         icon={<AccountBalanceWallet />}
+                                        label={
+                                            menuOpen ? "Wallet" : ""
+                                        }
+                                        value="wallet"
+                                        iconPosition="start"
                                     />
-                                    <BottomNavigationAction
-                                        value="viewer"
-                                        label="Viewer"
+
+                                    <Tab
                                         icon={<ManageSearch />}
+                                        label={
+                                            menuOpen
+                                                ? "JSON Viewer"
+                                                : ""
+                                        }
+                                        value="viewer"
+                                        iconPosition="start"
+                                        sx={{
+                                            whiteSpace: "nowrap",
+                                        }}
                                     />
-                                    <BottomNavigationAction
-                                        value="settings"
-                                        label="Settings"
+
+                                    <Tab
                                         icon={<Settings />}
+                                        label={
+                                            menuOpen ? "Settings" : ""
+                                        }
+                                        value="settings"
+                                        iconPosition="start"
                                     />
-                                    <BottomNavigationAction
-                                        value="more"
-                                        label="More"
-                                        icon={<MoreHoriz />}
-                                        disabled={!displayComponent}
-                                    />
-                                </BottomNavigation>
-                            </>
-                        )}
-                    </TabContext>
+                                </TabList>
+                            </Box>
 
-                    {!isTabletUp && (
-                        <Dialog
-                            fullScreen
-                            open={moreOpen}
-                            onClose={() => setMoreOpen(false)}
-                        >
-                            <AppBar sx={{ position: "relative" }}>
-                                <Toolbar
-                                    sx={{
-                                        height: 80,
-                                        alignItems: "flex-end",
-                                        minHeight: "80px !important",
-                                    }}
-                                >
-                                    <IconButton
-                                        edge="start"
-                                        color="inherit"
-                                        onClick={() => setMoreOpen(false)}
-                                    >
-                                        <Close />
-                                    </IconButton>
+                            <Box
+                                id="contentScroll"
+                                sx={{
+                                    flex: 1,
+                                    minWidth: 0,
+                                    overflow: "auto",
+                                    px: 2,
+                                    py: 1,
+                                }}
+                            >
+                                {tabPanels}
+                            </Box>
+                        </Box>
+                    ) : (
+                        <>
+                            <Box
+                                id="contentScroll"
+                                sx={{
+                                    flex: 1,
+                                    overflow: "auto",
+                                    WebkitOverflowScrolling: "touch",
+                                    px: 1,
+                                    pb: `calc(${safeBottom}px + 56px)`,
+                                }}
+                            >
+                                {tabPanels}
+                            </Box>
 
-                                    <Typography
-                                        variant="h6"
-                                        component="h6"
-                                        sx={{ ml: 2 }}
-                                    >
-                                        Archon
-                                    </Typography>
-
-                                    <Box
-                                        component="img"
-                                        src="/icon_transparent.png"
-                                        alt="Archon"
-                                        sx={{ width: 32, height: 32 }}
-                                    />
-                                </Toolbar>
-                            </AppBar>
-
-                            <List sx={{ py: 0 }}>
-                                <ListItemButton
-                                    onClick={() => selectFromMore("auth")}
-                                >
-                                    <ListItemIcon>
-                                        <Key />
-                                    </ListItemIcon>
-                                    <ListItemText primary="Auth" />
-                                </ListItemButton>
-
-                                <ListItemButton
-                                    onClick={() => selectFromMore("dmail")}
-                                >
-                                    <ListItemIcon>
-                                        <Email />
-                                    </ListItemIcon>
-                                    <ListItemText primary="DMail" />
-                                </ListItemButton>
-
-                                <ListItemButton
-                                    onClick={() =>
-                                        selectFromMore("credentials")
-                                    }
-                                >
-                                    <ListItemIcon>
-                                        <Badge />
-                                    </ListItemIcon>
-                                    <ListItemText primary="Credentials" />
-                                </ListItemButton>
-
-                                <ListItemButton
-                                    onClick={() => selectFromMore("aliases")}
-                                >
-                                    <ListItemIcon>
-                                        <ListIcon />
-                                    </ListItemIcon>
-                                    <ListItemText primary="Aliases" />
-                                </ListItemButton>
-
-                                <ListItemButton
-                                    onClick={() => selectFromMore("properties")}
-                                >
-                                    <ListItemIcon>
-                                        <Tune />
-                                    </ListItemIcon>
-                                    <ListItemText primary="Properties" />
-                                </ListItemButton>
-
-                                <ListItemButton
-                                    onClick={() => selectFromMore("polls")}
-                                >
-                                    <ListItemIcon>
-                                        <Poll />
-                                    </ListItemIcon>
-                                    <ListItemText primary="Polls" />
-                                </ListItemButton>
-
-                                {hasLightning && (
-                                    <ListItemButton
-                                        onClick={() => selectFromMore("lightning")}
-                                    >
-                                        <ListItemIcon>
-                                            <Bolt />
-                                        </ListItemIcon>
-                                        <ListItemText primary="Lightning" />
-                                    </ListItemButton>
-                                )}
-
-                                <ListItemButton
-                                    onClick={() => selectFromMore("assets")}
-                                >
-                                    <ListItemIcon>
-                                        <Token />
-                                    </ListItemIcon>
-                                    <ListItemText primary="Assets" />
-                                </ListItemButton>
-                            </List>
-                        </Dialog>
+                            <BottomNavigation
+                                value={bottomNavValue}
+                                onChange={handleBottomNavChange}
+                                showLabels
+                                sx={{
+                                    position: "fixed",
+                                    left: 0,
+                                    right: 0,
+                                    bottom: 0,
+                                    pb: `${safeBottom}px`,
+                                    alignItems: "flex-start",
+                                    minHeight: 56,
+                                    bgcolor: "background.paper",
+                                    borderTop: (t) =>
+                                        `1px solid ${t.palette.divider}`,
+                                    zIndex: (t) => t.zIndex.appBar,
+                                    "& .MuiBottomNavigationAction-root": {
+                                        minWidth: "auto",
+                                        px: 0,
+                                    },
+                                }}
+                            >
+                                <BottomNavigationAction
+                                    value="identities"
+                                    label="Identities"
+                                    icon={<Person />}
+                                />
+                                <BottomNavigationAction
+                                    value="wallet"
+                                    label="Wallet"
+                                    icon={<AccountBalanceWallet />}
+                                />
+                                <BottomNavigationAction
+                                    value="viewer"
+                                    label="Viewer"
+                                    icon={<ManageSearch />}
+                                />
+                                <BottomNavigationAction
+                                    value="settings"
+                                    label="Settings"
+                                    icon={<Settings />}
+                                />
+                                <BottomNavigationAction
+                                    value="more"
+                                    label="More"
+                                    icon={<MoreHoriz />}
+                                    disabled={!displayComponent}
+                                />
+                            </BottomNavigation>
+                        </>
                     )}
-                </Box>
+                </TabContext>
+
+                {!isTabletUp && (
+                    <Dialog
+                        fullScreen
+                        open={moreOpen}
+                        onClose={() => setMoreOpen(false)}
+                    >
+                        <AppBar sx={{ position: "relative" }}>
+                            <Toolbar
+                                sx={{
+                                    height: 80,
+                                    alignItems: "flex-end",
+                                    minHeight: "80px !important",
+                                }}
+                            >
+                                <IconButton
+                                    edge="start"
+                                    color="inherit"
+                                    onClick={() => setMoreOpen(false)}
+                                >
+                                    <Close />
+                                </IconButton>
+
+                                <Typography
+                                    variant="h6"
+                                    component="h6"
+                                    sx={{ ml: 2 }}
+                                >
+                                        Archon
+                                </Typography>
+
+                                <Box
+                                    component="img"
+                                    src="/icon_transparent.png"
+                                    alt="Archon"
+                                    sx={{ width: 32, height: 32 }}
+                                />
+                            </Toolbar>
+                        </AppBar>
+
+                        <List sx={{ py: 0 }}>
+                            <ListItemButton
+                                onClick={() => selectFromMore("auth")}
+                            >
+                                <ListItemIcon>
+                                    <Key />
+                                </ListItemIcon>
+                                <ListItemText primary="Auth" />
+                            </ListItemButton>
+
+                            <ListItemButton
+                                onClick={() => selectFromMore("dmail")}
+                            >
+                                <ListItemIcon>
+                                    <Email />
+                                </ListItemIcon>
+                                <ListItemText primary="DMail" />
+                            </ListItemButton>
+
+                            <ListItemButton
+                                onClick={() =>
+                                    selectFromMore("credentials")
+                                }
+                            >
+                                <ListItemIcon>
+                                    <Badge />
+                                </ListItemIcon>
+                                <ListItemText primary="Credentials" />
+                            </ListItemButton>
+
+                            <ListItemButton
+                                onClick={() => selectFromMore("aliases")}
+                            >
+                                <ListItemIcon>
+                                    <ListIcon />
+                                </ListItemIcon>
+                                <ListItemText primary="Aliases" />
+                            </ListItemButton>
+
+                            <ListItemButton
+                                onClick={() => selectFromMore("properties")}
+                            >
+                                <ListItemIcon>
+                                    <Tune />
+                                </ListItemIcon>
+                                <ListItemText primary="Properties" />
+                            </ListItemButton>
+
+                            <ListItemButton
+                                onClick={() => selectFromMore("polls")}
+                            >
+                                <ListItemIcon>
+                                    <Poll />
+                                </ListItemIcon>
+                                <ListItemText primary="Polls" />
+                            </ListItemButton>
+
+                            {hasLightning && (
+                                <ListItemButton
+                                    onClick={() => selectFromMore("lightning")}
+                                >
+                                    <ListItemIcon>
+                                        <Bolt />
+                                    </ListItemIcon>
+                                    <ListItemText primary="Lightning" />
+                                </ListItemButton>
+                            )}
+
+                            <ListItemButton
+                                onClick={() => selectFromMore("assets")}
+                            >
+                                <ListItemIcon>
+                                    <Token />
+                                </ListItemIcon>
+                                <ListItemText primary="Assets" />
+                            </ListItemButton>
+                        </List>
+                    </Dialog>
+                )}
             </Box>
-        </ThemeProvider>
+        </Box>
     );
 }
 

--- a/apps/react-wallet/src/BrowserContent.tsx
+++ b/apps/react-wallet/src/BrowserContent.tsx
@@ -37,6 +37,7 @@ import SettingsTab from "./components/SettingsTab";
 import IdentitiesTab from "./components/IdentitiesTab";
 import BrowserHeader from "./components/BrowserHeader";
 import JsonViewer from "./components/JsonViewer";
+import PageHeader from "./components/layout/PageHeader";
 import { useVariablesContext } from "./contexts/VariablesProvider";
 import { useUIContext } from "./contexts/UIContext";
 import { useThemeContext } from "./contexts/ContextProviders";
@@ -217,6 +218,10 @@ function BrowserContent() {
             </TabPanel>
 
             <TabPanel value="viewer" sx={{ p: 0 }}>
+                <PageHeader
+                    title="Resolver"
+                    description="Resolve any DID and inspect the document it returns."
+                />
                 <JsonViewer browserTab="viewer" showResolveField={true} />
             </TabPanel>
 

--- a/apps/react-wallet/src/components/AliasedDIDs.tsx
+++ b/apps/react-wallet/src/components/AliasedDIDs.tsx
@@ -40,6 +40,7 @@ import TextInputModal from "../modals/TextInputModal";
 import SelectInputModal from "../modals/SelectInputModal";
 import CopyResolveDID from "./CopyResolveDID";
 import { scanAliasQrCode } from "../utils/utils";
+import PageHeader from "./layout/PageHeader";
 
 function AliasedDIDs() {
     const [removeOpen, setRemoveOpen] = useState<boolean>(false);
@@ -385,6 +386,10 @@ function AliasedDIDs() {
 
     return (
         <Box>
+            <PageHeader
+                title="Aliases"
+                description="Short names you have given to DIDs, so you do not have to remember them."
+            />
             <WarningModal
                 title="Remove DID"
                 warningText={`Are you sure you want to remove '${removeName}'?`}

--- a/apps/react-wallet/src/components/AssetsTab.tsx
+++ b/apps/react-wallet/src/components/AssetsTab.tsx
@@ -8,6 +8,7 @@ import FileTab from "./FileTab";
 import GroupsTab from "./GroupsTab";
 import VaultTab from "./VaultTab";
 import CloneAssetTab from "./CloneAssetTab";
+import PageHeader from "./layout/PageHeader";
 
 function AssetsTab({ subTab }: {subTab: string}) {
     const [assetSubTab, setAssetSubTab] = useState<string>("schemas");
@@ -22,6 +23,10 @@ function AssetsTab({ subTab }: {subTab: string}) {
 
     return (
         <TabContext value={assetSubTab}>
+            <PageHeader
+                title="Assets"
+                description="Vaults, schemas, images, files and groups owned by this identity."
+            />
             <Box
                 sx={{
                     position: "sticky",

--- a/apps/react-wallet/src/components/AuthTab.tsx
+++ b/apps/react-wallet/src/components/AuthTab.tsx
@@ -12,6 +12,7 @@ import { useVariablesContext } from "../contexts/VariablesProvider";
 import { scanQrCodeRaw } from "../utils/utils";
 import { dispatchDeepLink } from "../utils/deepLinkQueue";
 import PageHeader from "./layout/PageHeader";
+import ActionMenu from "./layout/ActionMenu";
 
 interface AutoLoginState {
     responseDID: string;
@@ -428,45 +429,26 @@ function AuthTab() {
                         />
                     </Box>
 
-                    <Box className="flex-box">
+                    <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 1 }}>
                         <Button
                             variant="contained"
-                            color="primary"
-                            onClick={openChallengeDialog}
-                            className="button large bottom"
-                        >
-                            New...
-                        </Button>
-
-                        <Button
-                            variant="contained"
-                            color="primary"
-                            onClick={() => resolveChallenge(challenge)}
-                            className="button large bottom"
-                            disabled={!challenge || challenge === authDID}
-                        >
-                            Resolve
-                        </Button>
-
-                        <Button
-                            variant="contained"
-                            color="primary"
                             onClick={createResponse}
-                            className="button large bottom"
                             disabled={!challenge}
                         >
                             Respond
                         </Button>
 
-                        <Button
-                            variant="contained"
-                            color="primary"
-                            onClick={clearChallenge}
-                            className="button large bottom"
-                            disabled={!challenge}
-                        >
-                            Clear
+                        <Button variant="outlined" onClick={openChallengeDialog}>
+                            New challenge
                         </Button>
+
+                        <ActionMenu
+                            label="More"
+                            items={[
+                                { label: "Resolve challenge", onClick: () => resolveChallenge(challenge), disabled: !challenge || challenge === authDID },
+                                { label: "Clear", onClick: clearChallenge, disabled: !challenge },
+                            ]}
+                        />
                     </Box>
 
                     <Box className="flex-box mt-2">
@@ -480,46 +462,30 @@ function AuthTab() {
                         />
                     </Box>
 
-                    <Box className="flex-box">
+                    <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 1 }}>
                         <Button
                             variant="contained"
-                            color="primary"
-                            onClick={() => decryptResponse(response)}
-                            className="button large bottom"
-                            disabled={!response || response === authDID}
-                        >
-                            Decrypt
-                        </Button>
-
-                        <Button
-                            variant="contained"
-                            color="primary"
-                            onClick={verifyResponse}
-                            className="button large bottom"
-                            disabled={!response}
-                        >
-                            Verify
-                        </Button>
-
-                        <Button
-                            variant="contained"
-                            color="primary"
                             onClick={sendResponse}
-                            className="button large bottom"
                             disabled={disableSendResponse}
                         >
                             Send
                         </Button>
 
                         <Button
-                            variant="contained"
-                            color="primary"
-                            onClick={clearResponse}
-                            className="button large bottom"
+                            variant="outlined"
+                            onClick={verifyResponse}
                             disabled={!response}
                         >
-                            Clear
+                            Verify
                         </Button>
+
+                        <ActionMenu
+                            label="More"
+                            items={[
+                                { label: "Decrypt response", onClick: () => decryptResponse(response), disabled: !response || response === authDID },
+                                { label: "Clear", onClick: clearResponse, disabled: !response },
+                            ]}
+                        />
                     </Box>
 
                     <Dialog open={showChallengeDialog} onClose={closeChallengeDialog}>

--- a/apps/react-wallet/src/components/AuthTab.tsx
+++ b/apps/react-wallet/src/components/AuthTab.tsx
@@ -11,6 +11,7 @@ import { useUIContext } from "../contexts/UIContext";
 import { useVariablesContext } from "../contexts/VariablesProvider";
 import { scanQrCodeRaw } from "../utils/utils";
 import { dispatchDeepLink } from "../utils/deepLinkQueue";
+import PageHeader from "./layout/PageHeader";
 
 interface AutoLoginState {
     responseDID: string;
@@ -286,6 +287,10 @@ function AuthTab() {
 
     return (
         <Box>
+            <PageHeader
+                title="Authentication"
+                description="Respond to login challenges and verify responses from others."
+            />
             {autoLoginLoading && (
                 <Paper elevation={2} sx={{ p: 3, m: 2, textAlign: 'center' }}>
                     <CircularProgress size={40} />

--- a/apps/react-wallet/src/components/CredentialsTab.tsx
+++ b/apps/react-wallet/src/components/CredentialsTab.tsx
@@ -4,6 +4,7 @@ import { TabContext, TabPanel } from "@mui/lab";
 import IssueTab from "./IssueTab";
 import IssuedTab from "./IssuedTab";
 import HeldTab from "./HeldTab";
+import PageHeader from "./layout/PageHeader";
 
 function CredentialsTab({ subTab, refresh }: {subTab: string, refresh: number}) {
     const [credentialTab, setCredentialTab] = useState<string>("held");
@@ -18,6 +19,10 @@ function CredentialsTab({ subTab, refresh }: {subTab: string, refresh: number}) 
 
     return (
         <TabContext value={credentialTab}>
+            <PageHeader
+                title="Credentials"
+                description="Credentials you hold, and credentials you have issued to others."
+            />
             <Box
                 sx={{
                     position: "sticky",

--- a/apps/react-wallet/src/components/DmailTab.tsx
+++ b/apps/react-wallet/src/components/DmailTab.tsx
@@ -51,6 +51,7 @@ import DisplayDID from "./DisplayDID";
 import VersionNavigator from "./VersionNavigator";
 import { DidCidDocument } from "@didcid/gatekeeper/types";
 import PageHeader from "./layout/PageHeader";
+import ActionMenu from "./layout/ActionMenu";
 
 const DmailTab: React.FC = () => {
     const [registry, setRegistry] = useState<string>("hyperswarm");
@@ -1194,28 +1195,32 @@ const DmailTab: React.FC = () => {
                     </Button>
                 </Box>
 
-                <Box display="flex" alignItems="center" gap={2} flexWrap="wrap">
-
-                    <Button variant="contained" onClick={handleUpdate} disabled={!dmailDid}>
-                        Update
-                    </Button>
+                <Box display="flex" alignItems="center" gap={1} flexWrap="wrap">
 
                     <Button variant="contained" onClick={handleSend} disabled={!dmailDid}>
                         Send
                     </Button>
 
-                    <Button variant="contained" color="primary" onClick={() => setRevokeOpen(true)} disabled={!dmailDid}>
-                        Revoke
+                    <Button variant="outlined" onClick={handleUpdate} disabled={!dmailDid}>
+                        Save draft
                     </Button>
 
-                    <Button
-                        variant="outlined"
-                        color="secondary"
-                        onClick={clearAll}
-                        disabled={!(sendToList.length || sendCcList.length || sendCc || sendTo || sendSubject || sendBody)}
-                    >
-                        Clear
-                    </Button>
+                    <ActionMenu
+                        label="More"
+                        items={[
+                            {
+                                label: "Clear",
+                                onClick: clearAll,
+                                disabled: !(sendToList.length || sendCcList.length || sendCc || sendTo || sendSubject || sendBody),
+                            },
+                            {
+                                label: "Revoke",
+                                onClick: () => setRevokeOpen(true),
+                                disabled: !dmailDid,
+                                destructive: true,
+                            },
+                        ]}
+                    />
                 </Box>
 
                 <Box display="flex" flexDirection="column" gap={1}>

--- a/apps/react-wallet/src/components/DmailTab.tsx
+++ b/apps/react-wallet/src/components/DmailTab.tsx
@@ -50,6 +50,7 @@ import DmailSearchModal, { AdvancedSearchParams } from "../modals/DmailSearchMod
 import DisplayDID from "./DisplayDID";
 import VersionNavigator from "./VersionNavigator";
 import { DidCidDocument } from "@didcid/gatekeeper/types";
+import PageHeader from "./layout/PageHeader";
 
 const DmailTab: React.FC = () => {
     const [registry, setRegistry] = useState<string>("hyperswarm");
@@ -1277,6 +1278,10 @@ const DmailTab: React.FC = () => {
 
     return (
         <Box>
+            <PageHeader
+                title="DMail"
+                description="Encrypted messages addressed to your identities."
+            />
             <WarningModal
                 isOpen={revokeOpen}
                 title="Revoke DMail"

--- a/apps/react-wallet/src/components/HeldTab.tsx
+++ b/apps/react-wallet/src/components/HeldTab.tsx
@@ -9,6 +9,10 @@ import { useSnackbar } from "../contexts/SnackbarProvider";
 import JsonViewer from "./JsonViewer";
 import DisplayDID from "./DisplayDID";
 import {scanQrCode} from "../utils/utils";
+import { Badge } from "@mui/icons-material";
+import Section from "./layout/Section";
+import EmptyState from "./layout/EmptyState";
+import ActionMenu from "./layout/ActionMenu";
 
 function HeldTab() {
     const [open, setOpen] = useState<boolean>(false);
@@ -275,70 +279,42 @@ function HeldTab() {
             </Box>
 
             <Box className="overflow-box">
-                {heldList.map((did) => (
-                    <Box key={did} className="margin-bottom">
-                        <DisplayDID did={did} />
+                {heldList.length === 0 ? (
+                    <Section>
+                        <EmptyState
+                            icon={<Badge />}
+                            title="No credentials held"
+                            description="Credentials issued to your identities will appear here once accepted."
+                        />
+                    </Section>
+                ) : heldList.map((did) => (
+                    <Section key={did}>
+                        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 2, flexWrap: "wrap" }}>
+                            <Box sx={{ minWidth: 0, flex: 1 }}>
+                                <DisplayDID did={did} />
+                            </Box>
 
-                        <Box className="flex-box">
-                            <Button
-                                variant="outlined"
-                                className="button large top"
-                                onClick={() => displayJson(did)}
-                            >
-                                Resolve
-                            </Button>
-
-                            <Button
-                                variant="outlined"
-                                className="button large top"
-                                onClick={() =>
-                                    decryptCredential(did)
-                                }
-                            >
-                                Decrypt
-                            </Button>
-
-                            <Button
-                                variant="outlined"
-                                className="button large top"
-                                onClick={() => {
-                                    handleRemoveOpen();
-                                    setRemoveDID(did);
-                                }}
-                                disabled={!credentialUnpublished(did)}
-                            >
-                                Remove
-                            </Button>
+                            <Box sx={{ display: "flex", gap: 1, flexShrink: 0 }}>
+                                <Button variant="outlined" onClick={() => displayJson(did)}>
+                                    Resolve
+                                </Button>
+                                <ActionMenu
+                                    items={[
+                                        { label: "Decrypt", onClick: () => decryptCredential(did) },
+                                        { label: "Publish", onClick: () => publishCredential(did), disabled: credentialPublished(did) },
+                                        { label: "Reveal", onClick: () => revealCredential(did), disabled: credentialRevealed(did) },
+                                        { label: "Unpublish", onClick: () => unpublishCredential(did), disabled: credentialUnpublished(did) },
+                                        {
+                                            label: "Remove",
+                                            onClick: () => { handleRemoveOpen(); setRemoveDID(did); },
+                                            disabled: !credentialUnpublished(did),
+                                            destructive: true,
+                                        },
+                                    ]}
+                                />
+                            </Box>
                         </Box>
-                        <Box className="flex-box">
-                            <Button
-                                variant="outlined"
-                                className="button large bottom"
-                                onClick={() => publishCredential(did)}
-                                disabled={credentialPublished(did)}
-                            >
-                                Publish
-                            </Button>
-
-                            <Button
-                                variant="outlined"
-                                className="button large bottom"
-                                onClick={() => revealCredential(did)}
-                                disabled={credentialRevealed(did)}
-                            >
-                                Reveal
-                            </Button>
-
-                            <Button
-                                variant="outlined"
-                                className="button large bottom"
-                                onClick={() => unpublishCredential(did)}
-                                disabled={credentialUnpublished(did)}
-                            >
-                                Unpublish
-                            </Button>
-                        </Box>
-                    </Box>
+                    </Section>
                 ))}
             </Box>
             <JsonViewer browserTab="credentials" browserSubTab="held" />

--- a/apps/react-wallet/src/components/IdentitiesTab.tsx
+++ b/apps/react-wallet/src/components/IdentitiesTab.tsx
@@ -2,7 +2,11 @@ import { ChangeEvent, useCallback, useEffect, useState } from "react";
 import JsonView from "@uiw/react-json-view";
 import { useWalletContext } from "../contexts/WalletProvider";
 import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormControlLabel, FormLabel, MenuItem, Paper, Radio, RadioGroup, Select, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, TextField, Typography } from "@mui/material";
-import { Badge, Create, Image, Login, PermIdentity } from "@mui/icons-material";
+import { Badge, Create, DriveFileRenameOutline, Image, Login, LoopOutlined, PermIdentity, RestoreOutlined, SaveAltOutlined, SwapHorizOutlined, DeleteOutline } from "@mui/icons-material";
+import PageHeader from "./layout/PageHeader";
+import Section from "./layout/Section";
+import EmptyState from "./layout/EmptyState";
+import ActionMenu from "./layout/ActionMenu";
 import { useUIContext } from "../contexts/UIContext";
 import { useSnackbar } from "../contexts/SnackbarProvider";
 import WarningModal from "../modals/WarningModal";
@@ -1009,63 +1013,47 @@ function IdentitiesTab() {
                 </DialogActions>
             </Dialog>
 
-            <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 0, width: '100%' }}>
-                <Box sx={{ mt: currentId ? 2 : 0, display: 'flex', alignItems: 'center', width: '100%', flexWrap: 'wrap', flexDirection: 'row', gap: 1 }}>
-                    <Button variant="contained" onClick={openCreateModal}>
-                        Create ID
-                    </Button>
-                    {currentId && (
+            <Box sx={{ width: '100%' }}>
+                <PageHeader
+                    title="Identities"
+                    description={currentId
+                        ? `Managing ${currentId}. Keys, addresses and profile for this identity.`
+                        : "Create an identity to start issuing and holding credentials."}
+                    actions={
                         <>
-                            <Button
-                                variant="contained"
-                                color="primary"
-                                onClick={handleRenameId}
-                            >
-                                Rename
-                            </Button>
-
-                            <Button
-                                variant="contained"
-                                color="primary"
-                                onClick={handleRemoveId}
-                            >
-                                Remove
-                            </Button>
-
-                            <Button
-                                variant="contained"
-                                color="primary"
-                                onClick={backupId}
-                            >
-                                Backup
-                            </Button>
-
-                            <Button
-                                variant="contained"
-                                color="primary"
-                                onClick={handleRecoverId}
-                            >
-                                Recover
-                            </Button>
-
-                            <Button
-                                variant="contained"
-                                color="primary"
-                                onClick={rotateKeys}
-                            >
-                                Rotate
-                            </Button>
-
-                            <Button
-                                variant="contained"
-                                color="primary"
-                                onClick={() => setMigrateOpen(true)}
-                            >
-                                Migrate...
+                            {currentId && (
+                                <ActionMenu
+                                    items={[
+                                        { label: "Rename", onClick: handleRenameId, icon: <DriveFileRenameOutline fontSize="small" /> },
+                                        { label: "Backup", onClick: backupId, icon: <SaveAltOutlined fontSize="small" /> },
+                                        { label: "Recover", onClick: handleRecoverId, icon: <RestoreOutlined fontSize="small" /> },
+                                        { label: "Rotate keys", onClick: rotateKeys, icon: <LoopOutlined fontSize="small" /> },
+                                        { label: "Migrate registry", onClick: () => setMigrateOpen(true), icon: <SwapHorizOutlined fontSize="small" /> },
+                                        { label: "Remove identity", onClick: handleRemoveId, icon: <DeleteOutline fontSize="small" />, destructive: true },
+                                    ]}
+                                />
+                            )}
+                            <Button variant="contained" onClick={openCreateModal}>
+                                Create ID
                             </Button>
                         </>
-                    )}
-                </Box>
+                    }
+                />
+
+                {!currentId && (
+                    <Section>
+                        <EmptyState
+                            icon={<PermIdentity />}
+                            title="No identity selected"
+                            description="An identity holds your keys and is the subject of the credentials you issue and receive."
+                            action={
+                                <Button variant="contained" onClick={openCreateModal}>
+                                    Create ID
+                                </Button>
+                            }
+                        />
+                    </Section>
+                )}
                 {currentId && (
                     <Box sx={{ mt: 2, width: '100%' }}>
                         <Tabs
@@ -1073,325 +1061,371 @@ function IdentitiesTab() {
                             onChange={(_event, newValue) => setIdentityTab(newValue)}
                             variant="scrollable"
                             scrollButtons="auto"
+                            sx={{ mb: 2, minHeight: 40, borderBottom: 1, borderColor: "divider" }}
                         >
-                            <Tab value="details" label="Details" icon={<PermIdentity />} iconPosition="top" />
-                            <Tab value="addresses" label="Addresses" icon={<Badge />} iconPosition="top" />
-                            <Tab value="name" label="Name" icon={<Create />} iconPosition="top" />
-                            <Tab value="avatar" label="Avatar" icon={<Image />} iconPosition="top" />
-                            <Tab value="nostr" label="Nostr" icon={<Login />} iconPosition="top" />
+                            <Tab value="details" label="Details" icon={<PermIdentity fontSize="small" />} iconPosition="start" />
+                            <Tab value="addresses" label="Addresses" icon={<Badge fontSize="small" />} iconPosition="start" />
+                            <Tab value="name" label="Name" icon={<Create fontSize="small" />} iconPosition="start" />
+                            <Tab value="avatar" label="Avatar" icon={<Image fontSize="small" />} iconPosition="start" />
+                            <Tab value="nostr" label="Nostr" icon={<Login fontSize="small" />} iconPosition="start" />
                         </Tabs>
                         {identityTab === "details" && (
-                            <Box sx={{ mt: 2, width: '100%' }}>
-                                <Paper variant="outlined" sx={{ p: 2, overflowX: "auto", width: '100%' }}>
-                                    {currentIdDocs ? (
-                                        <Box sx={{ width: '100%' }}>
-                                            <JsonView value={currentIdDocs} displayDataTypes={false} />
-                                        </Box>
-                                    ) : (
-                                        <Typography variant="body2" color="text.secondary">
-                                        No DID document available for the current identity.
-                                        </Typography>
-                                    )}
-                                </Paper>
-                            </Box>
+                            <Section
+                                title="DID document"
+                                description="The resolved document for this identity, as published to its registry."
+                                dense
+                            >
+                                {currentIdDocs ? (
+                                    <Box sx={{ p: 2, overflowX: "auto", width: '100%' }}>
+                                        <JsonView value={currentIdDocs} displayDataTypes={false} />
+                                    </Box>
+                                ) : (
+                                    <EmptyState
+                                        icon={<PermIdentity />}
+                                        title="No DID document"
+                                        description="Nothing has resolved for this identity yet. It may still be propagating to its registry."
+                                    />
+                                )}
+                            </Section>
                         )}
                         {identityTab === "addresses" && (
-                            <Box sx={{ mt: 2, width: '100%' }}>
-                                <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
-                                    <TextField label="Name" size="small" value={addressName} onChange={(e) => setAddressName(e.target.value)} />
-                                    <TextField label="Domain" size="small" value={addressDomain} onChange={(e) => setAddressDomain(e.target.value)} />
-                                </Box>
-                                <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 1 }}>
-                                    <Button variant="contained" size="small" onClick={checkAddressValue} disabled={addressBusy || !addressName.trim() || !addressDomain.trim()}>Check</Button>
-                                    <Button variant="contained" size="small" onClick={addAddressValue} disabled={addressBusy || !addressName.trim() || !addressDomain.trim()}>Add</Button>
-                                    <Button variant="contained" size="small" onClick={() => resolveStoredAddress(addressDomain)} disabled={addressBusy || !addressDomain.trim()}>Get</Button>
-                                    <Button variant="contained" size="small" onClick={importAddressDomain} disabled={addressBusy || !addressDomain.trim()}>Import</Button>
-                                    <Button variant="contained" size="small" onClick={() => removeAddressValue()} disabled={addressBusy || (!selectedAddress && (!addressName.trim() || !addressDomain.trim()))}>Remove</Button>
-                                    <Button variant="contained" size="small" onClick={clearAddressFields} disabled={addressBusy || (!addressName && !addressDomain && !selectedAddress && !addressDetails)}>Clear</Button>
-                                </Box>
-                                <TableContainer component={Paper} sx={{ mb: 1 }}>
-                                    <Table size="small" sx={{ tableLayout: "fixed" }}>
-                                        <colgroup>
-                                            <col />
-                                            <col style={{ width: "140px" }} />
-                                            <col style={{ width: "210px" }} />
-                                        </colgroup>
-                                        <TableHead>
-                                            <TableRow>
-                                                <TableCell>Address</TableCell>
-                                                <TableCell>Added</TableCell>
-                                                <TableCell>Actions</TableCell>
-                                            </TableRow>
-                                        </TableHead>
-                                        <TableBody>
-                                            {Object.entries(addressList).sort(([a], [b]) => a.localeCompare(b)).map(([address, info]) => (
-                                                <TableRow key={address} selected={address === selectedAddress}>
-                                                    <TableCell sx={{ fontFamily: 'monospace', fontWeight: address === publishedAddress ? 700 : 400 }}>{address}</TableCell>
-                                                    <TableCell sx={{ fontFamily: 'monospace' }}>{formatAddedDate(info.added)}</TableCell>
-                                                    <TableCell>
-                                                        <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
-                                                            <Button variant="contained" size="small" onClick={() => selectAddress(address)} disabled={addressBusy}>Select</Button>
-                                                            <Button
-                                                                variant="contained"
-                                                                size="small"
-                                                                color={address === publishedAddress ? "error" : "primary"}
-                                                                onClick={() => address === publishedAddress ? clearPublishedAddressValue() : setPublishedAddressValue(address)}
-                                                                disabled={addressBusy || !currentId}
-                                                            >
-                                                                {address === publishedAddress ? "Unpublish" : "Publish"}
-                                                            </Button>
-                                                        </Box>
-                                                    </TableCell>
+                            <Box sx={{ width: '100%' }}>
+                                <Section
+                                    title="Add an address"
+                                    description="Claim a name at a domain and attach it to this identity."
+                                >
+                                    <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap', alignItems: 'center' }}>
+                                        <TextField label="Name" size="small" value={addressName} onChange={(e) => setAddressName(e.target.value)} />
+                                        <TextField label="Domain" size="small" value={addressDomain} onChange={(e) => setAddressDomain(e.target.value)} />
+                                        <Button variant="contained" onClick={addAddressValue} disabled={addressBusy || !addressName.trim() || !addressDomain.trim()}>Add</Button>
+                                        <Button variant="outlined" onClick={checkAddressValue} disabled={addressBusy || !addressName.trim() || !addressDomain.trim()}>Check</Button>
+                                        <ActionMenu
+                                            label="More"
+                                            items={[
+                                                { label: "Get stored address", onClick: () => resolveStoredAddress(addressDomain), disabled: addressBusy || !addressDomain.trim() },
+                                                { label: "Import from domain", onClick: importAddressDomain, disabled: addressBusy || !addressDomain.trim() },
+                                                { label: "Clear fields", onClick: clearAddressFields, disabled: addressBusy || (!addressName && !addressDomain && !selectedAddress && !addressDetails) },
+                                                { label: "Remove address", onClick: () => removeAddressValue(), disabled: addressBusy || (!selectedAddress && (!addressName.trim() || !addressDomain.trim())), destructive: true },
+                                            ]}
+                                        />
+                                    </Box>
+                                </Section>
+                                <Section title="Addresses" dense>
+                                    <TableContainer sx={{ border: 0 }}>
+                                        <Table size="small" sx={{ tableLayout: "fixed" }}>
+                                            <colgroup>
+                                                <col />
+                                                <col style={{ width: "140px" }} />
+                                                <col style={{ width: "210px" }} />
+                                            </colgroup>
+                                            <TableHead>
+                                                <TableRow>
+                                                    <TableCell>Address</TableCell>
+                                                    <TableCell>Added</TableCell>
+                                                    <TableCell>Actions</TableCell>
                                                 </TableRow>
-                                            ))}
-                                        </TableBody>
-                                    </Table>
-                                </TableContainer>
-                                <TextField multiline minRows={8} fullWidth value={addressDetails} InputProps={{ readOnly: true }} />
+                                            </TableHead>
+                                            <TableBody>
+                                                {Object.entries(addressList).sort(([a], [b]) => a.localeCompare(b)).map(([address, info]) => (
+                                                    <TableRow key={address} selected={address === selectedAddress}>
+                                                        <TableCell sx={{ fontFamily: 'monospace', fontWeight: address === publishedAddress ? 700 : 400 }}>{address}</TableCell>
+                                                        <TableCell sx={{ fontFamily: 'monospace' }}>{formatAddedDate(info.added)}</TableCell>
+                                                        <TableCell>
+                                                            <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+                                                                <Button variant="contained" size="small" onClick={() => selectAddress(address)} disabled={addressBusy}>Select</Button>
+                                                                <Button
+                                                                    variant="contained"
+                                                                    size="small"
+                                                                    color={address === publishedAddress ? "error" : "primary"}
+                                                                    onClick={() => address === publishedAddress ? clearPublishedAddressValue() : setPublishedAddressValue(address)}
+                                                                    disabled={addressBusy || !currentId}
+                                                                >
+                                                                    {address === publishedAddress ? "Unpublish" : "Publish"}
+                                                                </Button>
+                                                            </Box>
+                                                        </TableCell>
+                                                    </TableRow>
+                                                ))}
+                                            </TableBody>
+                                        </Table>
+                                    </TableContainer>
+                                    {Object.keys(addressList).length === 0 && (
+                                        <EmptyState
+                                            icon={<Badge />}
+                                            title="No addresses yet"
+                                            description="Addresses let others reach this identity by a human-readable name instead of its DID."
+                                        />
+                                    )}
+                                </Section>
+
+                                <Section title="Details" description="Raw response for the selected address." dense>
+                                    <TextField
+                                        multiline
+                                        minRows={8}
+                                        fullWidth
+                                        value={addressDetails}
+                                        InputProps={{ readOnly: true, sx: { fontFamily: 'monospace', fontSize: '0.8125rem' } }}
+                                        sx={{ '& fieldset': { border: 0 } }}
+                                    />
+                                </Section>
                             </Box>
                         )}
                         {identityTab === "name" && (
-                            <Box sx={{ mt: 2, width: '100%', maxWidth: 520 }}>
-                                <Typography variant="body2" sx={{ mb: 1 }}>
-                                    The selected identity stores its display name as the `name` property.
-                                </Typography>
-                                <TextField
-                                    label="Current Name"
-                                    value={identityNameValue}
-                                    fullWidth
-                                    size="small"
-                                    margin="normal"
-                                    slotProps={{ input: { readOnly: true } }}
-                                    placeholder={identityNameLoading ? "Loading..." : "No name set"}
-                                />
-                                <TextField
-                                    label="Name"
-                                    value={identityNameInput}
-                                    onChange={(e) => setIdentityNameInput(e.target.value)}
-                                    fullWidth
-                                    size="small"
-                                    margin="normal"
-                                    placeholder="Enter name"
-                                />
-                                {identityNameError && (
-                                    <Alert severity="warning" sx={{ mt: 1 }}>
-                                        {identityNameError}
-                                    </Alert>
-                                )}
-                                <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 2 }}>
-                                    <Button
-                                        variant="contained"
-                                        onClick={setIdentityNameProperty}
-                                        disabled={!identityNameInput.trim()}
-                                    >
+                            <Box sx={{ width: '100%', maxWidth: 560 }}>
+                                <Section
+                                    title="Display name"
+                                    description="Stored on the identity as its `name` property."
+                                >
+                                    <TextField
+                                        label="Current Name"
+                                        value={identityNameValue}
+                                        fullWidth
+                                        size="small"
+                                        margin="normal"
+                                        slotProps={{ input: { readOnly: true } }}
+                                        placeholder={identityNameLoading ? "Loading..." : "No name set"}
+                                    />
+                                    <TextField
+                                        label="Name"
+                                        value={identityNameInput}
+                                        onChange={(e) => setIdentityNameInput(e.target.value)}
+                                        fullWidth
+                                        size="small"
+                                        margin="normal"
+                                        placeholder="Enter name"
+                                    />
+                                    {identityNameError && (
+                                        <Alert severity="warning" sx={{ mt: 1 }}>
+                                            {identityNameError}
+                                        </Alert>
+                                    )}
+                                    <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 2 }}>
+                                        <Button
+                                            variant="contained"
+                                            onClick={setIdentityNameProperty}
+                                            disabled={!identityNameInput.trim()}
+                                        >
                                         Set Name
-                                    </Button>
-                                    <Button
-                                        variant="contained"
-                                        color="error"
-                                        onClick={removeIdentityNameProperty}
-                                        disabled={!identityNameValue}
-                                    >
+                                        </Button>
+                                        <Button
+                                            variant="outlined"
+                                            color="error"
+                                            onClick={removeIdentityNameProperty}
+                                            disabled={!identityNameValue}
+                                        >
                                         Remove Name
-                                    </Button>
-                                </Box>
+                                        </Button>
+                                    </Box>
+                                </Section>
                             </Box>
                         )}
                         {identityTab === "avatar" && (
-                            <Box sx={{ mt: 2, width: "100%" }}>
-                                <Box sx={{ display: "flex", gap: 3, flexWrap: "wrap", alignItems: "flex-start", mb: 3 }}>
-                                    <Box sx={{ width: 220 }}>
-                                        <Typography variant="subtitle1" sx={{ mb: 1 }}>{displayedAvatarTitle}</Typography>
-                                        <Paper variant="outlined" sx={{ width: 220, height: 220, display: "flex", alignItems: "center", justifyContent: "center", overflow: "hidden", bgcolor: "grey.50" }}>
-                                            {displayedAvatarPreviewUrl ? (
-                                                <img src={displayedAvatarPreviewUrl} alt={`${currentId} avatar`} style={{ width: "100%", height: "100%", objectFit: "contain" }} />
-                                            ) : (
-                                                <Typography color="text.secondary" sx={{ textAlign: "center", px: 2 }}>
-                                                    {displayedAvatarEmptyText}
-                                                </Typography>
+                            <Box sx={{ width: "100%" }}>
+                                <Section
+                                    title="Avatar"
+                                    description="Stored on the identity as its `avatar` property."
+                                >
+                                    <Box sx={{ display: "flex", gap: 3, flexWrap: "wrap", alignItems: "flex-start" }}>
+                                        <Box sx={{ width: 220 }}>
+                                            <Typography variant="subtitle1" sx={{ mb: 1 }}>{displayedAvatarTitle}</Typography>
+                                            <Paper variant="outlined" sx={{ width: 220, height: 220, display: "flex", alignItems: "center", justifyContent: "center", overflow: "hidden", bgcolor: "action.hover", borderRadius: 2 }}>
+                                                {displayedAvatarPreviewUrl ? (
+                                                    <img src={displayedAvatarPreviewUrl} alt={`${currentId} avatar`} style={{ width: "100%", height: "100%", objectFit: "contain" }} />
+                                                ) : (
+                                                    <Typography color="text.secondary" sx={{ textAlign: "center", px: 2 }}>
+                                                        {displayedAvatarEmptyText}
+                                                    </Typography>
+                                                )}
+                                            </Paper>
+                                        </Box>
+                                        <Box sx={{ flex: 1, minWidth: 280 }}>
+                                            <Typography variant="body2" sx={{ mb: 1 }}>
+                                                {isAvatarPreviewMode
+                                                    ? "Review the preview below, then apply it to the selected identity."
+                                                    : "The selected identity stores its avatar as the `avatar` property."}
+                                            </Typography>
+                                            <TextField
+                                                label={displayedAvatarDidLabel}
+                                                value={displayedAvatarDid}
+                                                fullWidth
+                                                size="small"
+                                                margin="normal"
+                                                InputProps={{ readOnly: true }}
+                                            />
+                                            {displayedAvatarError && (
+                                                <Alert severity="warning" sx={{ mt: 1 }}>
+                                                    {displayedAvatarError}
+                                                </Alert>
                                             )}
-                                        </Paper>
-                                    </Box>
-                                    <Box sx={{ flex: 1, minWidth: 280 }}>
-                                        <Typography variant="body2" sx={{ mb: 1 }}>
-                                            {isAvatarPreviewMode
-                                                ? "Review the preview below, then apply it to the selected identity."
-                                                : "The selected identity stores its avatar as the `avatar` property."}
-                                        </Typography>
-                                        <TextField
-                                            label={displayedAvatarDidLabel}
-                                            value={displayedAvatarDid}
-                                            fullWidth
-                                            size="small"
-                                            margin="normal"
-                                            InputProps={{ readOnly: true }}
-                                        />
-                                        {displayedAvatarError && (
-                                            <Alert severity="warning" sx={{ mt: 1 }}>
-                                                {displayedAvatarError}
-                                            </Alert>
-                                        )}
-                                        <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 2 }}>
-                                            {isAvatarPreviewMode ? (
-                                                <>
-                                                    <Button
-                                                        variant="contained"
-                                                        onClick={applyAvatarCandidate}
-                                                        disabled={!avatarCandidateDid || !avatarCandidatePreviewUrl}
-                                                    >
+                                            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 2 }}>
+                                                {isAvatarPreviewMode ? (
+                                                    <>
+                                                        <Button
+                                                            variant="contained"
+                                                            onClick={applyAvatarCandidate}
+                                                            disabled={!avatarCandidateDid || !avatarCandidatePreviewUrl}
+                                                        >
                                                         Set Avatar
-                                                    </Button>
-                                                    <Button
-                                                        variant="outlined"
-                                                        onClick={clearAvatarCandidate}
-                                                        disabled={!avatarCandidateDid && !avatarCandidatePreviewUrl && !avatarCandidateError}
-                                                    >
+                                                        </Button>
+                                                        <Button
+                                                            variant="outlined"
+                                                            onClick={clearAvatarCandidate}
+                                                            disabled={!avatarCandidateDid && !avatarCandidatePreviewUrl && !avatarCandidateError}
+                                                        >
                                                         Clear Preview
-                                                    </Button>
-                                                </>
-                                            ) : (
-                                                <Button variant="contained" color="error" onClick={removeAvatarProperty} disabled={!avatarDid}>
+                                                        </Button>
+                                                    </>
+                                                ) : (
+                                                    <Button variant="outlined" color="error" onClick={removeAvatarProperty} disabled={!avatarDid}>
                                                     Remove Avatar
-                                                </Button>
-                                            )}
+                                                    </Button>
+                                                )}
+                                            </Box>
                                         </Box>
                                     </Box>
-                                </Box>
 
-                                <FormControl sx={{ mb: 2 }}>
-                                    <FormLabel>Set Avatar From</FormLabel>
-                                    <RadioGroup row value={avatarMode} onChange={handleAvatarModeChange}>
-                                        <FormControlLabel value="alias" control={<Radio />} label="Image Alias" />
-                                        <FormControlLabel value="did" control={<Radio />} label="DID" />
-                                        <FormControlLabel value="upload" control={<Radio />} label="Upload Image" />
-                                    </RadioGroup>
-                                </FormControl>
+                                    <FormControl sx={{ mb: 2 }}>
+                                        <FormLabel>Set Avatar From</FormLabel>
+                                        <RadioGroup row value={avatarMode} onChange={handleAvatarModeChange}>
+                                            <FormControlLabel value="alias" control={<Radio />} label="Image Alias" />
+                                            <FormControlLabel value="did" control={<Radio />} label="DID" />
+                                            <FormControlLabel value="upload" control={<Radio />} label="Upload Image" />
+                                        </RadioGroup>
+                                    </FormControl>
 
-                                {avatarMode === "alias" && (
-                                    <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
-                                        <Select
-                                            value={avatarAlias}
-                                            displayEmpty
-                                            size="small"
-                                            sx={{ minWidth: 280 }}
-                                            onChange={(event) => setAvatarAlias(event.target.value)}
-                                        >
-                                            <MenuItem value="" disabled>Select image alias</MenuItem>
-                                            {imageList.map((name) => (
-                                                <MenuItem key={name} value={name}>{name}</MenuItem>
-                                            ))}
-                                        </Select>
-                                        <Button
-                                            variant="contained"
-                                            onClick={() => previewAvatarCandidate(avatarAlias, { alias: avatarAlias })}
-                                            disabled={!avatarAlias}
-                                        >
+                                    {avatarMode === "alias" && (
+                                        <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+                                            <Select
+                                                value={avatarAlias}
+                                                displayEmpty
+                                                size="small"
+                                                sx={{ minWidth: 280 }}
+                                                onChange={(event) => setAvatarAlias(event.target.value)}
+                                            >
+                                                <MenuItem value="" disabled>Select image alias</MenuItem>
+                                                {imageList.map((name) => (
+                                                    <MenuItem key={name} value={name}>{name}</MenuItem>
+                                                ))}
+                                            </Select>
+                                            <Button
+                                                variant="contained"
+                                                onClick={() => previewAvatarCandidate(avatarAlias, { alias: avatarAlias })}
+                                                disabled={!avatarAlias}
+                                            >
                                             Preview
-                                        </Button>
-                                    </Box>
-                                )}
+                                            </Button>
+                                        </Box>
+                                    )}
 
-                                {avatarMode === "did" && (
-                                    <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
-                                        <TextField
-                                            label="Avatar DID"
-                                            value={avatarInputDid}
-                                            onChange={(e) => setAvatarInputDid(e.target.value)}
-                                            size="small"
-                                            sx={{ minWidth: 420, flex: 1 }}
-                                        />
-                                        <Button
-                                            variant="contained"
-                                            onClick={() => previewAvatarCandidate(avatarInputDid)}
-                                            disabled={!avatarInputDid.trim()}
-                                        >
+                                    {avatarMode === "did" && (
+                                        <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+                                            <TextField
+                                                label="Avatar DID"
+                                                value={avatarInputDid}
+                                                onChange={(e) => setAvatarInputDid(e.target.value)}
+                                                size="small"
+                                                sx={{ minWidth: 420, flex: 1 }}
+                                            />
+                                            <Button
+                                                variant="contained"
+                                                onClick={() => previewAvatarCandidate(avatarInputDid)}
+                                                disabled={!avatarInputDid.trim()}
+                                            >
                                             Preview
-                                        </Button>
-                                    </Box>
-                                )}
+                                            </Button>
+                                        </Box>
+                                    )}
 
-                                {avatarMode === "upload" && (
-                                    <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
-                                        <Select
-                                            value={registries.includes(registry) ? registry : ""}
-                                            onChange={(e) => setRegistry(e.target.value)}
-                                            size="small"
-                                            sx={{ minWidth: 220 }}
-                                        >
-                                            {registries.map((r) => (
-                                                <MenuItem key={r} value={r}>{r}</MenuItem>
-                                            ))}
-                                        </Select>
-                                        <Button
-                                            variant="contained"
-                                            onClick={() => document.getElementById("avatarUpload")?.click()}
-                                            disabled={!registry}
-                                        >
+                                    {avatarMode === "upload" && (
+                                        <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+                                            <Select
+                                                value={registries.includes(registry) ? registry : ""}
+                                                onChange={(e) => setRegistry(e.target.value)}
+                                                size="small"
+                                                sx={{ minWidth: 220 }}
+                                            >
+                                                {registries.map((r) => (
+                                                    <MenuItem key={r} value={r}>{r}</MenuItem>
+                                                ))}
+                                            </Select>
+                                            <Button
+                                                variant="contained"
+                                                onClick={() => document.getElementById("avatarUpload")?.click()}
+                                                disabled={!registry}
+                                            >
                                             Upload Image...
-                                        </Button>
-                                        <input
-                                            type="file"
-                                            id="avatarUpload"
-                                            accept="image/*"
-                                            style={{ display: "none" }}
-                                            onChange={uploadAvatarImage}
-                                        />
-                                    </Box>
-                                )}
+                                            </Button>
+                                            <input
+                                                type="file"
+                                                id="avatarUpload"
+                                                accept="image/*"
+                                                style={{ display: "none" }}
+                                                onChange={uploadAvatarImage}
+                                            />
+                                        </Box>
+                                    )}
+                                </Section>
                             </Box>
                         )}
                         {identityTab === "nostr" && (
-                            <Box sx={{ mt: 2, width: '100%' }}>
-                                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 1 }}>
-                                    {nostrKeys ? (
-                                        <Button variant="contained" color="error" onClick={() => setRemoveNostrModal(true)} sx={{ whiteSpace: 'nowrap' }}>
+                            <Box sx={{ width: '100%' }}>
+                                <Section
+                                    title="Nostr"
+                                    description="Attach a Nostr keypair to this identity, or import an existing nsec."
+                                >
+                                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 1 }}>
+                                        {nostrKeys ? (
+                                            <Button variant="contained" color="error" onClick={() => setRemoveNostrModal(true)} sx={{ whiteSpace: 'nowrap' }}>
                                             Remove Nostr
-                                        </Button>
-                                    ) : (
-                                        <>
-                                            <Button variant="contained" color="primary" onClick={addNostr} sx={{ whiteSpace: 'nowrap' }}>
-                                                Add Nostr
-                                            </Button>
-                                            <Button variant="contained" color="primary" onClick={() => setImportNostrModal(true)} sx={{ whiteSpace: 'nowrap' }}>
-                                                Import nsec
-                                            </Button>
-                                        </>
-                                    )}
-                                    {nostrKeys && (
-                                        nsecValue ? (
-                                            <Button variant="contained" color="warning" onClick={hideNsec} sx={{ whiteSpace: 'nowrap' }}>
-                                                Hide nsec
                                             </Button>
                                         ) : (
-                                            <Button variant="contained" color="warning" onClick={showNsec} sx={{ whiteSpace: 'nowrap' }}>
-                                                Show nsec
-                                            </Button>
-                                        )
-                                    )}
-                                </Box>
-                                {nostrKeys ? (
-                                    <Box>
-                                        <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
-                                            npub: {nostrKeys.npub}
-                                        </Typography>
-                                        <br />
-                                        <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
-                                            pubkey: {nostrKeys.pubkey}
-                                        </Typography>
-                                        {nsecValue && (
                                             <>
-                                                <br />
-                                                <Typography variant="caption" color="error" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
-                                                    nsec: {nsecValue}
-                                                </Typography>
+                                                <Button variant="contained" color="primary" onClick={addNostr} sx={{ whiteSpace: 'nowrap' }}>
+                                                Add Nostr
+                                                </Button>
+                                                <Button variant="contained" color="primary" onClick={() => setImportNostrModal(true)} sx={{ whiteSpace: 'nowrap' }}>
+                                                Import nsec
+                                                </Button>
                                             </>
                                         )}
+                                        {nostrKeys && (
+                                            nsecValue ? (
+                                                <Button variant="contained" color="warning" onClick={hideNsec} sx={{ whiteSpace: 'nowrap' }}>
+                                                Hide nsec
+                                                </Button>
+                                            ) : (
+                                                <Button variant="contained" color="warning" onClick={showNsec} sx={{ whiteSpace: 'nowrap' }}>
+                                                Show nsec
+                                                </Button>
+                                            )
+                                        )}
                                     </Box>
-                                ) : (
-                                    <Typography variant="body2" color="text.secondary">
-                                        No Nostr keys are configured for this identity yet.
-                                    </Typography>
-                                )}
+                                    {nostrKeys ? (
+                                        <Box>
+                                            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+                                            npub: {nostrKeys.npub}
+                                            </Typography>
+                                            <br />
+                                            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+                                            pubkey: {nostrKeys.pubkey}
+                                            </Typography>
+                                            {nsecValue && (
+                                                <>
+                                                    <br />
+                                                    <Typography variant="caption" color="error" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
+                                                    nsec: {nsecValue}
+                                                    </Typography>
+                                                </>
+                                            )}
+                                        </Box>
+                                    ) : (
+                                        <EmptyState
+                                            icon={<Login />}
+                                            title="No Nostr keys"
+                                            description="Add a keypair to use this identity on Nostr, or import an existing nsec."
+                                        />
+                                    )}
+                                </Section>
                             </Box>
                         )}
                     </Box>

--- a/apps/react-wallet/src/components/IdentitiesTab.tsx
+++ b/apps/react-wallet/src/components/IdentitiesTab.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, useCallback, useEffect, useState } from "react";
 import JsonView from "@uiw/react-json-view";
+import { jsonViewTheme } from "./layout/jsonViewTheme";
 import { useWalletContext } from "../contexts/WalletProvider";
 import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, FormControl, FormControlLabel, FormLabel, MenuItem, Paper, Radio, RadioGroup, Select, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, TextField, Typography } from "@mui/material";
 import { Badge, Create, DriveFileRenameOutline, Image, Login, LoopOutlined, PermIdentity, RestoreOutlined, SaveAltOutlined, SwapHorizOutlined, DeleteOutline } from "@mui/icons-material";
@@ -8,6 +9,7 @@ import Section from "./layout/Section";
 import EmptyState from "./layout/EmptyState";
 import ActionMenu from "./layout/ActionMenu";
 import { useUIContext } from "../contexts/UIContext";
+import { useThemeContext } from "../contexts/ContextProviders";
 import { useSnackbar } from "../contexts/SnackbarProvider";
 import WarningModal from "../modals/WarningModal";
 import TextInputModal from "../modals/TextInputModal";
@@ -85,6 +87,7 @@ function IdentitiesTab() {
     const [avatarCandidateLoading, setAvatarCandidateLoading] = useState<boolean>(false);
     const [avatarCandidateError, setAvatarCandidateError] = useState<string>("");
     const { keymaster } = useWalletContext();
+    const { darkMode } = useThemeContext();
     const { setError, setSuccess } = useSnackbar();
     const {
         refreshAll,
@@ -1077,7 +1080,7 @@ function IdentitiesTab() {
                             >
                                 {currentIdDocs ? (
                                     <Box sx={{ p: 2, overflowX: "auto", width: '100%' }}>
-                                        <JsonView value={currentIdDocs} displayDataTypes={false} />
+                                        <JsonView value={currentIdDocs} displayDataTypes={false} style={jsonViewTheme(darkMode)} />
                                     </Box>
                                 ) : (
                                     <EmptyState

--- a/apps/react-wallet/src/components/JsonViewer.tsx
+++ b/apps/react-wallet/src/components/JsonViewer.tsx
@@ -5,6 +5,7 @@ import React, {
     useState
 } from "react";
 import JsonView from '@uiw/react-json-view';
+import { jsonViewTheme } from "./layout/jsonViewTheme";
 import {
     Box,
     TextField,
@@ -18,11 +19,13 @@ import {
 } from "@mui/icons-material";
 import { useWalletContext } from "../contexts/WalletProvider";
 import { useUIContext } from "../contexts/UIContext";
+import { useThemeContext } from "../contexts/ContextProviders";
 import { useSnackbar } from "../contexts/SnackbarProvider";
 import { DidCidDocument } from "@didcid/gatekeeper/types";
 import VersionNavigator from "./VersionNavigator";
 
 function JsonViewer({ browserTab, browserSubTab, showResolveField = false }: { browserTab: string, browserSubTab?: string, showResolveField?: boolean }) {
+    const { darkMode } = useThemeContext();
     const [aliasDocs, setAliasDocs] = useState<Record<string, unknown> | undefined>(undefined);
     const [aliasDocsVersion, setAliasDocsVersion] = useState<number>(1);
     const [aliasDocsVersionMax, setAliasDocsVersionMax] = useState<number>(1);
@@ -253,6 +256,7 @@ function JsonViewer({ browserTab, browserSubTab, showResolveField = false }: { b
                     <JsonView
                         value={aliasDocs}
                         shortenTextAfterLength={0}
+                        style={jsonViewTheme(darkMode)}
                     >
                         <JsonView.String
                             render={(

--- a/apps/react-wallet/src/components/LightningTab.tsx
+++ b/apps/react-wallet/src/components/LightningTab.tsx
@@ -17,6 +17,9 @@ import { DecodedLightningInvoice, LightningPaymentRecord, LightningPaymentStatus
 import { useWalletContext } from "../contexts/WalletProvider";
 import { useVariablesContext } from "../contexts/VariablesProvider";
 import { useSnackbar } from "../contexts/SnackbarProvider";
+import { Bolt } from "@mui/icons-material";
+import PageHeader from "./layout/PageHeader";
+import EmptyState from "./layout/EmptyState";
 
 const LIGHTNING_PAYMENT_STATUS_CHECKS = 3;
 const LIGHTNING_PAYMENT_STATUS_DELAY_MS = 1000;
@@ -267,10 +270,14 @@ const LightningTab: React.FC = () => {
 
     return (
         <Box>
+            <PageHeader
+                title="Lightning"
+                description="Receive, send and zap sats from this identity's Lightning wallet."
+            />
             <Tabs
                 value={activeTab}
                 onChange={(_, v) => setActiveTab(v)}
-                sx={{ borderBottom: 1, borderColor: "divider", mb: 2 }}
+                sx={{ borderBottom: 1, borderColor: "divider", mb: 2, minHeight: 40 }}
             >
                 <Tab label="Wallet" value="wallet" />
                 <Tab label="Payments" value="payments" />
@@ -284,14 +291,16 @@ const LightningTab: React.FC = () => {
                     {loadingBalance && <CircularProgress size={24} />}
 
                     {!loadingBalance && isConfigured === false && (
-                        <Box>
-                            <Typography sx={{ mb: 2 }}>
-                                No Lightning wallet configured for this identity.
-                            </Typography>
-                            <Button variant="contained" onClick={handleSetupLightning}>
+                        <EmptyState
+                            icon={<Bolt />}
+                            title="No Lightning wallet"
+                            description="Set one up to receive and send sats from this identity."
+                            action={
+                                <Button variant="contained" onClick={handleSetupLightning}>
                                 Set Up Lightning
-                            </Button>
-                        </Box>
+                                </Button>
+                            }
+                        />
                     )}
 
                     {!loadingBalance && isConfigured === true && (

--- a/apps/react-wallet/src/components/PollTab.tsx
+++ b/apps/react-wallet/src/components/PollTab.tsx
@@ -38,6 +38,7 @@ import WarningModal from "../modals/WarningModal";
 import CopyResolveDID from "./CopyResolveDID";
 import DisplayDID from "./DisplayDID";
 import { useThemeContext } from "../contexts/ContextProviders";
+import PageHeader from "./layout/PageHeader";
 
 const PollsTab: React.FC = () => {
     const { keymaster } = useWalletContext();
@@ -435,6 +436,10 @@ const PollsTab: React.FC = () => {
 
     return (
         <Box>
+            <PageHeader
+                title="Polls"
+                description="Create polls, cast ballots and publish results."
+            />
             <WarningModal
                 title="Remove Poll"
                 warningText={`Are you sure you want to remove '${removeName}'?`}

--- a/apps/react-wallet/src/components/PropertiesTab.tsx
+++ b/apps/react-wallet/src/components/PropertiesTab.tsx
@@ -14,6 +14,7 @@ import { useWalletContext } from "../contexts/WalletProvider";
 import { useVariablesContext } from "../contexts/VariablesProvider";
 import { useSnackbar } from "../contexts/SnackbarProvider";
 import WarningModal from "../modals/WarningModal";
+import PageHeader from "./layout/PageHeader";
 
 function PropertiesTab() {
     const { keymaster } = useWalletContext();
@@ -170,6 +171,10 @@ function PropertiesTab() {
 
     return (
         <Box>
+            <PageHeader
+                title="Properties"
+                description="Arbitrary key/value data stored on the selected identity."
+            />
             <WarningModal
                 title="Remove Property"
                 warningText={`Are you sure you want to remove '${deleteKey}'?`}

--- a/apps/react-wallet/src/components/SettingsTab.tsx
+++ b/apps/react-wallet/src/components/SettingsTab.tsx
@@ -9,6 +9,8 @@ import {
     GATEKEEPER_KEY,
 } from "../constants";
 import packageJson from "../../package.json";
+import PageHeader from "./layout/PageHeader";
+import Section from "./layout/Section";
 
 const REFRESH_INTERVAL_STORAGE_KEY = 'ARCHON_REFRESH_INTERVAL_SECONDS';
 const DEFAULT_REFRESH_INTERVAL_SECONDS = 30;
@@ -85,56 +87,65 @@ const SettingsTab = () => {
     };
 
     return (
-        <Box
-            sx={{ display: "flex", flexDirection: "column", maxWidth: "400px", mt: 1 }}
-        >
-            <Box sx={{ display: "flex", flexDirection: "row", alignItems: "center", mb: 2 }}>
-                <Typography>Theme</Typography>
-                <LightMode sx={{ ml: 2, mr: 1 }} />
+        <Box sx={{ maxWidth: 560 }}>
+            <PageHeader
+                title="Settings"
+                description="Appearance, the node this wallet talks to, and how often it refreshes."
+            />
 
-                <Switch
-                    checked={darkMode}
-                    onChange={handleDarkModeToggle}
-                    color="default"
+            <Section title="Appearance">
+                <Box sx={{ display: "flex", flexDirection: "row", alignItems: "center" }}>
+                    <Typography sx={{ flex: 1 }}>Theme</Typography>
+                    <LightMode fontSize="small" sx={{ mr: 1, color: "text.secondary" }} />
+
+                    <Switch
+                        checked={darkMode}
+                        onChange={handleDarkModeToggle}
+                        color="default"
+                    />
+
+                    <DarkMode fontSize="small" sx={{ ml: 1, color: "text.secondary" }} />
+                </Box>
+            </Section>
+
+            <Section title="Connection" description="The Archon node this wallet reads from and writes to.">
+                <TextField
+                    fullWidth
+                    label="Node URL"
+                    variant="outlined"
+                    value={gatekeeperUrl}
+                    onChange={(e) => setGatekeeperUrl(e.target.value)}
+                    sx={{ mb: 2 }}
+                    className="text-field"
                 />
 
-                <DarkMode sx={{ ml: 1 }} />
-            </Box>
+                <TextField
+                    fullWidth
+                    label="Auto-refresh interval (seconds)"
+                    variant="outlined"
+                    type="number"
+                    value={refreshIntervalSeconds}
+                    onChange={(e) => setRefreshIntervalSeconds(e.target.value)}
+                    sx={{ mb: 2 }}
+                    className="text-field"
+                    inputProps={{ min: 0, step: 1 }}
+                    helperText="Set to 0 to disable automatic DMail and poll refresh."
+                />
 
-            <TextField
-                label="Node URL"
-                variant="outlined"
-                value={gatekeeperUrl}
-                onChange={(e) => setGatekeeperUrl(e.target.value)}
-                sx={{ mb: 2 }}
-                className="text-field"
-            />
-
-            <TextField
-                label="Auto-refresh interval (seconds)"
-                variant="outlined"
-                type="number"
-                value={refreshIntervalSeconds}
-                onChange={(e) => setRefreshIntervalSeconds(e.target.value)}
-                sx={{ mb: 2 }}
-                className="text-field"
-                inputProps={{ min: 0, step: 1 }}
-                helperText="Set to 0 to disable automatic DMail and poll refresh."
-            />
-
-            <Button
-                variant="contained"
-                color="primary"
-                onClick={handleSave}
-                startIcon={<Save />}
-                sx={{ alignSelf: "start" }}
-            >
+                <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={handleSave}
+                    startIcon={<Save />}
+                    sx={{ alignSelf: "start" }}
+                >
                 Save
-            </Button>
+                </Button>
+            </Section>
 
-            <Box sx={{ mt: 3, opacity: 0.6 }}>
-                <Typography variant="caption" display="block">
-                    Client v{packageJson.version} | Server v{serverVersion || "..."}
+            <Box sx={{ mt: 1 }}>
+                <Typography variant="caption" color="text.secondary" display="block">
+                    Client v{packageJson.version} &nbsp;·&nbsp; Server v{serverVersion || "..."}
                 </Typography>
             </Box>
         </Box>

--- a/apps/react-wallet/src/components/VaultTab.tsx
+++ b/apps/react-wallet/src/components/VaultTab.tsx
@@ -422,9 +422,8 @@ function VaultTab() {
             </Typography>
             {isVaultItemFile(item) ? (
                 <Button
-                    variant="contained"
+                    variant="outlined"
                     size="small"
-                    color="primary"
                     onClick={() => downloadVaultItem(name)}
                     sx={{ mr: 1 }}
                 >
@@ -432,9 +431,8 @@ function VaultTab() {
                 </Button>
             ) : (
                 <Button
-                    variant="contained"
+                    variant="outlined"
                     size="small"
-                    color="primary"
                     onClick={() => revealVaultItem(name)}
                     sx={{ mr: 1 }}
                 >
@@ -443,9 +441,9 @@ function VaultTab() {
             )}
             {selectedVaultOwned &&
                 <Button
-                    variant="contained"
+                    variant="outlined"
                     size="small"
-                    color="primary"
+                    color="error"
                     onClick={() => removeVaultItem(name)}
                 >
                     Remove

--- a/apps/react-wallet/src/components/WalletTab.tsx
+++ b/apps/react-wallet/src/components/WalletTab.tsx
@@ -14,6 +14,9 @@ import { Filesystem, Directory, Encoding } from "@capacitor/filesystem";
 import { Share } from "@capacitor/share";
 import { FilePicker } from "@capawesome/capacitor-file-picker";
 import { Capacitor } from "@capacitor/core";
+import PageHeader from "./layout/PageHeader";
+import Section from "./layout/Section";
+import ActionMenu from "./layout/ActionMenu";
 
 const WalletTab = () => {
     const [open, setOpen] = useState<boolean>(false);
@@ -315,113 +318,53 @@ const WalletTab = () => {
                     right: 0,
                 }}
             >
-                <Box display="flex" flexDirection="column" alignItems="center">
+                <PageHeader
+                    title="Wallet"
+                    description="Back up, restore and secure the wallet holding your identities."
+                    actions={
+                        <ActionMenu
+                            items={[
+                                { label: "Import wallet", onClick: importWallet },
+                                { label: "New wallet", onClick: handleClickOpen, destructive: true },
+                            ]}
+                        />
+                    }
+                />
 
-                    <Box display="flex" flexDirection="column" sx={{ mb: 2, width: 'max-content' }}>
-                        <Button
-                            className="mini-margin"
-                            variant="contained"
-                            color="primary"
-                            onClick={handleClickOpen}
-                            sx={{ width: '100%', mb: 1 }}
-                        >
-                            New
-                        </Button>
+                <Section
+                    title="Backup and restore"
+                    description="Keep a copy of this wallet somewhere safe, or restore one you already have."
+                >
+                    <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+                        <Button variant="contained" onClick={backupWallet}>Backup</Button>
+                        <Button variant="outlined" onClick={handleRecoverWallet}>Recover</Button>
+                        <Button variant="outlined" onClick={downloadWallet}>Download</Button>
+                        <Button variant="outlined" onClick={handleUploadClick}>Upload</Button>
+                    </Box>
+                </Section>
 
-                        <Button
-                            className="mini-margin"
-                            variant="contained"
-                            color="primary"
-                            onClick={importWallet}
-                            sx={{ width: '100%', mb: 1 }}
-                        >
-                            Import
-                        </Button>
-
-                        <Button
-                            className="mini-margin"
-                            variant="contained"
-                            color="primary"
-                            onClick={backupWallet}
-                            sx={{ width: '100%', mb: 1 }}
-                        >
-                            Backup
-                        </Button>
-
-                        <Button
-                            className="mini-margin"
-                            variant="contained"
-                            color="primary"
-                            onClick={handleRecoverWallet}
-                            sx={{ width: '100%', mb: 1 }}
-                        >
-                            Recover
-                        </Button>
-
-                        <Button
-                            className="mini-margin"
-                            variant="contained"
-                            color="primary"
-                            onClick={checkWallet}
-                            sx={{ width: '100%', mb: 1 }}
-                            disabled={checkingWallet}
-                        >
-                            Check
-                        </Button>
-
-                        {mnemonicString ? (
-                            <Button
-                                className="mini-margin"
-                                variant="contained"
-                                color="primary"
-                                onClick={hideMnemonic}
-                                sx={{ width: '100%', mb: 1 }}
-                            >
-                                Hide Mnemonic
-                            </Button>
-                        ) : (
-                            <Button
-                                className="mini-margin"
-                                variant="contained"
-                                color="primary"
-                                onClick={showMnemonic}
-                                sx={{ width: '100%', mb: 1 }}
-                            >
-                                Show Mnemonic
-                            </Button>
-                        )}
-
-                        <Button
-                            className="mini-margin"
-                            variant="contained"
-                            color="primary"
-                            onClick={() => setShowChangePassphrase(true)}
-                            sx={{ width: '100%', mb: 1 }}
-                        >
+                <Section
+                    title="Security"
+                    description="Your recovery phrase reconstructs this wallet. Only reveal it somewhere private."
+                >
+                    <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+                        <Button variant="contained" onClick={() => setShowChangePassphrase(true)}>
                             Change Passphrase
                         </Button>
-
-                        <Button
-                            className="mini-margin"
-                            variant="contained"
-                            color="primary"
-                            onClick={downloadWallet}
-                            sx={{ width: '100%', mb: 1 }}
-                        >
-                            Download
-                        </Button>
-
-                        <Button
-                            className="mini-margin"
-                            variant="contained"
-                            color="primary"
-                            onClick={handleUploadClick}
-                            sx={{ width: '100%', mb: 1 }}
-                        >
-                            Upload
-                        </Button>
+                        {mnemonicString ? (
+                            <Button variant="outlined" onClick={hideMnemonic}>Hide Mnemonic</Button>
+                        ) : (
+                            <Button variant="outlined" onClick={showMnemonic}>Show Mnemonic</Button>
+                        )}
                     </Box>
-                </Box>
+                </Section>
+
+                <Section
+                    title="Maintenance"
+                    description="Check the wallet for inconsistencies and repair them."
+                >
+                    <Button variant="outlined" onClick={checkWallet} disabled={checkingWallet}>Check</Button>
+                </Section>
 
                 {mnemonicString && (
                     <Box

--- a/apps/react-wallet/src/components/layout/ActionMenu.tsx
+++ b/apps/react-wallet/src/components/layout/ActionMenu.tsx
@@ -1,0 +1,83 @@
+import { ReactNode, useState } from "react";
+import { Button, Divider, ListItemIcon, ListItemText, Menu, MenuItem } from "@mui/material";
+import { MoreHoriz } from "@mui/icons-material";
+
+// Seven equally-weighted contained buttons in a wrapping row was the single
+// loudest thing about these screens: nothing was primary because everything was.
+// Secondary and destructive actions move in here, leaving one primary button
+// visible. Destructive items are separated and coloured so "Remove" is not one
+// mis-click away from "Rename".
+
+export interface ActionMenuItem {
+    label: string;
+    onClick: () => void;
+    icon?: ReactNode;
+    disabled?: boolean;
+    destructive?: boolean;
+}
+
+export default function ActionMenu(
+    {
+        items,
+        label = "Manage",
+    }: {
+        items: ActionMenuItem[];
+        label?: string;
+    }) {
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+    if (!items.length) {
+        return null;
+    }
+
+    const regular = items.filter(item => !item.destructive);
+    const destructive = items.filter(item => item.destructive);
+
+    function run(item: ActionMenuItem) {
+        setAnchorEl(null);
+        item.onClick();
+    }
+
+    function renderItem(item: ActionMenuItem) {
+        return (
+            <MenuItem
+                key={item.label}
+                onClick={() => run(item)}
+                disabled={item.disabled}
+                sx={item.destructive ? { color: "error.main" } : undefined}
+            >
+                {item.icon && (
+                    <ListItemIcon sx={item.destructive ? { color: "error.main" } : undefined}>
+                        {item.icon}
+                    </ListItemIcon>
+                )}
+                <ListItemText>{item.label}</ListItemText>
+            </MenuItem>
+        );
+    }
+
+    return (
+        <>
+            <Button
+                variant="outlined"
+                onClick={(event) => setAnchorEl(event.currentTarget)}
+                endIcon={<MoreHoriz />}
+            >
+                {label}
+            </Button>
+
+            <Menu
+                anchorEl={anchorEl}
+                open={Boolean(anchorEl)}
+                onClose={() => setAnchorEl(null)}
+                anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+                transformOrigin={{ vertical: "top", horizontal: "right" }}
+                slotProps={{ paper: { sx: { minWidth: 200 } } }}
+            >
+                {regular.map(renderItem)}
+                {destructive.length > 0 && regular.length > 0 && <Divider />}
+                {destructive.map(renderItem)}
+            </Menu>
+        </>
+    );
+}

--- a/apps/react-wallet/src/components/layout/ActionMenu.tsx
+++ b/apps/react-wallet/src/components/layout/ActionMenu.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from "react";
+import { ReactNode, useId, useState } from "react";
 import { Button, Divider, ListItemIcon, ListItemText, Menu, MenuItem } from "@mui/material";
 import { MoreHoriz } from "@mui/icons-material";
 
@@ -25,6 +25,10 @@ export default function ActionMenu(
         label?: string;
     }) {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const open = Boolean(anchorEl);
+    const id = useId();
+    const buttonId = `action-menu-button-${id}`;
+    const menuId = `action-menu-${id}`;
 
     if (!items.length) {
         return null;
@@ -62,13 +66,19 @@ export default function ActionMenu(
                 variant="outlined"
                 onClick={(event) => setAnchorEl(event.currentTarget)}
                 endIcon={<MoreHoriz />}
+                id={buttonId}
+                aria-haspopup="menu"
+                aria-expanded={open ? true : undefined}
+                aria-controls={open ? menuId : undefined}
             >
                 {label}
             </Button>
 
             <Menu
+                id={menuId}
                 anchorEl={anchorEl}
-                open={Boolean(anchorEl)}
+                open={open}
+                MenuListProps={{ "aria-labelledby": buttonId }}
                 onClose={() => setAnchorEl(null)}
                 anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
                 transformOrigin={{ vertical: "top", horizontal: "right" }}

--- a/apps/react-wallet/src/components/layout/EmptyState.tsx
+++ b/apps/react-wallet/src/components/layout/EmptyState.tsx
@@ -1,0 +1,67 @@
+import { ReactNode } from "react";
+import { Box, Typography } from "@mui/material";
+
+// "No DID document available for the current identity." was previously a bare
+// line of grey text sitting where content would be. An empty state is a
+// deliberate composition instead: a mark, a sentence, and the one action that
+// resolves it.
+
+export default function EmptyState(
+    {
+        icon,
+        title,
+        description,
+        action,
+    }: {
+        icon?: ReactNode;
+        title: string;
+        description?: string;
+        action?: ReactNode;
+    }) {
+    return (
+        <Box
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                textAlign: "center",
+                gap: 1,
+                px: 3,
+                py: 6,
+            }}
+        >
+            {icon && (
+                <Box
+                    sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        width: 40,
+                        height: 40,
+                        mb: 0.5,
+                        borderRadius: 2,
+                        border: 1,
+                        borderColor: "divider",
+                        color: "text.secondary",
+                        "& svg": { fontSize: 20 },
+                    }}
+                >
+                    {icon}
+                </Box>
+            )}
+
+            <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                {title}
+            </Typography>
+
+            {description && (
+                <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 360 }}>
+                    {description}
+                </Typography>
+            )}
+
+            {action && <Box sx={{ mt: 1.5 }}>{action}</Box>}
+        </Box>
+    );
+}

--- a/apps/react-wallet/src/components/layout/PageHeader.tsx
+++ b/apps/react-wallet/src/components/layout/PageHeader.tsx
@@ -1,0 +1,51 @@
+import { ReactNode } from "react";
+import { Box, Typography } from "@mui/material";
+
+// Every screen in this app used to open straight into a row of buttons, with no
+// title and nothing to say what the screen was for. A header gives each screen a
+// name, one line of orientation, and exactly one primary action -- which is what
+// lets every other action be demoted instead of competing.
+
+export default function PageHeader(
+    {
+        title,
+        description,
+        actions,
+    }: {
+        title: string;
+        description?: string;
+        actions?: ReactNode;
+    }) {
+    return (
+        <Box
+            sx={{
+                display: "flex",
+                alignItems: "flex-start",
+                justifyContent: "space-between",
+                gap: 2,
+                flexWrap: "wrap",
+                pb: 2.5,
+                mb: 3,
+                borderBottom: 1,
+                borderColor: "divider",
+            }}
+        >
+            <Box sx={{ minWidth: 0 }}>
+                <Typography variant="h3" sx={{ mb: description ? 0.5 : 0 }}>
+                    {title}
+                </Typography>
+                {description && (
+                    <Typography variant="body2" color="text.secondary">
+                        {description}
+                    </Typography>
+                )}
+            </Box>
+
+            {actions && (
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexShrink: 0 }}>
+                    {actions}
+                </Box>
+            )}
+        </Box>
+    );
+}

--- a/apps/react-wallet/src/components/layout/PageHeader.tsx
+++ b/apps/react-wallet/src/components/layout/PageHeader.tsx
@@ -31,7 +31,10 @@ export default function PageHeader(
             }}
         >
             <Box sx={{ minWidth: 0 }}>
-                <Typography variant="h3" sx={{ mb: description ? 0.5 : 0 }}>
+                {/* h3 is the visual size; h1 is the document level. MUI maps
+                    variant to element by default, which would open every page
+                    at level 3 with no h1 for screen-reader navigation. */}
+                <Typography variant="h3" component="h1" sx={{ mb: description ? 0.5 : 0 }}>
                     {title}
                 </Typography>
                 {description && (

--- a/apps/react-wallet/src/components/layout/Section.tsx
+++ b/apps/react-wallet/src/components/layout/Section.tsx
@@ -41,7 +41,9 @@ export default function Section(
                     }}
                 >
                     <Box sx={{ minWidth: 0 }}>
-                        {title && <Typography variant="h6">{title}</Typography>}
+                        {/* Visual size h6, document level h2: sections sit
+                            directly beneath the page title. */}
+                        {title && <Typography variant="h6" component="h2">{title}</Typography>}
                         {description && (
                             <Typography variant="body2" color="text.secondary" sx={{ mt: 0.25 }}>
                                 {description}

--- a/apps/react-wallet/src/components/layout/Section.tsx
+++ b/apps/react-wallet/src/components/layout/Section.tsx
@@ -1,0 +1,62 @@
+import { ReactNode } from "react";
+import { Box, Paper, Typography } from "@mui/material";
+
+// The unit that replaces flat <Box> stacks. Related controls live inside a
+// bordered panel with a name, so a screen reads as a few labelled groups rather
+// than one undifferentiated column of inputs and buttons.
+//
+// `dense` drops the inner padding for content that brings its own -- tables and
+// the JSON viewer, which look wrong inset twice.
+
+export default function Section(
+    {
+        title,
+        description,
+        actions,
+        dense,
+        children,
+    }: {
+        title?: string;
+        description?: string;
+        actions?: ReactNode;
+        dense?: boolean;
+        children: ReactNode;
+    }) {
+    const hasHeader = Boolean(title || actions);
+
+    return (
+        <Paper variant="outlined" sx={{ overflow: "hidden", mb: 2 }}>
+            {hasHeader && (
+                <Box
+                    sx={{
+                        display: "flex",
+                        alignItems: "flex-start",
+                        justifyContent: "space-between",
+                        gap: 2,
+                        flexWrap: "wrap",
+                        px: 2,
+                        py: 1.5,
+                        borderBottom: 1,
+                        borderColor: "divider",
+                    }}
+                >
+                    <Box sx={{ minWidth: 0 }}>
+                        {title && <Typography variant="h6">{title}</Typography>}
+                        {description && (
+                            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.25 }}>
+                                {description}
+                            </Typography>
+                        )}
+                    </Box>
+                    {actions && (
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexShrink: 0 }}>
+                            {actions}
+                        </Box>
+                    )}
+                </Box>
+            )}
+
+            <Box sx={{ p: dense ? 0 : 2 }}>{children}</Box>
+        </Paper>
+    );
+}

--- a/apps/react-wallet/src/components/layout/jsonViewTheme.ts
+++ b/apps/react-wallet/src/components/layout/jsonViewTheme.ts
@@ -1,0 +1,13 @@
+import { githubDarkTheme } from "@uiw/react-json-view/githubDark";
+import { githubLightTheme } from "@uiw/react-json-view/githubLight";
+
+// @uiw/react-json-view ships its own palette and defaults to a light one, so on
+// a dark surface it renders dark text on dark background -- unreadable, and not
+// something the MUI theme can reach. Pick the matching theme explicitly.
+//
+// The background is dropped so the viewer sits on whatever Section or Paper
+// contains it, instead of punching its own slab of colour through the layout.
+export function jsonViewTheme(isDark: boolean) {
+    const theme = isDark ? githubDarkTheme : githubLightTheme;
+    return { ...theme, backgroundColor: "transparent" };
+}

--- a/apps/react-wallet/src/contexts/ContextProviders.tsx
+++ b/apps/react-wallet/src/contexts/ContextProviders.tsx
@@ -2,8 +2,9 @@ import React, { createContext, ReactNode, useContext, useEffect, useState } from
 import { WalletProvider } from "./WalletProvider";
 import { VariablesProvider } from "./VariablesProvider";
 import { UIProvider } from "./UIContext";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
-import { Box, useMediaQuery } from "@mui/material";
+import { ThemeProvider } from "@mui/material/styles";
+import { Box, CssBaseline, useMediaQuery } from "@mui/material";
+import { createAppTheme } from "../theme";
 import { SafeAreaProvider } from "./SafeAreaContext";
 import { SnackbarProvider } from "./SnackbarProvider";
 
@@ -28,11 +29,7 @@ export function ContextProviders(
     const [darkMode, setDarkMode] = useState<boolean>(false);
     const THEME_KEY = 'themeMode';
 
-    const theme = createTheme({
-        palette: {
-            mode: darkMode ? 'dark' : 'light',
-        },
-    });
+    const theme = createAppTheme(darkMode);
 
     function handleDarkModeToggle(event: React.ChangeEvent<HTMLInputElement>) {
         const isDark = event.target.checked;
@@ -68,6 +65,7 @@ export function ContextProviders(
     return (
         <ThemeContext.Provider value={value}>
             <ThemeProvider theme={theme}>
+                <CssBaseline />
                 <Box
                     sx={{
                         width: "100%",

--- a/apps/react-wallet/src/main.tsx
+++ b/apps/react-wallet/src/main.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import ReactDOM from "react-dom/client";
 import BrowserContent from "./BrowserContent";
 import { ContextProviders } from "./contexts/ContextProviders";
+import "@fontsource-variable/inter";
 import "./extension.css";
 import "./utils/polyfills";
 import { App } from '@capacitor/app';

--- a/apps/react-wallet/src/theme.ts
+++ b/apps/react-wallet/src/theme.ts
@@ -8,12 +8,12 @@ import { createTheme, ThemeOptions } from "@mui/material/styles";
 // whole app restyles at once and the change is reverted by dropping this file
 // and restoring the two-line createTheme call in ContextProviders.
 
-// Inter is the typeface this look is built around. It is not a dependency yet,
-// so the stack falls through to the platform UI font, which is close in
-// proportion. Adding `@fontsource/inter` and importing it in main.tsx is the
-// single highest-fidelity follow-up.
+// Inter is the typeface this look is built around, loaded as a variable font in
+// main.tsx. The rest of the stack is the fallback path if it fails to load.
 const FONT_STACK = [
-    "InterVariable",
+    // Exactly as @fontsource-variable/inter registers it: the space matters,
+    // and a mismatch here fails silently by falling through to the next font.
+    "Inter Variable",
     "Inter",
     "system-ui",
     "-apple-system",

--- a/apps/react-wallet/src/theme.ts
+++ b/apps/react-wallet/src/theme.ts
@@ -1,0 +1,334 @@
+import { createTheme, ThemeOptions } from "@mui/material/styles";
+
+// Theme-only restyle in the Linear/Vercel idiom: near-black surfaces, high
+// contrast text against muted secondary text, hairline borders instead of
+// drop shadows, tight radii, dense type, and no shouting uppercase.
+//
+// Everything here is theme configuration. No component file is touched, so the
+// whole app restyles at once and the change is reverted by dropping this file
+// and restoring the two-line createTheme call in ContextProviders.
+
+// Inter is the typeface this look is built around. It is not a dependency yet,
+// so the stack falls through to the platform UI font, which is close in
+// proportion. Adding `@fontsource/inter` and importing it in main.tsx is the
+// single highest-fidelity follow-up.
+const FONT_STACK = [
+    "InterVariable",
+    "Inter",
+    "system-ui",
+    "-apple-system",
+    "Segoe UI",
+    "Roboto",
+    "Helvetica Neue",
+    "Arial",
+    "sans-serif",
+].join(", ");
+
+const MONO_STACK = [
+    "ui-monospace",
+    "SFMono-Regular",
+    "Menlo",
+    "Monaco",
+    "Consolas",
+    "Liberation Mono",
+    "monospace",
+].join(", ");
+
+const dark = {
+    // Layered near-blacks rather than grey. The gap between default and paper
+    // is what gives depth once shadows are removed.
+    bg: "#08090A",
+    surface: "#0F1011",
+    surfaceRaised: "#151617",
+    border: "rgba(255, 255, 255, 0.09)",
+    borderStrong: "rgba(255, 255, 255, 0.16)",
+    text: "#F7F8F8",
+    textMuted: "#8A8F98",
+    accent: "#6E79D6",
+    accentHover: "#828CE0",
+};
+
+const light = {
+    bg: "#FFFFFF",
+    surface: "#FFFFFF",
+    surfaceRaised: "#FAFAFA",
+    border: "rgba(0, 0, 0, 0.09)",
+    borderStrong: "rgba(0, 0, 0, 0.16)",
+    text: "#08090A",
+    textMuted: "#60646C",
+    accent: "#5E6AD2",
+    accentHover: "#4C57BE",
+};
+
+// This idiom is nearly shadowless: separation comes from borders and surface
+// layering. MUI requires all 25 slots, so the low elevations are near-invisible
+// and only overlays (menus, dialogs) get anything real.
+function shadows(isDark: boolean): ThemeOptions["shadows"] {
+    const soft = isDark ? "rgba(0, 0, 0, 0.6)" : "rgba(15, 23, 42, 0.08)";
+    const hard = isDark ? "rgba(0, 0, 0, 0.8)" : "rgba(15, 23, 42, 0.14)";
+    const overlay = `0 8px 24px ${soft}, 0 2px 6px ${hard}`;
+    const raised = `0 16px 48px ${soft}, 0 4px 12px ${hard}`;
+
+    return [
+        "none",
+        `0 1px 2px ${soft}`,
+        `0 1px 3px ${soft}`,
+        overlay,
+        overlay,
+        overlay,
+        overlay,
+        overlay,
+        raised,
+        ...Array(16).fill(raised),
+    ] as ThemeOptions["shadows"];
+}
+
+export function createAppTheme(isDark: boolean) {
+    const c = isDark ? dark : light;
+
+    return createTheme({
+        palette: {
+            mode: isDark ? "dark" : "light",
+            primary: { main: c.accent, dark: c.accentHover, contrastText: "#FFFFFF" },
+            background: { default: c.bg, paper: c.surface },
+            text: { primary: c.text, secondary: c.textMuted },
+            divider: c.border,
+            success: { main: isDark ? "#4CB782" : "#3E9E6E" },
+            warning: { main: isDark ? "#F2C94C" : "#C99A16" },
+            error: { main: isDark ? "#EB5757" : "#D64545" },
+        },
+
+        shape: { borderRadius: 8 },
+        shadows: shadows(isDark),
+
+        typography: {
+            fontFamily: FONT_STACK,
+            // 14px base: this idiom runs denser than Material's 16px default.
+            fontSize: 14,
+            // Negative tracking on display sizes is most of what separates a
+            // "designed" heading from a default one.
+            h1: { fontSize: "2rem", fontWeight: 600, letterSpacing: "-0.02em", lineHeight: 1.2 },
+            h2: { fontSize: "1.5rem", fontWeight: 600, letterSpacing: "-0.02em", lineHeight: 1.25 },
+            h3: { fontSize: "1.25rem", fontWeight: 600, letterSpacing: "-0.015em", lineHeight: 1.3 },
+            h4: { fontSize: "1.125rem", fontWeight: 600, letterSpacing: "-0.01em" },
+            h5: { fontSize: "1rem", fontWeight: 600, letterSpacing: "-0.01em" },
+            h6: { fontSize: "0.9375rem", fontWeight: 600, letterSpacing: "-0.005em" },
+            body1: { fontSize: "0.875rem", lineHeight: 1.6 },
+            body2: { fontSize: "0.8125rem", lineHeight: 1.6, color: c.textMuted },
+            button: { textTransform: "none", fontWeight: 500, letterSpacing: 0 },
+            caption: { fontSize: "0.75rem", color: c.textMuted },
+        },
+
+        components: {
+            MuiCssBaseline: {
+                styleOverrides: {
+                    body: {
+                        backgroundColor: c.bg,
+                        color: c.text,
+                        WebkitFontSmoothing: "antialiased",
+                        MozOsxFontSmoothing: "grayscale",
+                    },
+                    // Default scrollbars are a giveaway on dark surfaces.
+                    "*::-webkit-scrollbar": { width: 10, height: 10 },
+                    "*::-webkit-scrollbar-track": { background: "transparent" },
+                    "*::-webkit-scrollbar-thumb": {
+                        backgroundColor: c.borderStrong,
+                        borderRadius: 8,
+                        border: `2px solid ${c.bg}`,
+                    },
+                    "*::-webkit-scrollbar-thumb:hover": { backgroundColor: c.textMuted },
+                    "::selection": { backgroundColor: `${c.accent}55` },
+                    code: { fontFamily: MONO_STACK, fontSize: "0.85em" },
+                },
+            },
+
+            MuiPaper: {
+                styleOverrides: {
+                    root: {
+                        // MUI lightens dark paper with a gradient overlay per
+                        // elevation; that grey wash is exactly what this look
+                        // avoids. Flat surface plus a hairline border instead.
+                        backgroundImage: "none",
+                        border: `1px solid ${c.border}`,
+                    },
+                    // Menus and dialogs float, so they keep a real shadow.
+                    elevation0: { border: "none" },
+                },
+            },
+
+            MuiAppBar: {
+                defaultProps: { elevation: 0, color: "transparent" },
+                styleOverrides: {
+                    root: {
+                        backgroundColor: c.bg,
+                        borderBottom: `1px solid ${c.border}`,
+                        backgroundImage: "none",
+                    },
+                },
+            },
+
+            MuiButton: {
+                defaultProps: { disableElevation: true },
+                styleOverrides: {
+                    root: {
+                        borderRadius: 8,
+                        paddingInline: 14,
+                        minHeight: 34,
+                        transition: "background-color 120ms ease, border-color 120ms ease",
+                    },
+                    contained: {
+                        "&:hover": { backgroundColor: c.accentHover },
+                    },
+                    outlined: {
+                        borderColor: c.border,
+                        "&:hover": {
+                            borderColor: c.borderStrong,
+                            backgroundColor: isDark ? "rgba(255,255,255,0.04)" : "rgba(0,0,0,0.03)",
+                        },
+                    },
+                    text: {
+                        "&:hover": {
+                            backgroundColor: isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.04)",
+                        },
+                    },
+                },
+            },
+
+            MuiIconButton: {
+                styleOverrides: {
+                    root: {
+                        borderRadius: 8,
+                        "&:hover": {
+                            backgroundColor: isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.04)",
+                        },
+                    },
+                },
+            },
+
+            MuiOutlinedInput: {
+                styleOverrides: {
+                    root: {
+                        backgroundColor: isDark ? "rgba(255,255,255,0.03)" : "rgba(0,0,0,0.015)",
+                        "& .MuiOutlinedInput-notchedOutline": { borderColor: c.border },
+                        "&:hover .MuiOutlinedInput-notchedOutline": { borderColor: c.borderStrong },
+                        "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+                            borderColor: c.accent,
+                            borderWidth: 1,
+                        },
+                    },
+                    input: { fontSize: "0.875rem" },
+                },
+            },
+
+            MuiTab: {
+                styleOverrides: {
+                    root: {
+                        textTransform: "none",
+                        fontWeight: 500,
+                        fontSize: "0.8125rem",
+                        letterSpacing: 0,
+                        minHeight: 40,
+                        borderRadius: 6,
+                        color: c.textMuted,
+                        "&.Mui-selected": { color: c.text },
+                    },
+                },
+            },
+
+            MuiTabs: {
+                styleOverrides: {
+                    // The sliding underline is a Material tell. A selected-row
+                    // treatment suits the sidebar this app already uses.
+                    indicator: {
+                        backgroundColor: c.accent,
+                        borderRadius: 2,
+                    },
+                },
+            },
+
+            MuiBottomNavigation: {
+                styleOverrides: {
+                    root: {
+                        backgroundColor: c.surface,
+                        borderTop: `1px solid ${c.border}`,
+                    },
+                },
+            },
+
+            MuiBottomNavigationAction: {
+                styleOverrides: {
+                    root: {
+                        color: c.textMuted,
+                        "&.Mui-selected": { color: c.text },
+                    },
+                    label: { fontSize: "0.6875rem", "&.Mui-selected": { fontSize: "0.6875rem" } },
+                },
+            },
+
+            MuiChip: {
+                styleOverrides: {
+                    root: {
+                        borderRadius: 6,
+                        fontWeight: 500,
+                        fontSize: "0.75rem",
+                        height: 24,
+                    },
+                    outlined: { borderColor: c.border },
+                },
+            },
+
+            MuiDivider: {
+                styleOverrides: { root: { borderColor: c.border } },
+            },
+
+            MuiTooltip: {
+                styleOverrides: {
+                    tooltip: {
+                        backgroundColor: isDark ? c.surfaceRaised : "#1A1B1D",
+                        border: `1px solid ${c.border}`,
+                        fontSize: "0.75rem",
+                        borderRadius: 6,
+                        padding: "6px 10px",
+                    },
+                },
+            },
+
+            MuiDialog: {
+                styleOverrides: {
+                    paper: { borderRadius: 12, border: `1px solid ${c.border}` },
+                },
+            },
+
+            MuiMenu: {
+                styleOverrides: {
+                    paper: { borderRadius: 8, border: `1px solid ${c.border}` },
+                },
+            },
+
+            MuiMenuItem: {
+                styleOverrides: {
+                    root: { fontSize: "0.8125rem", borderRadius: 6, marginInline: 4 },
+                },
+            },
+
+            MuiListItemButton: {
+                styleOverrides: { root: { borderRadius: 6 } },
+            },
+
+            MuiTableCell: {
+                styleOverrides: {
+                    root: { borderColor: c.border, fontSize: "0.8125rem" },
+                    head: { fontWeight: 600, color: c.textMuted },
+                },
+            },
+
+            MuiTextField: {
+                defaultProps: { size: "small" },
+            },
+
+            MuiSelect: {
+                defaultProps: { size: "small" },
+            },
+        },
+    });
+}

--- a/apps/react-wallet/src/theme.ts
+++ b/apps/react-wallet/src/theme.ts
@@ -89,7 +89,15 @@ export function createAppTheme(isDark: boolean) {
     return createTheme({
         palette: {
             mode: isDark ? "dark" : "light",
-            primary: { main: c.accent, dark: c.accentHover, contrastText: "#FFFFFF" },
+            // White on the dark-mode accent is only ~3.9:1 (and ~3.1:1 on hover),
+            // under the 4.5:1 needed at this text size. The bright accent is
+            // right against near-black surfaces, so the label goes dark instead
+            // of the accent going muddy: 5.1:1 and 6.4:1.
+            primary: {
+                main: c.accent,
+                dark: c.accentHover,
+                contrastText: isDark ? "#08090A" : "#FFFFFF",
+            },
             background: { default: c.bg, paper: c.surface },
             text: { primary: c.text, secondary: c.textMuted },
             divider: c.border,
@@ -176,7 +184,11 @@ export function createAppTheme(isDark: boolean) {
                         minHeight: 34,
                         transition: "background-color 120ms ease, border-color 120ms ease",
                     },
-                    contained: {
+                    // Scoped to primary: applied to every contained button this
+                    // repainted error and warning buttons with the accent on
+                    // hover, dropping the destructive signal exactly when the
+                    // pointer is on the control.
+                    containedPrimary: {
                         "&:hover": { backgroundColor: c.accentHover },
                     },
                     outlined: {


### PR DESCRIPTION
## Why it looked dated

Not stale tooling — MUI 7, React 19 and Vite 8 are all current. The entire theme was:

```ts
createTheme({ palette: { mode: darkMode ? 'dark' : 'light' } })
```

No palette, no type scale, no radii, no component overrides. Every screen rendered **stock Material defaults** — default blue, 4px corners, elevation shadows — which reads as "MUI with the theme left untouched", and MUI's defaults are still anchored to Material Design 2.

**Theming alone did not fix it.** A first pass changed only tokens, and the result was accurately described as "a dark mode version of the plain UI." The real problem was composition: across 12 tabs and ~11,000 lines there were **zero page headings and zero Cards**. Every screen was a flat `Box` stack opening onto a wrapping row of equally-weighted contained buttons — nothing primary, because everything was.

So this PR is two things.

## 1. A theme (`src/theme.ts`)

Linear/Vercel idiom: layered near-blacks, hairline borders instead of drop shadows, dense 14px type scale with negative tracking on headings, tighter radii, no uppercase buttons, restyled scrollbars.

The load-bearing detail is `backgroundImage: none` on `Paper` — MUI lightens dark surfaces with a per-elevation gradient, and that grey wash is one of the strongest unthemed-MUI tells.

## 2. Four layout primitives (`components/layout/`)

`PageHeader`, `Section`, `EmptyState`, `ActionMenu` — ~200 lines, and the thing that actually creates hierarchy.

**Applied across the app:**

- **Every top-level screen** now has a title and a line of orientation (previously: none had one)
- **IdentitiesTab** — seven equal buttons → one primary + a "Manage" menu, with **Remove separated and coloured destructive**; it previously sat one mis-click from Rename, styled identically. Panels became labelled sections with real empty states.
- **WalletTab** — a centred column of ten identical full-width buttons → three grouped sections. "New wallet" is demoted and marked destructive, since it overwrites the existing wallet.
- **HeldTab** — each credential row carried **six** outlined buttons across two rows; now one `Resolve` + a menu, each credential its own card.
- **SettingsTab**, **LightningTab** — grouped, with empty states.

Sub-tab children (`HeldTab`/`IssuedTab` inside `CredentialsTab`; asset tabs inside `AssetsTab`) deliberately get **no** header of their own, so headers don't nest.

## Two bugs fixed in passing

- **`CssBaseline` was never mounted**, so the themed background never reached `<body>` — dark mode left a white page behind the app.
- The avatar tile hardcoded `bgcolor: "grey.50"`, which goes muddy on dark.

Also worth noting: `@fontsource/roboto` is a dependency that is **never imported**, so the app has been falling through to platform fonts regardless.

## Behaviour

Unchanged. Handler reference counts were compared before/after on both files where whole blocks were replaced — IdentitiesTab (18 handlers) and HeldTab (9) — and are identical. tsc, eslint and the build are clean.

One binding *was* dropped mid-way (`checkingWallet` on WalletTab's Check button) and restored; tsc caught it as an unused variable. Worth knowing that's the failure mode for this kind of refactor — a lost `disabled` prop only surfaces if the variable becomes entirely unused.

## Not done yet

`DmailTab`, `PollTab`, `VaultTab` and `AuthTab` have headers but still have their internal button walls. Follow-up commits to this branch.

## Reviewing

This is a visual change and CI cannot judge it. Worth running `cd apps/react-wallet && npm run dev` and toggling dark mode in Settings — dark is where this idiom lives.

Inter is the typeface the theme is built around and is **not** a dependency; the stack falls through to `system-ui`. Adding `@fontsource/inter` plus one import is the highest-fidelity follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)