### PR TITLE
fix(herald-client): Point the quickstart at this node, not archon.technology

### DIFF
--- a/apps/herald-client/src/App.tsx
+++ b/apps/herald-client/src/App.tsx
@@ -610,6 +610,19 @@ function Home() {
         }
     })();
 
+    // The CLI in the quickstart has to talk to *this* node. publicUrl is this
+    // service's own address (DRAWBRIDGE_PUBLIC_HOST + /names), so its origin is
+    // the node URL. Falls back to a placeholder rather than a real host, so a
+    // misconfigured instance cannot quietly send someone to the wrong node.
+    const nodeUrl = (() => {
+        try {
+            return publicUrl ? new URL(publicUrl).origin : 'https://your-node.com';
+        }
+        catch {
+            return 'https://your-node.com';
+        }
+    })();
+
     useEffect(() => {
         const init = async () => {
             try {
@@ -779,7 +792,7 @@ function Home() {
 npm install -g @didcid/keymaster
 
 # Set up environment
-export ARCHON_NODE_URL=https://archon.technology
+export ARCHON_NODE_URL=${nodeUrl}
 export ARCHON_PASSPHRASE="your-secret-passphrase"
 
 # Create wallet and identity


### PR DESCRIPTION
Closes #448.

## Problem

The AI Agent Quick Start told every visitor to run:

```
export ARCHON_NODE_URL=https://archon.technology
```

regardless of which Herald instance they were reading. Anyone following it on another node pointed their CLI at the wrong one — and at a node where the address they were about to claim doesn't exist.

## Fix

Derive it the way `agentDomain` already is. `publicUrl` is this service's own address (`DRAWBRIDGE_PUBLIC_HOST` + `/names`) from `/api/config`, so its **origin** is the node URL:

```ts
const nodeUrl = (() => {
    try {
        return publicUrl ? new URL(publicUrl).origin : 'https://your-node.com';
    }
    catch {
        return 'https://your-node.com';
    }
})();
```

**The fallback is a placeholder, not a real host.** If `publicUrl` is missing or malformed, `https://your-node.com` is obviously something to replace — whereas defaulting to a working third-party node would send someone to the wrong place *while appearing to work*, which is the bug being fixed.

## Note

The "Powered by Archon Protocol" link further down still points at `archon.technology`, and should — that's the project's site, not a node URL. It's the only remaining reference in this file.

## Verification

`your-node.com` appears in the built bundle and the hardcoded `ARCHON_NODE_URL=https://archon.technology` no longer does. Build and lint clean.

(The `tsc` run on this app reports a pre-existing `TS5110` config error — `module: ESNext` with `moduleResolution: NodeNext` — present on `main` and unrelated to this change. Its build script is `vite build`, which doesn't typecheck.)

## Related

- #840 / #895 — same class: deployment-specific URLs baked into client code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)