### PR TITLE
fix(gatekeeper): skip the universal resolver for our own DID method

### DIFF
--- a/rust/services/gatekeeper/src/api.rs
+++ b/rust/services/gatekeeper/src/api.rs
@@ -1114,7 +1114,20 @@ pub(crate) async fn resolve_did(
         .and_then(|value| value.get("error"))
         .is_some();
 
-    if has_resolver_error && !state.config.fallback_url.trim().is_empty() {
+    // The universal resolver is for FOREIGN DID methods (did:web, did:ethr, ...).
+    // This gatekeeper is itself an authority for its own method, so when a local
+    // resolve of one of our own DIDs fails, an external universal resolver has
+    // nothing to add: it has no driver for our method and the request simply
+    // burns the full fallback_timeout_ms before failing. Skipping it here removes
+    // that stall and lets the confirm fallback -- another Archon gatekeeper,
+    // which *can* resolve our DIDs -- be tried immediately instead.
+    // Mirrors services/gatekeeper/server/src/v1-did-router.ts.
+    let is_own_method = did.starts_with(&format!(
+        "{}:",
+        state.config.did_prefix.trim_end_matches(':')
+    ));
+
+    if has_resolver_error && !is_own_method && !state.config.fallback_url.trim().is_empty() {
         let url = format!(
             "{}/1.0/identifiers/{}",
             state.config.fallback_url.trim_end_matches('/'),

--- a/services/gatekeeper/server/src/v1-did-router.ts
+++ b/services/gatekeeper/server/src/v1-did-router.ts
@@ -451,11 +451,25 @@ export function createDidRouter(options: CreateV1RouterOptions): express.Router 
      *       500:
      *         description: Internal Server Error.
      */
+    // The universal resolver is for FOREIGN DID methods (did:web, did:ethr, ...).
+    // This gatekeeper is itself an authority for its own method, so when a local
+    // resolve of one of our own DIDs fails, an external universal resolver has
+    // nothing to add: it has no driver for our method and the request simply
+    // burns the full fallbackTimeout before failing. Skipping it here removes
+    // that stall and lets the confirm fallback -- another Archon gatekeeper,
+    // which *can* resolve our DIDs -- be tried immediately instead.
+    // Falls open: with no configured prefix nothing counts as our own method, so
+    // the fallback behaves exactly as it did before this guard existed.
+    function isOwnMethod(did: string): boolean {
+        const prefix = (config.didPrefix ?? '').replace(/:+$/, '');
+        return prefix.length > 0 && did.startsWith(`${prefix}:`);
+    }
+
     async function resolveFromUniversalResolver(did: string): Promise<any | null> {
-        if (!config.fallbackURL) {
+        if (!config.fallbackURL || isOwnMethod(did)) {
             return null;
         }
-    
+
         try {
             const baseURL = config.fallbackURL.replace(/\/+$/, '');
             const url = `${baseURL}/1.0/identifiers/${encodeURIComponent(did)}`;

--- a/tests/gatekeeper/v1-api.test.ts
+++ b/tests/gatekeeper/v1-api.test.ts
@@ -322,20 +322,22 @@ describe('/api/v1 DID routes', () => {
         expect(response.body).toEqual({ error: 'DID not found' });
     });
 
+    // The universal resolver is only consulted for FOREIGN methods, so these use
+    // did:web rather than this node's own method (see the did:cid case below).
     it('falls back to the universal resolver when resolution returns an error', async () => {
         const { app, gatekeeper } = mount({ fallbackURL: 'https://resolver.test/' });
         gatekeeper.resolveDID = jest.fn<any>().mockResolvedValue({
             didDocument: {},
             didResolutionMetadata: { error: 'notFound' },
         });
-        const upstream = { didDocument: { id: 'did:cid:abc' } };
+        const upstream = { didDocument: { id: 'did:web:example.com' } };
         global.fetch = jest.fn<any>().mockResolvedValue({ ok: true, json: async () => upstream });
 
-        const response = await request(app).get('/api/v1/did/did:cid:abc');
+        const response = await request(app).get('/api/v1/did/did:web:example.com');
         expect(response.status).toBe(200);
         expect(response.body).toEqual(upstream);
         expect(global.fetch).toHaveBeenCalledWith(
-            'https://resolver.test/1.0/identifiers/did%3Acid%3Aabc',
+            'https://resolver.test/1.0/identifiers/did%3Aweb%3Aexample.com',
             expect.objectContaining({ signal: expect.anything() }),
         );
     });
@@ -346,16 +348,49 @@ describe('/api/v1 DID routes', () => {
         const notOk = mount({ fallbackURL: 'https://resolver.test' });
         notOk.gatekeeper.resolveDID = jest.fn<any>().mockResolvedValue(errorDoc);
         global.fetch = jest.fn<any>().mockResolvedValue({ ok: false });
-        const first = await request(notOk.app).get('/api/v1/did/did:cid:abc');
+        const first = await request(notOk.app).get('/api/v1/did/did:web:example.com');
         expect(first.status).toBe(200);
         expect(first.body).toEqual(errorDoc);
 
         const threw = mount({ fallbackURL: 'https://resolver.test' });
         threw.gatekeeper.resolveDID = jest.fn<any>().mockResolvedValue(errorDoc);
         global.fetch = jest.fn<any>().mockRejectedValue(new Error('network down'));
-        const second = await request(threw.app).get('/api/v1/did/did:cid:abc');
+        const second = await request(threw.app).get('/api/v1/did/did:web:example.com');
         expect(second.status).toBe(200);
         expect(second.body).toEqual(errorDoc);
+    });
+
+    it('skips the universal resolver for DIDs of its own method', async () => {
+        // A universal resolver has no driver for this node's own method, so asking
+        // it about our DIDs only burns fallbackTimeout. The node is the authority.
+        const { app, gatekeeper } = mount({ fallbackURL: 'https://resolver.test' });
+        const errorDoc = { didDocument: {}, didResolutionMetadata: { error: 'notFound' } };
+        gatekeeper.resolveDID = jest.fn<any>().mockResolvedValue(errorDoc);
+        global.fetch = jest.fn<any>();
+
+        const response = await request(app).get('/api/v1/did/did:cid:abc');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(errorDoc);
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('still consults the universal resolver for foreign methods when a prefix is set', async () => {
+        // Guards against the skip being too broad: only our own prefix is exempt.
+        const { app, gatekeeper } = mount({
+            fallbackURL: 'https://resolver.test',
+            didPrefix: 'did:cid',
+        });
+        gatekeeper.resolveDID = jest.fn<any>().mockResolvedValue({
+            didDocument: {},
+            didResolutionMetadata: { error: 'notFound' },
+        });
+        const upstream = { didDocument: { id: 'did:ethr:0xabc' } };
+        global.fetch = jest.fn<any>().mockResolvedValue({ ok: true, json: async () => upstream });
+
+        const response = await request(app).get('/api/v1/did/did:ethr:0xabc');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(upstream);
+        expect(global.fetch).toHaveBeenCalled();
     });
 
     it('sends non-create operations to updateDID', async () => {
@@ -388,7 +423,8 @@ describe('/api/v1 DID routes', () => {
         gatekeeper.resolveDID = jest.fn<any>().mockResolvedValue(errorDoc);
         global.fetch = jest.fn<any>();
 
-        const response = await request(app).get('/api/v1/did/did:cid:abc');
+        // Foreign method, so the missing fallbackURL is the only reason to skip.
+        const response = await request(app).get('/api/v1/did/did:web:example.com');
         expect(response.status).toBe(200);
         expect(response.body).toEqual(errorDoc);
         expect(global.fetch).not.toHaveBeenCalled();


### PR DESCRIPTION
## Problem

`resolveFromUniversalResolver` sends **every** locally-unresolvable DID to the universal resolver, including DIDs of the gatekeeper's own method. No universal resolver has a driver for `did:cid`, so each of those requests burns the full `ARCHON_GATEKEEPER_FALLBACK_TIMEOUT` and is then aborted. Only afterwards is the confirm fallback — another Archon gatekeeper, which *can* resolve it — attempted.

The dispatch order in `v1-did-router.ts` is: local resolve → **universal resolver** → confirm fallback.

## Impact measured on a live node

Investigating a report of a third-party service being "rate limited" by our Universal Resolver turned up the opposite: the load was self-inflicted.

| | |
|---|---|
| Gatekeeper → own universal resolver | **2,866 req/hour**, sustained |
| Per day | ~53,000 requests, **every one ending in HTTP 499** (client abort at the 2.5s timeout) |
| Share of that resolver's total traffic | **81%** |
| The third party we thought we were throttling | 1.7% of load, zero 429s, all 200s |

Each aborted request holds an upstream resolver worker for the full timeout, which is what actually degraded service for legitimate consumers.

## Fix

Return early from `resolveFromUniversalResolver` when the DID belongs to this gatekeeper's own method.

- Compares against the configured `didPrefix`, **not** a hardcoded `did:cid` — the prefix is settable via `ARCHON_GATEKEEPER_DID_PREFIX`, so hardcoding would silently fail on a node using a different one.
- **Falls open**: with no prefix configured nothing counts as our own method and behaviour is exactly as before, so a partial config can't turn this into a 500 on every resolve.
- Applied to **both** gatekeeper flavors per the parity contract (`rust/services/gatekeeper/src/api.rs`).

Unknown `did:cid` now falls straight through to the confirm fallback, which is the path that can actually resolve it.

## Result after deploying to a live node

| | before | after |
|---|---|---|
| Unknown `did:cid` resolution | ~2,500 ms | **77 ms** |
| `did:web` (foreign method) | works | **still works**, 220 ms |
| Self-inflicted resolver load | 53k/day | **0** |

## Tests

`tests/gatekeeper/v1-api.test.ts` — 27 passing.

Two existing fallback tests used `did:cid` purely as a sample DID while exercising the mechanism; they now use `did:web` / `did:ethr`, which is what that path is actually for. Added two cases: one pinning the skip for our own method, one confirming the skip is not too broad (foreign methods still reach the resolver).

Also verified: root `npm run build`, `tsc --noEmit`, eslint on the changed file, full jest suite, and `cargo check` + `cargo test` for the Rust flavor.

## Reviewer note

This changes behaviour for anyone whose `ARCHON_GATEKEEPER_FALLBACK_URL` points at a resolver that *does* have a driver for this method — those DIDs now resolve via the confirm fallback instead. That seemed clearly preferable to paying a full timeout on every miss, but it is a deliberate behaviour change and worth a second opinion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)