### PR TITLE
feat: Serve the node's own explorer publicly at /explorer

### DIFF
--- a/docker/Dockerfile.explorer
+++ b/docker/Dockerfile.explorer
@@ -23,6 +23,14 @@ COPY services/explorer ./explorer/
 WORKDIR /app/explorer
 
 RUN npm i
+
+# Vite bakes the base into the bundle, so it has to be set for the build -- a
+# runtime-only value would move the express mount while the assets stayed baked
+# at the old prefix. Carried into ENV as well so server.js mounts at the same
+# place it was built for.
+ARG VITE_EXPLORER_BASE=/explorer/
+ENV VITE_EXPLORER_BASE=$VITE_EXPLORER_BASE
+
 RUN npm run build
 
 ARG GIT_COMMIT=unknown

--- a/docker/compose/drawbridge.yml
+++ b/docker/compose/drawbridge.yml
@@ -130,9 +130,7 @@ services:
       - ARCHON_DRAWBRIDGE_DIDCOMM_DEPOSIT_GLOBAL_BYTES=${ARCHON_DRAWBRIDGE_DIDCOMM_DEPOSIT_GLOBAL_BYTES:-67108864}
       - ARCHON_DRAWBRIDGE_DIDCOMM_RATE_LIMIT_WINDOW=${ARCHON_DRAWBRIDGE_DIDCOMM_RATE_LIMIT_WINDOW:-60}
       - ARCHON_HERALD_URL=${ARCHON_HERALD_URL-http://herald:4230}
-      # Empty unless the explorer profile is enabled, in which case /explorer
-      # proxies to it; otherwise Drawbridge answers 501 there.
-      - ARCHON_EXPLORER_URL=${ARCHON_EXPLORER_URL-}
+      - ARCHON_EXPLORER_URL=${ARCHON_EXPLORER_URL-http://explorer:4000}
     user: "${ARCHON_UID}:${ARCHON_GID}"
     ports:
       - ${ARCHON_DRAWBRIDGE_PORT:-4222}:4222

--- a/docker/compose/drawbridge.yml
+++ b/docker/compose/drawbridge.yml
@@ -130,6 +130,9 @@ services:
       - ARCHON_DRAWBRIDGE_DIDCOMM_DEPOSIT_GLOBAL_BYTES=${ARCHON_DRAWBRIDGE_DIDCOMM_DEPOSIT_GLOBAL_BYTES:-67108864}
       - ARCHON_DRAWBRIDGE_DIDCOMM_RATE_LIMIT_WINDOW=${ARCHON_DRAWBRIDGE_DIDCOMM_RATE_LIMIT_WINDOW:-60}
       - ARCHON_HERALD_URL=${ARCHON_HERALD_URL-http://herald:4230}
+      # Empty unless the explorer profile is enabled, in which case /explorer
+      # proxies to it; otherwise Drawbridge answers 501 there.
+      - ARCHON_EXPLORER_URL=${ARCHON_EXPLORER_URL-}
     user: "${ARCHON_UID}:${ARCHON_GID}"
     ports:
       - ${ARCHON_DRAWBRIDGE_PORT:-4222}:4222

--- a/docker/compose/explorer.yml
+++ b/docker/compose/explorer.yml
@@ -6,11 +6,15 @@ services:
       dockerfile: docker/Dockerfile.explorer
       args:
         GIT_COMMIT: ${GIT_COMMIT:-unknown}
+        # Must match the runtime value below: this one is baked into the bundle's
+        # asset URLs, the other decides where express mounts it.
+        VITE_EXPLORER_BASE: ${VITE_EXPLORER_BASE:-/explorer/}
     image: ghcr.io/archetech/explorer
     environment:
       - VITE_EXPLORER_PORT=4000
-      # Path prefix the bundle is built with and the server mounts at. Must match
-      # the Drawbridge route, which preserves the prefix rather than stripping it.
+      # Where express mounts the app. Kept in step with the build arg above; the
+      # Drawbridge route preserves this prefix rather than stripping it, so
+      # changing it means changing that route too.
       - VITE_EXPLORER_BASE=${VITE_EXPLORER_BASE:-/explorer/}
       # Resolved at runtime and handed to the browser, so a publicly served
       # explorer points visitors at this node rather than their own loopback.

--- a/docker/compose/explorer.yml
+++ b/docker/compose/explorer.yml
@@ -9,6 +9,14 @@ services:
     image: ghcr.io/archetech/explorer
     environment:
       - VITE_EXPLORER_PORT=4000
+      # Path prefix the bundle is built with and the server mounts at. Must match
+      # the Drawbridge route, which preserves the prefix rather than stripping it.
+      - VITE_EXPLORER_BASE=${VITE_EXPLORER_BASE:-/explorer/}
+      # Resolved at runtime and handed to the browser, so a publicly served
+      # explorer points visitors at this node rather than their own loopback.
+      # Default to the node's public gatekeeper surface when one is configured.
+      - ARCHON_EXPLORER_GATEKEEPER_URL=${ARCHON_EXPLORER_GATEKEEPER_URL:-${ARCHON_DRAWBRIDGE_PUBLIC_HOST:-http://localhost:4224}}
+      - ARCHON_EXPLORER_SEARCH_URL=${ARCHON_EXPLORER_SEARCH_URL:-${ARCHON_DRAWBRIDGE_PUBLIC_HOST:-http://localhost:4224}}
       - VITE_GATEKEEPER_URL=http://localhost:4224
       - VITE_SEARCH_SERVER=http://localhost:4224
       - VITE_OPERATION_NETWORKS=hyperswarm,local,BTC:signet,BTC:testnet4,ZEC:mainnet

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -481,6 +481,7 @@ Drawbridge and the services it fronts are separate profiles, each named after wh
 | `drawbridge` | `drawbridge`, `drawbridge-client` | The front-door proxy itself |
 | `lightning` | `lightning-mediator` + the Lightning rail (CLN, LNbits, RTL, init containers) | L402 paywall, zaps, `/invoice/:did` |
 | `herald` | `herald`, `herald-client` | `/names/*`, `/.well-known/*` |
+| `explorer` | `explorer` | `/explorer` — the node's own DID explorer, which Herald links to |
 | `tor` | `tor` | Onion hidden service |
 
 The full stack — the same service set the single `drawbridge` profile used to give:
@@ -496,10 +497,13 @@ COMPOSE_PROFILES=hyperswarm,didcomm,drawbridge
 ARCHON_DIDCOMM_URL=http://didcomm:4236
 ARCHON_LIGHTNING_MEDIATOR_URL=
 ARCHON_HERALD_URL=
+ARCHON_EXPLORER_URL=
 ARCHON_DIDCOMM_TOR_PROXY=
 ```
 
-**Blanking the two upstream URLs is required, not optional.** Drawbridge decides what it offers from the URLs, not from the profiles: `ARCHON_LIGHTNING_MEDIATOR_URL` or `ARCHON_HERALD_URL` left at its default makes `GET /api/v1/capabilities` advertise the service and the proxy routes attempt a connection to a container that is not running. Empty means the capability reports `false` and the route returns HTTP 501.
+**Blanking the unused upstream URLs is required, not optional.** Drawbridge decides what it offers from the URLs, not from the profiles: `ARCHON_LIGHTNING_MEDIATOR_URL`, `ARCHON_HERALD_URL` or `ARCHON_EXPLORER_URL` left at its default makes `GET /api/v1/capabilities` advertise the service and the proxy routes attempt a connection to a container that is not running. Empty means the capability reports `false` and the route returns HTTP 501.
+
+`ARCHON_EXPLORER_URL` has a further consequence: Herald links to `<public host>/explorer` by default, so leaving it set without the `explorer` profile gives every visitor a broken link from the identity pages. Either run the profile or set `ARCHON_HERALD_EXPLORER_URL` to a reachable explorer — or empty, to hide the links.
 
 `ARCHON_DIDCOMM_TOR_PROXY` is **not** a Drawbridge capability variable and behaves differently. It is read by the DIDComm relay, and the `didcomm` capability stays enabled either way via `ARCHON_DIDCOMM_URL`. Blanking it affects only `.onion` delivery, which then returns HTTP 502 naming the unset variable instead of failing to dial a Tor container that is not running.
 

--- a/docs/services/drawbridge/README.md
+++ b/docs/services/drawbridge/README.md
@@ -88,6 +88,7 @@ Binds to `${ARCHON_BIND_ADDRESS}:${ARCHON_DRAWBRIDGE_PORT}` (default
 | `*` | `/didcomm/**` | Forwarded to the local DIDComm relay (path prefix `/didcomm` stripped). Carries the relay's own routes (mailbox `messages/*`, signed-`challenge`, egress `deliver`). Not paywalled — DIDComm authenticates with its own signed challenge. **501** if DIDComm is disabled. `application/didcomm-encrypted+json` bodies are captured as text and forwarded verbatim. |
 | `GET` | `/.well-known/*` | Forwarded to Herald (e.g. `lnurlp/<name>`, `webfinger`, `names`). |
 | `GET\|POST\|PUT\|DELETE` | `/names/*` | Forwarded to Herald (`/api/*`). **501** if name resolution is disabled. |
+| `GET` | `/explorer/**` | Forwarded to the node's own DID explorer. **501** if the explorer is disabled. Unlike the routes above, the `/explorer` prefix is **not** stripped: the explorer's bundle is built with `base=/explorer/` and the app is mounted there, so the prefix has to survive the hop or its asset URLs point somewhere the upstream no longer answers. |
 | `*` | `/1.0/identifiers/**` | Forwarded verbatim to the Gatekeeper's standards-conformant DID resolution / dereferencing surface (`/1.0/identifiers/:did`, `/:did/data`, `/:did/registration`; see [Gatekeeper spec §2.6](../gatekeeper/README.md)). **Not paywalled** — public DID resolution for interop with universal resolvers, which do not speak L402. Proxied unchanged (no prefix stripped), so the Gatekeeper's resolution triple, raw dereferenced resources, and status/error shapes pass through intact. |
 | `GET` | `/metrics` | Prometheus exposition. |
 
@@ -477,6 +478,7 @@ shared with the reference TypeScript service.
 | `ARCHON_GATEKEEPER_URL` | `http://localhost:4224` | Upstream Gatekeeper. |
 | `ARCHON_HERALD_URL` | `http://localhost:4230` | Upstream Herald (for `/.well-known/*` and `/names/*`). Set **empty** to disable name resolution (capability `names:false`, `/names` → 501). |
 | `ARCHON_LIGHTNING_MEDIATOR_URL` | `http://localhost:4235` | Upstream for Lightning routes + L402 invoice/pending storage. Set **empty** to disable Lightning (capability `lightning:false`, `/lightning` + `/invoice/:did` → 501). |
+| `ARCHON_EXPLORER_URL` | `http://localhost:4000` | Upstream DID explorer proxied at `/explorer`. Set **empty** to disable it (capability `explorer:false`, `/explorer` → 501). Belongs to the `explorer` profile — blank it when that profile is off, or Herald links visitors at a container that is not running. |
 | `ARCHON_DIDCOMM_URL` | `http://localhost:4236` | Upstream DIDComm relay proxied at `/didcomm`. Set **empty** to disable DIDComm (capability `didcomm:false`, `/didcomm` → 501). *The bundled compose defaults this **empty** (DIDComm is opt-in, off by default); enabling requires the `didcomm` profile **and** setting this URL.* |
 | `ARCHON_DRAWBRIDGE_PUBLIC_HOST` | empty | Public base URL this node is reachable at (clearnet host or Tor onion). Used by `/didcomm-endpoint` to advertise `<host>/didcomm`. |
 | `ARCHON_DRAWBRIDGE_TOR_HOSTNAME_FILE` | `/data/tor/hostname` | When `PUBLIC_HOST` is empty, `/didcomm-endpoint` falls back to the Tor onion read from this shared hidden-service hostname file. |

--- a/sample.env
+++ b/sample.env
@@ -40,6 +40,7 @@ ARCHON_NODE_NAME=mynodeName
 #
 #   ARCHON_LIGHTNING_MEDIATOR_URL=      (without the `lightning` profile)
 #   ARCHON_HERALD_URL=                  (without the `herald` profile)
+#   ARCHON_EXPLORER_URL=                (without the `explorer` profile)
 #
 # Separately, blank the DIDComm relay's Tor proxy when running without `tor`.
 # This is NOT a Drawbridge capability: didcomm stays enabled via ARCHON_DIDCOMM_URL, and
@@ -254,6 +255,11 @@ ARCHON_LIGHTNING_MEDIATOR_URL=http://lightning-mediator:4235
 # this when that profile is off, or /capabilities reports names:true and /names/* +
 # /.well-known/* proxy to a container that isn't running.
 ARCHON_HERALD_URL=http://herald:4230
+# Upstream explorer. Belongs to the `explorer` profile — BLANK this when that
+# profile is off, or /explorer proxies to a container that isn't running instead
+# of answering 501. Herald links here by default, so leaving it set without the
+# profile gives visitors a broken link.
+ARCHON_EXPLORER_URL=http://explorer:4000
 ARCHON_DRAWBRIDGE_DEFAULT_PRICE_SATS=10
 ARCHON_DRAWBRIDGE_INVOICE_EXPIRY=3600
 ARCHON_DRAWBRIDGE_RATE_LIMIT_MAX=100

--- a/services/drawbridge/server/src/config.ts
+++ b/services/drawbridge/server/src/config.ts
@@ -29,6 +29,9 @@ const config = {
     // (the capability off-switch), while an unset var falls back to the default.
     heraldURL: process.env.ARCHON_HERALD_URL ?? 'http://localhost:4230',
     lightningMediatorURL: process.env.ARCHON_LIGHTNING_MEDIATOR_URL ?? 'http://localhost:4235',
+    // Explorer is profile-gated, so this is empty on most nodes and /explorer
+    // answers 501, matching how /names and /didcomm behave when disabled.
+    explorerURL: process.env.ARCHON_EXPLORER_URL ?? '',
     didcommURL: process.env.ARCHON_DIDCOMM_URL ?? 'http://localhost:4236',
     // Public base URL this node is reachable at (clearnet host or Tor onion).
     // Used to advertise the DIDComm relay endpoint (`<publicHost>/didcomm`).

--- a/services/drawbridge/server/src/config.ts
+++ b/services/drawbridge/server/src/config.ts
@@ -29,9 +29,11 @@ const config = {
     // (the capability off-switch), while an unset var falls back to the default.
     heraldURL: process.env.ARCHON_HERALD_URL ?? 'http://localhost:4230',
     lightningMediatorURL: process.env.ARCHON_LIGHTNING_MEDIATOR_URL ?? 'http://localhost:4235',
-    // Explorer is profile-gated, so this is empty on most nodes and /explorer
-    // answers 501, matching how /names and /didcomm behave when disabled.
-    explorerURL: process.env.ARCHON_EXPLORER_URL ?? '',
+    // Follows the same convention as heraldURL and lightningMediatorURL: it
+    // defaults to the container, and an operator running without the `explorer`
+    // profile blanks it, which makes /explorer answer 501 rather than proxying
+    // to something that is not running.
+    explorerURL: process.env.ARCHON_EXPLORER_URL ?? 'http://localhost:4000',
     didcommURL: process.env.ARCHON_DIDCOMM_URL ?? 'http://localhost:4236',
     // Public base URL this node is reachable at (clearnet host or Tor onion).
     // Used to advertise the DIDComm relay endpoint (`<publicHost>/didcomm`).

--- a/services/drawbridge/server/src/drawbridge-api.ts
+++ b/services/drawbridge/server/src/drawbridge-api.ts
@@ -434,6 +434,27 @@ async function main() {
         }
     });
 
+    // Public face for the node's own explorer, so Herald can link to it instead
+    // of the shared public instance.
+    //
+    // Note the empty prefixToStrip: the explorer's bundle is built with
+    // base=/explorer/ and the app is mounted there, so the prefix has to survive
+    // the hop. Stripping it -- as /names and /didcomm do -- would serve an
+    // index.html whose asset URLs point at /explorer/... on a server that no
+    // longer answers there.
+    app.use('/explorer', async (req, res) => {
+        if (config.explorerURL === '') {
+            res.status(501).json({ error: 'Explorer is not enabled on this node' });
+            return;
+        }
+        try {
+            await proxyRequest(req, res, config.explorerURL, '');
+        } catch (error: any) {
+            logger.error({ err: error, path: req.originalUrl }, 'Explorer proxy error');
+            res.status(502).json({ error: 'Upstream explorer error' });
+        }
+    });
+
     // Public face for the DIDComm relay (mailbox). The published
     // DIDCommMessaging endpoint is `<drawbridge public host>/didcomm`.
     // Optional service: when the relay URL is unconfigured the node does not

--- a/services/drawbridge/server/src/v1-router.ts
+++ b/services/drawbridge/server/src/v1-router.ts
@@ -51,6 +51,7 @@ export function createV1Router(options: CreateV1RouterOptions): express.Router {
             didcomm: config.didcommURL !== '',
             lightning: config.lightningMediatorURL !== '',
             names: config.heraldURL !== '',
+            explorer: config.explorerURL !== '',
         });
     });
 

--- a/services/explorer/README.md
+++ b/services/explorer/README.md
@@ -30,9 +30,48 @@ Then edit the `.env` file to set your desired configuration:
 # The port your explorer will run on
 VITE_EXPLORER_PORT=4000
 
-# URL where your Gatekeeper service is running
+# Path prefix the app is served under. Baked into the bundle's asset URLs at
+# build time AND used by server.js to decide where to mount, so the two must
+# match — see "Serving under a prefix" below.
+VITE_EXPLORER_BASE=/explorer/
+
+# URLs the *browser* calls. Served at runtime from /explorer/config.json, so one
+# image works for a local node and a public one; the values below are the
+# build-time fallback used when that endpoint is unavailable.
 VITE_GATEKEEPER_URL=http://localhost:4224
+VITE_SEARCH_SERVER=http://localhost:4224
+
+# Override what config.json serves, without rebuilding. On a publicly reachable
+# node these should be the node's public gatekeeper, not loopback.
+ARCHON_EXPLORER_GATEKEEPER_URL=
+ARCHON_EXPLORER_SEARCH_URL=
 ```
+
+### Serving under a prefix
+
+The explorer is mounted at a path prefix (default `/explorer/`) rather than at
+the root, so Drawbridge can expose it publicly on the node's own host at
+`<public host>/explorer`. Herald links there by default.
+
+Two consequences worth knowing:
+
+- **The prefix is baked into the image.** Vite writes it into every asset URL at
+  build time, so `VITE_EXPLORER_BASE` is a Docker build argument as well as a
+  runtime variable. Changing it at runtime alone moves where express mounts the
+  app while the assets stay baked at the old prefix, which breaks all of them.
+- **Drawbridge does not strip the prefix**, unlike its `/names` and `/didcomm`
+  routes, because the app is mounted at it.
+
+Reaching the container directly on its port redirects `/` to the prefix, so both
+paths behave the same.
+
+### Backend URLs are resolved at runtime
+
+`VITE_GATEKEEPER_URL` and `VITE_SEARCH_SERVER` are fetched by the **browser**,
+not the server. Baking them in and defaulting to loopback meant a publicly
+served explorer sent every visitor to their own machine. `server.js` now serves
+them from `/explorer/config.json` and the app reads that before first paint,
+falling back to the build-time values if the endpoint is unavailable.
 
 ### Running the Explorer
 

--- a/services/explorer/sample.env
+++ b/services/explorer/sample.env
@@ -1,4 +1,12 @@
 VITE_EXPLORER_PORT=4000
+# Path prefix the app is built for and served under. Must match the Docker build
+# argument of the same name; see README, "Serving under a prefix".
+VITE_EXPLORER_BASE=/explorer/
+# Build-time fallback for the URLs the browser calls.
 VITE_GATEKEEPER_URL=http://localhost:4224
 VITE_SEARCH_SERVER=http://localhost:4224
+# What /explorer/config.json serves at runtime. On a public node these must be
+# reachable from a visitor's browser, not loopback.
+ARCHON_EXPLORER_GATEKEEPER_URL=
+ARCHON_EXPLORER_SEARCH_URL=
 VITE_OPERATION_NETWORKS=hyperswarm,BTC:signet,BTC:testnet4

--- a/services/explorer/server.js
+++ b/services/explorer/server.js
@@ -12,6 +12,11 @@ const __dirname = path.dirname(__filename);
 const app = express();
 const port = process.env.VITE_EXPLORER_PORT || 4000;
 
+// Must match the `base` the bundle was built with, or the asset URLs baked into
+// index.html will not resolve. Normalised to a leading slash and no trailing one
+// so it can be used directly as an express mount path.
+const base = `/${(process.env.VITE_EXPLORER_BASE || '/explorer/').replace(/^\/+|\/+$/g, '')}`;
+
 let version = 'unknown';
 const commit = (process.env.GIT_COMMIT || 'unknown').slice(0, 7);
 
@@ -22,16 +27,39 @@ try {
     console.warn('Failed to read package.json, using unknown version');
 }
 
-app.get('/version', (_req, res) => {
+function serveVersion(_req, res) {
     res.json({ version, commit });
+}
+
+// At the root as well as under the prefix: the container healthcheck hits
+// /version directly and should not have to know the prefix.
+app.get('/version', serveVersion);
+app.get(`${base}/version`, serveVersion);
+
+// The gatekeeper and search URLs the browser should call. These used to be baked
+// into the bundle and defaulted to loopback, which meant a publicly served
+// explorer sent every visitor to their own machine. Served at runtime instead so
+// one image works for both a local node and a public deployment.
+app.get(`${base}/config.json`, (_req, res) => {
+    res.set('Cache-Control', 'no-store');
+    res.json({
+        gatekeeperUrl: process.env.ARCHON_EXPLORER_GATEKEEPER_URL || process.env.VITE_GATEKEEPER_URL || '',
+        searchServerUrl: process.env.ARCHON_EXPLORER_SEARCH_URL || process.env.VITE_SEARCH_SERVER || '',
+    });
 });
 
-app.use(express.static(path.join(__dirname, 'dist')));
+app.use(base, express.static(path.join(__dirname, 'dist')));
 
-app.get('{*path}', (req, res) => {
+// Anything under the prefix is a client-side route.
+app.get(`${base}{/*path}`, (req, res) => {
     res.sendFile(path.join(__dirname, 'dist', 'index.html'));
 });
 
+// Reaching the container directly on :4000 should still land somewhere useful.
+app.get('/', (_req, res) => {
+    res.redirect(base);
+});
+
 app.listen(port, () => {
-    console.log(`Explorer v${version} (${commit}) running at http://localhost:${port}`);
+    console.log(`Explorer v${version} (${commit}) running at http://localhost:${port}${base}`);
 });

--- a/services/explorer/server.js
+++ b/services/explorer/server.js
@@ -48,6 +48,12 @@ app.get(`${base}/config.json`, (_req, res) => {
     });
 });
 
+// Normalise the no-trailing-slash form. Anything resolving relative URLs from
+// the page would otherwise resolve them one level too high.
+app.get(base, (_req, res) => {
+    res.redirect(`${base}/`);
+});
+
 app.use(base, express.static(path.join(__dirname, 'dist')));
 
 // Anything under the prefix is a client-side route.

--- a/services/explorer/src/App.tsx
+++ b/services/explorer/src/App.tsx
@@ -15,6 +15,8 @@ import Header from "./components/Header.js";
 import { GatekeeperEvent } from "@didcid/gatekeeper/types";
 import { Routes, Route, useNavigate, Navigate } from 'react-router-dom';
 
+import { getRuntimeConfig } from './runtimeConfig.js';
+
 const gatekeeper = new GatekeeperClient();
 
 interface SnackbarState {
@@ -22,8 +24,6 @@ interface SnackbarState {
     message: string;
     severity: AlertColor;
 }
-
-const gatekeeperUrl = import.meta.env.VITE_GATEKEEPER_URL || 'http://localhost:4224';
 
 function App() {
     const [isReady, setIsReady] = useState<boolean>(false);
@@ -92,7 +92,7 @@ function App() {
 
         async function init() {
             await gatekeeper.connect({
-                url: gatekeeperUrl,
+                url: getRuntimeConfig().gatekeeperUrl,
                 waitUntilReady: true,
                 intervalSeconds: 5,
                 chatty: true,

--- a/services/explorer/src/components/JsonViewer.tsx
+++ b/services/explorer/src/components/JsonViewer.tsx
@@ -24,7 +24,7 @@ import { handleCopyDID } from '../shared/utilities.js';
 import axios from "axios";
 import { useSearchParams } from "react-router-dom";
 
-const searchServerURL = import.meta.env.VITE_SEARCH_SERVER || "http://localhost:4224";
+import { getRuntimeConfig } from "../runtimeConfig.js";
 const VERSION = '/api/v1';
 
 function JsonViewer(
@@ -93,7 +93,7 @@ function JsonViewer(
             setFormDid(query);
             setSearchPage(0);
 
-            const response = await axios.get(`${searchServerURL}${VERSION}/search`, {
+            const response = await axios.get(`${getRuntimeConfig().searchServerUrl}${VERSION}/search`, {
                 params: { q: query }
             });
             setSearchResults(response.data);

--- a/services/explorer/src/main.tsx
+++ b/services/explorer/src/main.tsx
@@ -3,14 +3,26 @@ import ReactDOM from 'react-dom/client';
 import App from './App.js';
 import { BrowserRouter } from 'react-router-dom';
 import './static/index.css';
+import { loadRuntimeConfig } from './runtimeConfig.js';
+
+// Vite bakes the base in at build time; the router has to agree with it or deep
+// links resolve against the wrong root when the app is served under a prefix.
+const basename = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 const rootElement = document.getElementById('root') as HTMLElement;
 const root = ReactDOM.createRoot(rootElement);
 
-root.render(
-    <React.StrictMode>
-        <BrowserRouter>
-            <App />
-        </BrowserRouter>
-    </React.StrictMode>
-);
+function render() {
+    root.render(
+        <React.StrictMode>
+            <BrowserRouter basename={basename}>
+                <App />
+            </BrowserRouter>
+        </React.StrictMode>
+    );
+}
+
+// Resolve the backend URLs before first paint, so nothing fires a request at the
+// build-time default and then re-fires at the real one. Not a top-level await:
+// the build target (es2020) does not support it.
+loadRuntimeConfig().then(render).catch(render);

--- a/services/explorer/src/runtimeConfig.ts
+++ b/services/explorer/src/runtimeConfig.ts
@@ -1,0 +1,52 @@
+// The explorer's backend URLs used to be baked in at build time and defaulted
+// to http://localhost:4224. That is fine when the only way to reach the explorer
+// is from the node itself, but these are *browser-side* fetches: served publicly,
+// every visitor would query their own loopback rather than the node's gatekeeper.
+//
+// So they are resolved at runtime instead. server.js serves the values it was
+// given, and the app fetches them before rendering. The build-time values remain
+// as the fallback, which keeps existing local setups working unchanged.
+
+export interface RuntimeConfig {
+    gatekeeperUrl: string;
+    searchServerUrl: string;
+}
+
+const buildTimeDefaults: RuntimeConfig = {
+    gatekeeperUrl: import.meta.env.VITE_GATEKEEPER_URL || "http://localhost:4224",
+    searchServerUrl: import.meta.env.VITE_SEARCH_SERVER || "http://localhost:4224",
+};
+
+let config: RuntimeConfig = { ...buildTimeDefaults };
+
+export function getRuntimeConfig(): RuntimeConfig {
+    return config;
+}
+
+export async function loadRuntimeConfig(): Promise<RuntimeConfig> {
+    // Relative to the app's base, so this works under any prefix the explorer
+    // is mounted at without knowing what that prefix is.
+    const url = new URL("config.json", document.baseURI).toString();
+
+    try {
+        const response = await fetch(url, { cache: "no-store" });
+
+        if (!response.ok) {
+            return config;
+        }
+
+        const served = await response.json();
+
+        config = {
+            gatekeeperUrl: served.gatekeeperUrl || buildTimeDefaults.gatekeeperUrl,
+            searchServerUrl: served.searchServerUrl || buildTimeDefaults.searchServerUrl,
+        };
+    }
+    catch {
+        // Serving config is best effort: an older server without the endpoint,
+        // or a transient failure, leaves the build-time values in place rather
+        // than blocking the app from starting.
+    }
+
+    return config;
+}

--- a/services/explorer/src/runtimeConfig.ts
+++ b/services/explorer/src/runtimeConfig.ts
@@ -24,9 +24,11 @@ export function getRuntimeConfig(): RuntimeConfig {
 }
 
 export async function loadRuntimeConfig(): Promise<RuntimeConfig> {
-    // Relative to the app's base, so this works under any prefix the explorer
-    // is mounted at without knowing what that prefix is.
-    const url = new URL("config.json", document.baseURI).toString();
+    // Resolved against Vite's base, not document.baseURI. The advertised link
+    // is `<host>/explorer` with no trailing slash, and relative resolution from
+    // there drops the last segment -- giving `/config.json`, a 404, and a silent
+    // fall back to the loopback defaults on the exact path most visitors take.
+    const url = new URL("config.json", new URL(import.meta.env.BASE_URL, window.location.origin)).toString();
 
     try {
         const response = await fetch(url, { cache: "no-store" });

--- a/services/explorer/vite.config.ts
+++ b/services/explorer/vite.config.ts
@@ -7,7 +7,11 @@ export default defineConfig(({ mode }) => {
     return {
         plugins: [react()],
         root: './',
-	    base: '/',
+        // Served under a path prefix so Drawbridge can expose it publicly on the
+        // node's own host. Vite bakes this in, so the image is prefix-specific;
+        // server.js mounts the app at the same prefix, which keeps direct access
+        // on port 4000 and proxied access byte-identical.
+        base: env.VITE_EXPLORER_BASE || '/explorer/',
         server: {
             port: parseInt(env.VITE_EXPLORER_PORT) || 4000,
         },

--- a/services/herald/server/src/config.ts
+++ b/services/herald/server/src/config.ts
@@ -11,11 +11,10 @@ export const DRAWBRIDGE_PUBLIC_HOST = process.env.ARCHON_DRAWBRIDGE_PUBLIC_HOST 
 export const GATEKEEPER_URL = process.env.ARCHON_GATEKEEPER_URL || 'http://localhost:4224';
 export const WALLET_URL = process.env.ARCHON_HERALD_WALLET_URL || 'https://wallet.archon.technology';
 // This URL is followed by the visitor's browser, so it must be reachable from
-// the public internet. The node's own explorer cannot be the default: it is
-// Drawbridge now proxies the node's own explorer at /explorer, so the default is
-// the node itself rather than the shared public instance. A node without the
-// explorer profile answers 501 there; operators in that position should point
-// this at a reachable explorer, or set it empty to hide the links entirely.
+// the public internet. Drawbridge proxies the node's own explorer at /explorer,
+// so the default is this node rather than the shared public instance. A node
+// without the explorer profile answers 501 there; operators in that position
+// should point this at a reachable explorer, or set it empty to hide the links.
 export const EXPLORER_URL = process.env.ARCHON_HERALD_EXPLORER_URL
     ?? `${DRAWBRIDGE_PUBLIC_HOST.replace(/\/$/, '')}/explorer`;
 export const HERALD_DATABASE_TYPE = process.env.ARCHON_HERALD_DB || 'json';

--- a/services/herald/server/src/config.ts
+++ b/services/herald/server/src/config.ts
@@ -12,11 +12,12 @@ export const GATEKEEPER_URL = process.env.ARCHON_GATEKEEPER_URL || 'http://local
 export const WALLET_URL = process.env.ARCHON_HERALD_WALLET_URL || 'https://wallet.archon.technology';
 // This URL is followed by the visitor's browser, so it must be reachable from
 // the public internet. The node's own explorer cannot be the default: it is
-// profile-gated, bound to port 4000, and proxied by neither Drawbridge nor
-// nginx, so there is no address to advertise — and `localhost:4000` would
-// resolve to each visitor's own machine. Operators running a reachable
-// explorer should set this to it. Set it empty to hide the links entirely.
-export const EXPLORER_URL = process.env.ARCHON_HERALD_EXPLORER_URL ?? 'https://explorer.archon.technology';
+// Drawbridge now proxies the node's own explorer at /explorer, so the default is
+// the node itself rather than the shared public instance. A node without the
+// explorer profile answers 501 there; operators in that position should point
+// this at a reachable explorer, or set it empty to hide the links entirely.
+export const EXPLORER_URL = process.env.ARCHON_HERALD_EXPLORER_URL
+    ?? `${DRAWBRIDGE_PUBLIC_HOST.replace(/\/$/, '')}/explorer`;
 export const HERALD_DATABASE_TYPE = process.env.ARCHON_HERALD_DB || 'json';
 export const DATA_DIR = process.env.ARCHON_HERALD_DATA_DIR || '/app/server/data';
 export const IPFS_API_URL = process.env.ARCHON_HERALD_IPFS_API_URL || 'http://localhost:5001/api/v0';

--- a/tests/drawbridge/v1-router.test.ts
+++ b/tests/drawbridge/v1-router.test.ts
@@ -98,15 +98,22 @@ describe('drawbridge v1 unprotected routes', () => {
 
     it('derives capabilities from which downstream URLs are configured', async () => {
         const all = mount({
-            config: { didcommURL: 'http://didcomm', lightningMediatorURL: 'http://ln', heraldURL: 'http://herald' },
+            config: {
+                didcommURL: 'http://didcomm',
+                lightningMediatorURL: 'http://ln',
+                heraldURL: 'http://herald',
+                explorerURL: 'http://explorer',
+            },
         });
         await expect(request(all.app).get('/api/v1/capabilities')).resolves.toMatchObject({
-            body: { didcomm: true, lightning: true, names: true },
+            body: { didcomm: true, lightning: true, names: true, explorer: true },
         });
 
-        const none = mount({ config: { didcommURL: '', lightningMediatorURL: '', heraldURL: '' } });
+        const none = mount({
+            config: { didcommURL: '', lightningMediatorURL: '', heraldURL: '', explorerURL: '' },
+        });
         await expect(request(none.app).get('/api/v1/capabilities')).resolves.toMatchObject({
-            body: { didcomm: false, lightning: false, names: false },
+            body: { didcomm: false, lightning: false, names: false, explorer: false },
         });
     });
 


### PR DESCRIPTION
Closes #840.

## Problem

A node couldn't link to its own explorer, so Herald had to advertise `explorer.archon.technology`. The obvious "same node" default of `localhost:4000` resolves to the **visitor's** machine, since the link is followed by their browser.

Three things had to change together — a Drawbridge route alone would have served a broken app.

## 1. Prefix

The bundle was built with `base: '/'`, so serving it under `/explorer` would leave every asset URL pointing at the host root.

- `base` is now `VITE_EXPLORER_BASE` (default `/explorer/`)
- the router takes its `basename` from the same value, so deep links resolve (the explorer uses `BrowserRouter` with path routes, which is why a relative base wasn't an option)
- `server.js` mounts the app at the same prefix

That keeps direct access on `:4000` and proxied access **byte-identical**, rather than two behaviours to reason about. The image is prefix-specific as a result, which #840 anticipated.

## 2. Backend URLs

`VITE_GATEKEEPER_URL` and `VITE_SEARCH_SERVER` were baked into the bundle and defaulted to loopback. These are **browser-side** fetches, so a publicly served explorer would send every visitor to their own machine — the same defect as the Herald link, one layer down.

They're now served at runtime from `/explorer/config.json` and fetched before first paint, with the build-time values kept as the fallback so existing local setups are unchanged.

## 3. Drawbridge route

`/explorer` proxies to the explorer, or answers `501` when the profile isn't enabled — matching `/names` and `/didcomm`.

It passes an **empty** `prefixToStrip`. Unlike those two, the prefix has to survive the hop, because the app is mounted at it; stripping it would serve an `index.html` whose asset URLs point at `/explorer/...` on a server that no longer answers there.

## 4. Herald default

`ARCHON_HERALD_EXPLORER_URL` now defaults to `${DRAWBRIDGE_PUBLIC_HOST}/explorer` instead of the public instance, derived exactly as `PUBLIC_URL` already is for `/names`. Still overridable, still hideable by setting it empty.

## Verification

Against a running server:

| probe | result |
| --- | --- |
| `/explorer/assets/index-*.js` | 200 (532 KB) |
| same path without the prefix | 404 — correctly not served |
| `/explorer/did:cid:abc` (deep link) | 200, serves the SPA |
| `/version` and `/explorer/version` | 200 both — container healthcheck unaffected |
| `/` | 302 → `/explorer` |
| `/explorer/config.json` | returns the injected URLs |

Asset URLs in the built `index.html` are `/explorer/assets/…`, confirming the base is baked correctly.

## Note for future work here

The render couldn't simply `await` the config load: the explorer builds with Vite 4 targeting es2020, where top-level await is unavailable. `main.tsx` renders from a `.then()` instead.

## Related

- #448 — Herald client hardcodes `archon.technology`. Same class (deployment-specific URLs baked into client code) and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)