### PR TITLE
feat(wallet): DIDComm messaging in the wallets

### DIFF
--- a/apps/gatekeeper-client/src/App.jsx
+++ b/apps/gatekeeper-client/src/App.jsx
@@ -37,6 +37,10 @@ function App() {
     const [modalAction, setModalAction] = useState(null);
     const [passphraseErrorText, setPassphraseErrorText] = useState("");
     const [keymaster, setKeymaster] = useState(null);
+    // Unknown (a node serving no capability manifest) is permissive, matching the
+    // gate inside Keymaster: show the surface rather than hide it against an
+    // older node, and let the operation fail late if the service really is absent.
+    const [hasDidComm, setHasDidComm] = useState(true);
     const [kmEpoch, setKmEpoch] = useState(0);
     const [uploadAction, setUploadAction] = useState(null);
     const [pendingWallet, setPendingWallet] = useState(null);
@@ -80,6 +84,14 @@ function App() {
         setPassphraseErrorText("");
         setKeymaster(instance);
         setKmEpoch((e) => e + 1);
+
+        try {
+            const capabilities = await instance.getNodeCapabilities();
+            setHasDidComm(capabilities?.didcomm !== false);
+        } catch {
+            // Capability manifest unreadable — leave DIDComm visible.
+        }
+
         setIsReady(true);
     };
 
@@ -294,6 +306,7 @@ function App() {
                     challengeDID={challengeDID}
                     onWalletUpload={handleWalletUploadFile}
                     hasLightning={hasLightning}
+                    hasDidComm={hasDidComm}
                     serverUrl={gatekeeperUrl}
                     onServerUrlChange={handleServerUrlChange}
                 />

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -403,6 +403,19 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [lightningStatusFilter, setLightningStatusFilter] = useState({ settled: true, pending: true, failed: true, expired: true });
     const [isPublished, setIsPublished] = useState(false);
     const [loadingPublishToggle, setLoadingPublishToggle] = useState(false);
+    // Inlined rather than imported from @didcid/keymaster: this file is shared with
+    // the server-wallet demo, which deliberately depends only on the thin client
+    // package. These are stable DIDComm protocol URIs.
+    const BASIC_MESSAGE_TYPE = 'https://didcomm.org/basicmessage/2.0/message';
+    const TRUST_PING_TYPE = 'https://didcomm.org/trust-ping/2.0/ping';
+    const TRUST_PING_RESPONSE_TYPE = 'https://didcomm.org/trust-ping/2.0/ping-response';
+
+    const [didcommTab, setDidcommTab] = useState('inbox');
+    const [didcommMessages, setDidcommMessages] = useState([]);
+    const [didcommInboxLoading, setDidcommInboxLoading] = useState(false);
+    // A ref, not the loading flag: the poll's interval callback closes over the
+    // render that created it, so a state read there would always be stale.
+    const didcommPollingRef = useRef(false);
     const [didcommStatus, setDidcommStatus] = useState(null);
     const [didcommEndpoint, setDidcommEndpoint] = useState('');
     const [didcommRoutingKeys, setDidcommRoutingKeys] = useState('');
@@ -445,9 +458,25 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     useEffect(() => {
         if (tab === 'didcomm') {
             refreshDidComm();
+            refreshDidCommInbox({ quiet: true });
         }
         // eslint-disable-next-line
     }, [tab, currentId]);
+
+    useEffect(() => {
+        // Poll only while the DIDComm screen is open, at the interval configured in
+        // Settings. Zero means manual refresh only.
+        if (tab !== 'didcomm' || refreshIntervalSeconds === 0) {
+            return;
+        }
+
+        const interval = setInterval(() => {
+            refreshDidCommInbox({ quiet: true });
+        }, refreshIntervalSeconds * 1000);
+
+        return () => clearInterval(interval);
+        // eslint-disable-next-line
+    }, [tab, currentId, refreshIntervalSeconds]);
 
     async function refreshDidComm() {
         if (!currentId) {
@@ -480,6 +509,86 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             showError(error);
             setDidcommStatus(null);
         }
+    }
+
+    // Reading with ack: false leaves everything on the server, so each poll returns
+    // the whole mailbox. The list is replaced rather than accumulated: what is on
+    // screen is exactly what is still in the mailbox.
+    async function refreshDidCommInbox(options = {}) {
+        if (!currentId) {
+            setDidcommMessages([]);
+            return;
+        }
+
+        if (didcommPollingRef.current) {
+            return;
+        }
+        didcommPollingRef.current = true;
+        setDidcommInboxLoading(true);
+
+        try {
+            const received = await keymaster.receiveDidComm({ name: currentId, ack: false });
+            setDidcommMessages(received);
+        } catch (error) {
+            // A polled failure is usually a node that is briefly unreachable; only
+            // an explicit refresh should raise a snackbar.
+            if (!options.quiet) {
+                showError(error);
+            }
+        } finally {
+            didcommPollingRef.current = false;
+            setDidcommInboxLoading(false);
+        }
+    }
+
+    async function dismissDidComm(ids) {
+        if (!ids.length) {
+            return;
+        }
+
+        setDidcommBusy(true);
+        try {
+            const removed = await keymaster.ackDidComm(ids, { name: currentId });
+            showSuccess(removed === 1 ? 'Message dismissed' : `${removed} messages dismissed`);
+            await refreshDidCommInbox();
+        } catch (error) {
+            showError(error);
+        } finally {
+            setDidcommBusy(false);
+        }
+    }
+
+    async function respondToDidCommPing(received) {
+        const message = received.message || {};
+
+        if (!message.from || !message.id) {
+            showError('This ping carries no sender to respond to');
+            return;
+        }
+
+        setDidcommBusy(true);
+        try {
+            await keymaster.sendDidComm(
+                { type: TRUST_PING_RESPONSE_TYPE, body: {}, thid: message.id },
+                message.from,
+                { name: currentId },
+            );
+            showSuccess('Ping response sent');
+        } catch (error) {
+            showError(error);
+        } finally {
+            setDidcommBusy(false);
+        }
+    }
+
+    function didcommMessageLabel(type) {
+        if (type === BASIC_MESSAGE_TYPE) {
+            return 'Message';
+        }
+        if (type === TRUST_PING_TYPE) {
+            return 'Trust ping';
+        }
+        return type || 'Unknown';
     }
 
     async function publishDidComm() {
@@ -7674,6 +7783,108 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                     }
                     {tab === 'didcomm' &&
                         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, maxWidth: 700, mt: 2 }}>
+                            <Tabs
+                                value={didcommTab}
+                                onChange={(_, v) => setDidcommTab(v)}
+                                indicatorColor="primary"
+                                textColor="primary"
+                            >
+                                <Tab label="Inbox" value="inbox" />
+                                <Tab label="Endpoint" value="endpoint" />
+                            </Tabs>
+
+                            {didcommTab === 'inbox' &&
+                                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                                    <Box sx={{ display: 'flex', gap: 1 }}>
+                                        <Button
+                                            variant="contained"
+                                            color="primary"
+                                            onClick={() => refreshDidCommInbox()}
+                                            disabled={didcommBusy || didcommInboxLoading}
+                                        >
+                                            Refresh
+                                        </Button>
+                                        <Button
+                                            variant="outlined"
+                                            color="primary"
+                                            onClick={() => dismissDidComm(didcommMessages.map(m => m.id))}
+                                            disabled={didcommBusy || !didcommMessages.length}
+                                        >
+                                            Dismiss All
+                                        </Button>
+                                    </Box>
+
+                                    {didcommMessages.length === 0
+                                        ? <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                            {didcommInboxLoading ? 'Loading...' : 'No messages in the mailbox for this identity.'}
+                                        </Typography>
+                                        : didcommMessages.map((received) => {
+                                            const message = received.message || {};
+                                            const sender = message.from || received.metadata?.sender;
+                                            // DIDComm created_time is seconds since the epoch, not milliseconds.
+                                            const time = message.created_time
+                                                ? new Date(message.created_time * 1000).toLocaleString()
+                                                : '';
+
+                                            return (
+                                                <Box key={received.id} sx={{ borderBottom: 1, borderColor: 'divider', pb: 1.5 }}>
+                                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                                                        <Typography variant="subtitle2">
+                                                            {didcommMessageLabel(message.type)}
+                                                        </Typography>
+                                                        {/* Anoncrypt hides the sender entirely, so "who sent this" and
+                                                            "is that claim verified" are two different questions. */}
+                                                        <Typography variant="caption" sx={{ opacity: 0.7 }}>
+                                                            {received.metadata?.authenticated ? 'authenticated' : 'anonymous'}
+                                                        </Typography>
+                                                        {time &&
+                                                            <Typography variant="caption" sx={{ opacity: 0.7 }}>
+                                                                {time}
+                                                            </Typography>
+                                                        }
+                                                        <Box sx={{ ml: 'auto', display: 'flex', gap: 1 }}>
+                                                            {message.type === TRUST_PING_TYPE &&
+                                                                <Button
+                                                                    size="small"
+                                                                    onClick={() => respondToDidCommPing(received)}
+                                                                    disabled={didcommBusy}
+                                                                >
+                                                                    Respond
+                                                                </Button>
+                                                            }
+                                                            <Button
+                                                                size="small"
+                                                                color="error"
+                                                                onClick={() => dismissDidComm([received.id])}
+                                                                disabled={didcommBusy}
+                                                            >
+                                                                Dismiss
+                                                            </Button>
+                                                        </Box>
+                                                    </Box>
+                                                    <Typography variant="body2" sx={{ opacity: 0.7, wordBreak: 'break-all' }}>
+                                                        From: {sender || 'unknown'}
+                                                    </Typography>
+                                                    {message.type === BASIC_MESSAGE_TYPE
+                                                        ? <Typography variant="body1" sx={{ mt: 1, whiteSpace: 'pre-wrap' }}>
+                                                            {String(message.body?.content ?? '')}
+                                                        </Typography>
+                                                        : <Box
+                                                            component="pre"
+                                                            sx={{ mt: 1, fontSize: '0.75rem', overflowX: 'auto', m: 0 }}
+                                                        >
+                                                            {JSON.stringify(message.body ?? {}, null, 2)}
+                                                        </Box>
+                                                    }
+                                                </Box>
+                                            );
+                                        })
+                                    }
+                                </Box>
+                            }
+
+                            {didcommTab === 'endpoint' &&
+                            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                             <Typography variant="body2" sx={{ opacity: 0.7 }}>
                                 Publish a messaging endpoint so other agents can send encrypted DIDComm messages to this identity.
                             </Typography>
@@ -7743,6 +7954,8 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                     Unpublish
                                 </Button>
                             </Box>
+                            </Box>
+                            }
                         </Box>
                     }
                     {tab === 'wallet' &&

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -52,6 +52,7 @@ import {
     Clear,
     ContentCopy,
     Create,
+    Forum,
     Groups,
     Delete,
     Download,
@@ -179,7 +180,7 @@ function formatAddedDate(value) {
     return value.slice(0, 10);
 }
 
-function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightning, serverUrl, onServerUrlChange }) {
+function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightning, hasDidComm, serverUrl, onServerUrlChange }) {
     const [tab, setTab] = useState(null);
     const [currentId, setCurrentId] = useState('');
     const [saveId, setSaveId] = useState('');
@@ -402,6 +403,11 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [lightningStatusFilter, setLightningStatusFilter] = useState({ settled: true, pending: true, failed: true, expired: true });
     const [isPublished, setIsPublished] = useState(false);
     const [loadingPublishToggle, setLoadingPublishToggle] = useState(false);
+    const [didcommStatus, setDidcommStatus] = useState(null);
+    const [didcommEndpoint, setDidcommEndpoint] = useState('');
+    const [didcommRoutingKeys, setDidcommRoutingKeys] = useState('');
+    const [didcommBusy, setDidcommBusy] = useState(false);
+
     const [refreshIntervalSeconds, setRefreshIntervalSeconds] = useState(() => loadRefreshIntervalSeconds());
     const [settingsRefreshIntervalSeconds, setSettingsRefreshIntervalSeconds] = useState(() => loadRefreshIntervalSeconds());
 
@@ -435,6 +441,81 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
         // eslint-disable-next-line
     }, [tab]);
+
+    useEffect(() => {
+        if (tab === 'didcomm') {
+            refreshDidComm();
+        }
+        // eslint-disable-next-line
+    }, [tab, currentId]);
+
+    async function refreshDidComm() {
+        if (!currentId) {
+            setDidcommStatus(null);
+            return;
+        }
+
+        try {
+            const docs = await keymaster.resolveDID(currentId);
+            const didDocument = docs.didDocument;
+            const service = (didDocument?.service || []).find(entry => entry.type === 'DIDCommMessaging');
+            const keyAgreement = Boolean(didDocument?.keyAgreement?.length);
+
+            if (!service && !keyAgreement) {
+                setDidcommStatus(null);
+                return;
+            }
+
+            // The plain string form carries no routing keys; the object form is
+            // what publishDidComm writes for an identity behind a mediator.
+            const endpoint = typeof service?.serviceEndpoint === 'string'
+                ? service.serviceEndpoint
+                : service?.serviceEndpoint?.uri;
+            const routingKeys = typeof service?.serviceEndpoint === 'object'
+                ? service.serviceEndpoint.routingKeys || []
+                : [];
+
+            setDidcommStatus({ keyAgreement, endpoint, routingKeys });
+        } catch (error) {
+            showError(error);
+            setDidcommStatus(null);
+        }
+    }
+
+    async function publishDidComm() {
+        setDidcommBusy(true);
+        try {
+            const keys = didcommRoutingKeys
+                .split(',')
+                .map(key => key.trim())
+                .filter(Boolean);
+
+            // An empty endpoint is not "no endpoint" -- it asks the node to supply
+            // its own relay, which is what most identities want.
+            await keymaster.publishDidComm(didcommEndpoint.trim() || undefined, currentId, keys.length ? keys : undefined);
+            showSuccess('DIDComm endpoint published');
+            setDidcommEndpoint('');
+            setDidcommRoutingKeys('');
+            await refreshDidComm();
+        } catch (error) {
+            showError(error);
+        } finally {
+            setDidcommBusy(false);
+        }
+    }
+
+    async function unpublishDidComm() {
+        setDidcommBusy(true);
+        try {
+            await keymaster.unpublishDidComm(currentId);
+            showSuccess('DIDComm endpoint unpublished');
+            await refreshDidComm();
+        } catch (error) {
+            showError(error);
+        } finally {
+            setDidcommBusy(false);
+        }
+    }
 
     function showAlert(warning) {
         setSnackbar({
@@ -4572,6 +4653,9 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                         {currentId && !widget && hasLightning &&
                             <Tab key="lightning" value="lightning" label={'Lightning'} icon={<Bolt />} />
                         }
+                        {currentId && !widget && hasDidComm &&
+                            <Tab key="didcomm" value="didcomm" label={'DIDComm'} icon={<Forum />} />
+                        }
                         {currentId &&
                             <Tab key="auth" value="auth" label={'Auth'} icon={<Key />} />
                         }
@@ -7586,6 +7670,79 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                     }
                                 </Box>
                             }
+                        </Box>
+                    }
+                    {tab === 'didcomm' &&
+                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, maxWidth: 700, mt: 2 }}>
+                            <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                Publish a messaging endpoint so other agents can send encrypted DIDComm messages to this identity.
+                            </Typography>
+
+                            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                                <Typography variant="subtitle2">Published</Typography>
+                                {didcommStatus
+                                    ? <>
+                                        {didcommStatus.endpoint
+                                            ? <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
+                                                <strong>Endpoint:</strong> {didcommStatus.endpoint}
+                                            </Typography>
+                                            : <Typography variant="body2">
+                                                <strong>Endpoint:</strong> key only (others can encrypt to this identity but have nowhere to deliver)
+                                            </Typography>
+                                        }
+                                        {didcommStatus.routingKeys.length > 0 &&
+                                            <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
+                                                <strong>Routing keys:</strong> {didcommStatus.routingKeys.join(', ')}
+                                            </Typography>
+                                        }
+                                        <Typography variant="body2">
+                                            <strong>Key agreement:</strong> {didcommStatus.keyAgreement ? 'published' : 'missing'}
+                                        </Typography>
+                                    </>
+                                    : <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                        Nothing published for this identity yet.
+                                    </Typography>
+                                }
+                            </Box>
+
+                            <TextField
+                                label="Endpoint URL (optional)"
+                                value={didcommEndpoint}
+                                onChange={(e) => setDidcommEndpoint(e.target.value)}
+                                disabled={didcommBusy}
+                                placeholder="https://relay.example/didcomm"
+                                helperText="Leave blank to use this node's own relay."
+                                fullWidth
+                            />
+
+                            <TextField
+                                label="Routing keys (optional, comma separated)"
+                                value={didcommRoutingKeys}
+                                onChange={(e) => setDidcommRoutingKeys(e.target.value)}
+                                disabled={didcommBusy}
+                                placeholder="did:cid:mediator#key-agreement-1"
+                                helperText="Set these when delivery goes through a mediator; senders then wrap messages in a Forward."
+                                fullWidth
+                            />
+
+                            <Box sx={{ display: 'flex', gap: 1 }}>
+                                <Button
+                                    variant="contained"
+                                    color="primary"
+                                    onClick={publishDidComm}
+                                    disabled={didcommBusy}
+                                >
+                                    {didcommStatus ? 'Update' : 'Publish'}
+                                </Button>
+                                <Button
+                                    variant="outlined"
+                                    color="primary"
+                                    onClick={unpublishDidComm}
+                                    disabled={didcommBusy || !didcommStatus}
+                                >
+                                    Unpublish
+                                </Button>
+                            </Box>
                         </Box>
                     }
                     {tab === 'wallet' &&

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -418,8 +418,11 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [didcommMessages, setDidcommMessages] = useState([]);
     const [didcommInboxLoading, setDidcommInboxLoading] = useState(false);
     // A ref, not the loading flag: the poll's interval callback closes over the
-    // render that created it, so a state read there would always be stale.
-    const didcommPollingRef = useRef(false);
+    // render that created it, so a state read there would always be stale. Keyed
+    // by identity, so an in-flight read neither blocks nor overwrites a read for a
+    // different identity.
+    const didcommInFlightRef = useRef(null);
+    const didcommActiveIdRef = useRef('');
     const [didcommStatus, setDidcommStatus] = useState(null);
     const [didcommEndpoint, setDidcommEndpoint] = useState('');
     const [didcommRoutingKeys, setDidcommRoutingKeys] = useState('');
@@ -460,6 +463,10 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     }, [tab]);
 
     useEffect(() => {
+        didcommActiveIdRef.current = currentId;
+        // Drop the previous identity's mail immediately rather than leaving it on
+        // screen under the new name until the fetch returns.
+        setDidcommMessages([]);
         if (tab === 'didcomm') {
             refreshDidComm();
             refreshDidCommInbox({ quiet: true });
@@ -519,19 +526,27 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     // the whole mailbox. The list is replaced rather than accumulated: what is on
     // screen is exactly what is still in the mailbox.
     async function refreshDidCommInbox(options = {}) {
-        if (!currentId) {
+        const requested = currentId;
+
+        if (!requested) {
             setDidcommMessages([]);
             return;
         }
 
-        if (didcommPollingRef.current) {
+        if (didcommInFlightRef.current === requested) {
             return;
         }
-        didcommPollingRef.current = true;
+        didcommInFlightRef.current = requested;
         setDidcommInboxLoading(true);
 
         try {
-            const received = await keymaster.receiveDidComm({ name: currentId, ack: false });
+            const received = await keymaster.receiveDidComm({ name: requested, ack: false });
+            // A read that finishes after the identity changed belongs to nobody on
+            // screen; committing it would show one identity's mail under another's
+            // name, and with polling off it would stay there.
+            if (didcommActiveIdRef.current !== requested) {
+                return;
+            }
             setDidcommMessages(received);
         } catch (error) {
             // A polled failure is usually a node that is briefly unreachable; only
@@ -540,7 +555,9 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                 showError(error);
             }
         } finally {
-            didcommPollingRef.current = false;
+            if (didcommInFlightRef.current === requested) {
+                didcommInFlightRef.current = null;
+            }
             setDidcommInboxLoading(false);
         }
     }
@@ -614,9 +631,13 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
 
     async function respondToDidCommPing(received) {
         const message = received.message || {};
+        // Only the envelope's authenticated sender is safe to address. The
+        // plaintext `from` is the sender's own claim, so responding to it could
+        // send the answer to a party who never pinged.
+        const sender = didcommAuthenticatedSender(received);
 
-        if (!message.from || !message.id) {
-            showError('This ping carries no sender to respond to');
+        if (!sender || !message.id) {
+            showError('This ping has no authenticated sender to respond to');
             return;
         }
 
@@ -624,7 +645,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         try {
             await keymaster.sendDidComm(
                 { type: TRUST_PING_RESPONSE_TYPE, body: {}, thid: message.id },
-                message.from,
+                sender,
                 { name: currentId },
             );
             showSuccess('Ping response sent');
@@ -633,6 +654,17 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         } finally {
             setDidcommBusy(false);
         }
+    }
+
+    // Authcrypt binds the sender to the envelope; `message.from` is an unverified
+    // claim inside it. unpack now rejects a mismatch outright, so this is the
+    // second line of the same rule: never address or display a claim as if the
+    // envelope vouched for it.
+    function didcommAuthenticatedSender(received) {
+        if (!received.metadata?.authenticated || !received.metadata?.sender) {
+            return undefined;
+        }
+        return received.metadata.sender.split('#')[0];
     }
 
     function didcommMessageLabel(type) {
@@ -7875,7 +7907,8 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                         </Typography>
                                         : didcommMessages.map((received) => {
                                             const message = received.message || {};
-                                            const sender = message.from || received.metadata?.sender;
+                                            const sender = didcommAuthenticatedSender(received);
+                                            const claimed = typeof message.from === 'string' ? message.from : undefined;
                                             // DIDComm created_time is seconds since the epoch, not milliseconds.
                                             const time = message.created_time
                                                 ? new Date(message.created_time * 1000).toLocaleString()
@@ -7898,7 +7931,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                             </Typography>
                                                         }
                                                         <Box sx={{ ml: 'auto', display: 'flex', gap: 1 }}>
-                                                            {message.type === TRUST_PING_TYPE &&
+                                                            {message.type === TRUST_PING_TYPE && sender &&
                                                                 <Button
                                                                     size="small"
                                                                     onClick={() => respondToDidCommPing(received)}
@@ -7927,7 +7960,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                         </Box>
                                                     </Box>
                                                     <Typography variant="body2" sx={{ opacity: 0.7, wordBreak: 'break-all' }}>
-                                                        From: {sender || 'unknown'}
+                                                        From: {sender || (claimed ? `${claimed} (unverified)` : 'unknown')}
                                                     </Typography>
                                                     {message.type === BASIC_MESSAGE_TYPE
                                                         ? <Typography variant="body1" sx={{ mt: 1, whiteSpace: 'pre-wrap' }}>

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -411,6 +411,10 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const TRUST_PING_RESPONSE_TYPE = 'https://didcomm.org/trust-ping/2.0/ping-response';
 
     const [didcommTab, setDidcommTab] = useState('inbox');
+    const [didcommComposeTo, setDidcommComposeTo] = useState('');
+    const [didcommComposeKind, setDidcommComposeKind] = useState('message');
+    const [didcommComposeContent, setDidcommComposeContent] = useState('');
+    const [didcommComposeAnoncrypt, setDidcommComposeAnoncrypt] = useState(false);
     const [didcommMessages, setDidcommMessages] = useState([]);
     const [didcommInboxLoading, setDidcommInboxLoading] = useState(false);
     // A ref, not the loading flag: the poll's interval callback closes over the
@@ -539,6 +543,56 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             didcommPollingRef.current = false;
             setDidcommInboxLoading(false);
         }
+    }
+
+    async function sendDidCommMessage() {
+        const recipient = didcommComposeTo.trim();
+
+        if (!recipient) {
+            showError('Enter a recipient DID or alias');
+            return;
+        }
+
+        if (didcommComposeKind === 'message' && !didcommComposeContent.trim()) {
+            showError('Enter a message to send');
+            return;
+        }
+
+        setDidcommBusy(true);
+        try {
+            // Resolve first: an alias must not travel in the envelope, which
+            // addresses recipients by DID. This also turns an unknown name into a
+            // clear error before any crypto happens.
+            const docs = await keymaster.resolveDID(recipient);
+            const recipientDid = docs.didDocument?.id;
+
+            if (!recipientDid) {
+                showError(`Could not resolve ${recipient}`);
+                return;
+            }
+
+            const message = didcommComposeKind === 'ping'
+                ? { type: TRUST_PING_TYPE, body: { response_requested: true } }
+                : { type: BASIC_MESSAGE_TYPE, body: { content: didcommComposeContent } };
+
+            await keymaster.sendDidComm(message, recipientDid, {
+                name: currentId,
+                anoncrypt: didcommComposeAnoncrypt,
+            });
+
+            showSuccess(didcommComposeKind === 'ping' ? 'Ping sent' : 'Message sent');
+            setDidcommComposeContent('');
+        } catch (error) {
+            showError(error);
+        } finally {
+            setDidcommBusy(false);
+        }
+    }
+
+    function replyToDidComm(sender) {
+        setDidcommComposeTo(sender);
+        setDidcommComposeKind('message');
+        setDidcommTab('compose');
     }
 
     async function dismissDidComm(ids) {
@@ -7790,6 +7844,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                 textColor="primary"
                             >
                                 <Tab label="Inbox" value="inbox" />
+                                <Tab label="Compose" value="compose" />
                                 <Tab label="Endpoint" value="endpoint" />
                             </Tabs>
 
@@ -7852,6 +7907,15 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                                     Respond
                                                                 </Button>
                                                             }
+                                                            {message.type === BASIC_MESSAGE_TYPE && sender &&
+                                                                <Button
+                                                                    size="small"
+                                                                    onClick={() => replyToDidComm(sender)}
+                                                                    disabled={didcommBusy}
+                                                                >
+                                                                    Reply
+                                                                </Button>
+                                                            }
                                                             <Button
                                                                 size="small"
                                                                 color="error"
@@ -7880,6 +7944,75 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                             );
                                         })
                                     }
+                                </Box>
+                            }
+
+                            {didcommTab === 'compose' &&
+                                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                                    <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                        Send a DIDComm message to any agent that publishes a messaging endpoint.
+                                    </Typography>
+
+                                    <TextField
+                                        label="To (DID or alias)"
+                                        value={didcommComposeTo}
+                                        onChange={(e) => setDidcommComposeTo(e.target.value)}
+                                        disabled={didcommBusy}
+                                        placeholder="did:cid:... or a wallet alias"
+                                        fullWidth
+                                    />
+
+                                    <TextField
+                                        select
+                                        label="Type"
+                                        value={didcommComposeKind}
+                                        onChange={(e) => setDidcommComposeKind(e.target.value)}
+                                        disabled={didcommBusy}
+                                        fullWidth
+                                    >
+                                        <MenuItem value="message">Message</MenuItem>
+                                        <MenuItem value="ping">Trust ping</MenuItem>
+                                    </TextField>
+
+                                    {didcommComposeKind === 'message' &&
+                                        <TextField
+                                            label="Message"
+                                            value={didcommComposeContent}
+                                            onChange={(e) => setDidcommComposeContent(e.target.value)}
+                                            disabled={didcommBusy}
+                                            multiline
+                                            minRows={4}
+                                            fullWidth
+                                        />
+                                    }
+
+                                    <Box>
+                                        <FormControlLabel
+                                            control={
+                                                <Checkbox
+                                                    checked={didcommComposeAnoncrypt}
+                                                    onChange={(e) => setDidcommComposeAnoncrypt(e.target.checked)}
+                                                    disabled={didcommBusy}
+                                                />
+                                            }
+                                            label="Send anonymously"
+                                        />
+                                        <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                            {didcommComposeAnoncrypt
+                                                ? 'The recipient cannot tell who sent this, and cannot reply to it.'
+                                                : 'The recipient can verify this came from the current identity.'}
+                                        </Typography>
+                                    </Box>
+
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
+                                        onClick={sendDidCommMessage}
+                                        disabled={didcommBusy}
+                                        sx={{ alignSelf: 'start' }}
+                                    >
+                                        Send
+                                    </Button>
                                 </Box>
                             }
 

--- a/apps/keymaster-client/src/App.jsx
+++ b/apps/keymaster-client/src/App.jsx
@@ -11,6 +11,10 @@ const keymasterUrl = localStorage.getItem(STORAGE_KEY) || defaultUrl;
 
 function App() {
     const [keymaster, setKeymaster] = useState(null);
+    // Unknown (a node serving no capability manifest) is permissive, matching the
+    // gate inside Keymaster: show the surface rather than hide it against an
+    // older node, and let the operation fail late if the service really is absent.
+    const [hasDidComm, setHasDidComm] = useState(true);
     const [showLogin, setShowLogin] = useState(true);
     const [loginError, setLoginError] = useState('');
 
@@ -36,6 +40,13 @@ function App() {
             if (adminApiKey) {
                 km.addCustomHeader('Authorization', `Bearer ${adminApiKey}`);
             }
+            try {
+                const capabilities = await km.getNodeCapabilities();
+                setHasDidComm(capabilities?.didcomm !== false);
+            } catch {
+                // Capability manifest unreadable — leave DIDComm visible.
+            }
+
             setShowLogin(false);
             setKeymaster(km);
         } catch {
@@ -61,6 +72,7 @@ function App() {
                 <KeymasterUI
                     keymaster={keymaster}
                     title={'Keymaster Server Wallet Demo'}
+                    hasDidComm={hasDidComm}
                     serverUrl={keymasterUrl}
                     onServerUrlChange={handleServerUrlChange}
                 />

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -403,6 +403,19 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [lightningStatusFilter, setLightningStatusFilter] = useState({ settled: true, pending: true, failed: true, expired: true });
     const [isPublished, setIsPublished] = useState(false);
     const [loadingPublishToggle, setLoadingPublishToggle] = useState(false);
+    // Inlined rather than imported from @didcid/keymaster: this file is shared with
+    // the server-wallet demo, which deliberately depends only on the thin client
+    // package. These are stable DIDComm protocol URIs.
+    const BASIC_MESSAGE_TYPE = 'https://didcomm.org/basicmessage/2.0/message';
+    const TRUST_PING_TYPE = 'https://didcomm.org/trust-ping/2.0/ping';
+    const TRUST_PING_RESPONSE_TYPE = 'https://didcomm.org/trust-ping/2.0/ping-response';
+
+    const [didcommTab, setDidcommTab] = useState('inbox');
+    const [didcommMessages, setDidcommMessages] = useState([]);
+    const [didcommInboxLoading, setDidcommInboxLoading] = useState(false);
+    // A ref, not the loading flag: the poll's interval callback closes over the
+    // render that created it, so a state read there would always be stale.
+    const didcommPollingRef = useRef(false);
     const [didcommStatus, setDidcommStatus] = useState(null);
     const [didcommEndpoint, setDidcommEndpoint] = useState('');
     const [didcommRoutingKeys, setDidcommRoutingKeys] = useState('');
@@ -445,9 +458,25 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     useEffect(() => {
         if (tab === 'didcomm') {
             refreshDidComm();
+            refreshDidCommInbox({ quiet: true });
         }
         // eslint-disable-next-line
     }, [tab, currentId]);
+
+    useEffect(() => {
+        // Poll only while the DIDComm screen is open, at the interval configured in
+        // Settings. Zero means manual refresh only.
+        if (tab !== 'didcomm' || refreshIntervalSeconds === 0) {
+            return;
+        }
+
+        const interval = setInterval(() => {
+            refreshDidCommInbox({ quiet: true });
+        }, refreshIntervalSeconds * 1000);
+
+        return () => clearInterval(interval);
+        // eslint-disable-next-line
+    }, [tab, currentId, refreshIntervalSeconds]);
 
     async function refreshDidComm() {
         if (!currentId) {
@@ -480,6 +509,86 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             showError(error);
             setDidcommStatus(null);
         }
+    }
+
+    // Reading with ack: false leaves everything on the server, so each poll returns
+    // the whole mailbox. The list is replaced rather than accumulated: what is on
+    // screen is exactly what is still in the mailbox.
+    async function refreshDidCommInbox(options = {}) {
+        if (!currentId) {
+            setDidcommMessages([]);
+            return;
+        }
+
+        if (didcommPollingRef.current) {
+            return;
+        }
+        didcommPollingRef.current = true;
+        setDidcommInboxLoading(true);
+
+        try {
+            const received = await keymaster.receiveDidComm({ name: currentId, ack: false });
+            setDidcommMessages(received);
+        } catch (error) {
+            // A polled failure is usually a node that is briefly unreachable; only
+            // an explicit refresh should raise a snackbar.
+            if (!options.quiet) {
+                showError(error);
+            }
+        } finally {
+            didcommPollingRef.current = false;
+            setDidcommInboxLoading(false);
+        }
+    }
+
+    async function dismissDidComm(ids) {
+        if (!ids.length) {
+            return;
+        }
+
+        setDidcommBusy(true);
+        try {
+            const removed = await keymaster.ackDidComm(ids, { name: currentId });
+            showSuccess(removed === 1 ? 'Message dismissed' : `${removed} messages dismissed`);
+            await refreshDidCommInbox();
+        } catch (error) {
+            showError(error);
+        } finally {
+            setDidcommBusy(false);
+        }
+    }
+
+    async function respondToDidCommPing(received) {
+        const message = received.message || {};
+
+        if (!message.from || !message.id) {
+            showError('This ping carries no sender to respond to');
+            return;
+        }
+
+        setDidcommBusy(true);
+        try {
+            await keymaster.sendDidComm(
+                { type: TRUST_PING_RESPONSE_TYPE, body: {}, thid: message.id },
+                message.from,
+                { name: currentId },
+            );
+            showSuccess('Ping response sent');
+        } catch (error) {
+            showError(error);
+        } finally {
+            setDidcommBusy(false);
+        }
+    }
+
+    function didcommMessageLabel(type) {
+        if (type === BASIC_MESSAGE_TYPE) {
+            return 'Message';
+        }
+        if (type === TRUST_PING_TYPE) {
+            return 'Trust ping';
+        }
+        return type || 'Unknown';
     }
 
     async function publishDidComm() {
@@ -7674,6 +7783,108 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                     }
                     {tab === 'didcomm' &&
                         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, maxWidth: 700, mt: 2 }}>
+                            <Tabs
+                                value={didcommTab}
+                                onChange={(_, v) => setDidcommTab(v)}
+                                indicatorColor="primary"
+                                textColor="primary"
+                            >
+                                <Tab label="Inbox" value="inbox" />
+                                <Tab label="Endpoint" value="endpoint" />
+                            </Tabs>
+
+                            {didcommTab === 'inbox' &&
+                                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                                    <Box sx={{ display: 'flex', gap: 1 }}>
+                                        <Button
+                                            variant="contained"
+                                            color="primary"
+                                            onClick={() => refreshDidCommInbox()}
+                                            disabled={didcommBusy || didcommInboxLoading}
+                                        >
+                                            Refresh
+                                        </Button>
+                                        <Button
+                                            variant="outlined"
+                                            color="primary"
+                                            onClick={() => dismissDidComm(didcommMessages.map(m => m.id))}
+                                            disabled={didcommBusy || !didcommMessages.length}
+                                        >
+                                            Dismiss All
+                                        </Button>
+                                    </Box>
+
+                                    {didcommMessages.length === 0
+                                        ? <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                            {didcommInboxLoading ? 'Loading...' : 'No messages in the mailbox for this identity.'}
+                                        </Typography>
+                                        : didcommMessages.map((received) => {
+                                            const message = received.message || {};
+                                            const sender = message.from || received.metadata?.sender;
+                                            // DIDComm created_time is seconds since the epoch, not milliseconds.
+                                            const time = message.created_time
+                                                ? new Date(message.created_time * 1000).toLocaleString()
+                                                : '';
+
+                                            return (
+                                                <Box key={received.id} sx={{ borderBottom: 1, borderColor: 'divider', pb: 1.5 }}>
+                                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                                                        <Typography variant="subtitle2">
+                                                            {didcommMessageLabel(message.type)}
+                                                        </Typography>
+                                                        {/* Anoncrypt hides the sender entirely, so "who sent this" and
+                                                            "is that claim verified" are two different questions. */}
+                                                        <Typography variant="caption" sx={{ opacity: 0.7 }}>
+                                                            {received.metadata?.authenticated ? 'authenticated' : 'anonymous'}
+                                                        </Typography>
+                                                        {time &&
+                                                            <Typography variant="caption" sx={{ opacity: 0.7 }}>
+                                                                {time}
+                                                            </Typography>
+                                                        }
+                                                        <Box sx={{ ml: 'auto', display: 'flex', gap: 1 }}>
+                                                            {message.type === TRUST_PING_TYPE &&
+                                                                <Button
+                                                                    size="small"
+                                                                    onClick={() => respondToDidCommPing(received)}
+                                                                    disabled={didcommBusy}
+                                                                >
+                                                                    Respond
+                                                                </Button>
+                                                            }
+                                                            <Button
+                                                                size="small"
+                                                                color="error"
+                                                                onClick={() => dismissDidComm([received.id])}
+                                                                disabled={didcommBusy}
+                                                            >
+                                                                Dismiss
+                                                            </Button>
+                                                        </Box>
+                                                    </Box>
+                                                    <Typography variant="body2" sx={{ opacity: 0.7, wordBreak: 'break-all' }}>
+                                                        From: {sender || 'unknown'}
+                                                    </Typography>
+                                                    {message.type === BASIC_MESSAGE_TYPE
+                                                        ? <Typography variant="body1" sx={{ mt: 1, whiteSpace: 'pre-wrap' }}>
+                                                            {String(message.body?.content ?? '')}
+                                                        </Typography>
+                                                        : <Box
+                                                            component="pre"
+                                                            sx={{ mt: 1, fontSize: '0.75rem', overflowX: 'auto', m: 0 }}
+                                                        >
+                                                            {JSON.stringify(message.body ?? {}, null, 2)}
+                                                        </Box>
+                                                    }
+                                                </Box>
+                                            );
+                                        })
+                                    }
+                                </Box>
+                            }
+
+                            {didcommTab === 'endpoint' &&
+                            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                             <Typography variant="body2" sx={{ opacity: 0.7 }}>
                                 Publish a messaging endpoint so other agents can send encrypted DIDComm messages to this identity.
                             </Typography>
@@ -7743,6 +7954,8 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                     Unpublish
                                 </Button>
                             </Box>
+                            </Box>
+                            }
                         </Box>
                     }
                     {tab === 'wallet' &&

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -52,6 +52,7 @@ import {
     Clear,
     ContentCopy,
     Create,
+    Forum,
     Groups,
     Delete,
     Download,
@@ -179,7 +180,7 @@ function formatAddedDate(value) {
     return value.slice(0, 10);
 }
 
-function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightning, serverUrl, onServerUrlChange }) {
+function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightning, hasDidComm, serverUrl, onServerUrlChange }) {
     const [tab, setTab] = useState(null);
     const [currentId, setCurrentId] = useState('');
     const [saveId, setSaveId] = useState('');
@@ -402,6 +403,11 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [lightningStatusFilter, setLightningStatusFilter] = useState({ settled: true, pending: true, failed: true, expired: true });
     const [isPublished, setIsPublished] = useState(false);
     const [loadingPublishToggle, setLoadingPublishToggle] = useState(false);
+    const [didcommStatus, setDidcommStatus] = useState(null);
+    const [didcommEndpoint, setDidcommEndpoint] = useState('');
+    const [didcommRoutingKeys, setDidcommRoutingKeys] = useState('');
+    const [didcommBusy, setDidcommBusy] = useState(false);
+
     const [refreshIntervalSeconds, setRefreshIntervalSeconds] = useState(() => loadRefreshIntervalSeconds());
     const [settingsRefreshIntervalSeconds, setSettingsRefreshIntervalSeconds] = useState(() => loadRefreshIntervalSeconds());
 
@@ -435,6 +441,81 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
         // eslint-disable-next-line
     }, [tab]);
+
+    useEffect(() => {
+        if (tab === 'didcomm') {
+            refreshDidComm();
+        }
+        // eslint-disable-next-line
+    }, [tab, currentId]);
+
+    async function refreshDidComm() {
+        if (!currentId) {
+            setDidcommStatus(null);
+            return;
+        }
+
+        try {
+            const docs = await keymaster.resolveDID(currentId);
+            const didDocument = docs.didDocument;
+            const service = (didDocument?.service || []).find(entry => entry.type === 'DIDCommMessaging');
+            const keyAgreement = Boolean(didDocument?.keyAgreement?.length);
+
+            if (!service && !keyAgreement) {
+                setDidcommStatus(null);
+                return;
+            }
+
+            // The plain string form carries no routing keys; the object form is
+            // what publishDidComm writes for an identity behind a mediator.
+            const endpoint = typeof service?.serviceEndpoint === 'string'
+                ? service.serviceEndpoint
+                : service?.serviceEndpoint?.uri;
+            const routingKeys = typeof service?.serviceEndpoint === 'object'
+                ? service.serviceEndpoint.routingKeys || []
+                : [];
+
+            setDidcommStatus({ keyAgreement, endpoint, routingKeys });
+        } catch (error) {
+            showError(error);
+            setDidcommStatus(null);
+        }
+    }
+
+    async function publishDidComm() {
+        setDidcommBusy(true);
+        try {
+            const keys = didcommRoutingKeys
+                .split(',')
+                .map(key => key.trim())
+                .filter(Boolean);
+
+            // An empty endpoint is not "no endpoint" -- it asks the node to supply
+            // its own relay, which is what most identities want.
+            await keymaster.publishDidComm(didcommEndpoint.trim() || undefined, currentId, keys.length ? keys : undefined);
+            showSuccess('DIDComm endpoint published');
+            setDidcommEndpoint('');
+            setDidcommRoutingKeys('');
+            await refreshDidComm();
+        } catch (error) {
+            showError(error);
+        } finally {
+            setDidcommBusy(false);
+        }
+    }
+
+    async function unpublishDidComm() {
+        setDidcommBusy(true);
+        try {
+            await keymaster.unpublishDidComm(currentId);
+            showSuccess('DIDComm endpoint unpublished');
+            await refreshDidComm();
+        } catch (error) {
+            showError(error);
+        } finally {
+            setDidcommBusy(false);
+        }
+    }
 
     function showAlert(warning) {
         setSnackbar({
@@ -4572,6 +4653,9 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                         {currentId && !widget && hasLightning &&
                             <Tab key="lightning" value="lightning" label={'Lightning'} icon={<Bolt />} />
                         }
+                        {currentId && !widget && hasDidComm &&
+                            <Tab key="didcomm" value="didcomm" label={'DIDComm'} icon={<Forum />} />
+                        }
                         {currentId &&
                             <Tab key="auth" value="auth" label={'Auth'} icon={<Key />} />
                         }
@@ -7586,6 +7670,79 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                     }
                                 </Box>
                             }
+                        </Box>
+                    }
+                    {tab === 'didcomm' &&
+                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, maxWidth: 700, mt: 2 }}>
+                            <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                Publish a messaging endpoint so other agents can send encrypted DIDComm messages to this identity.
+                            </Typography>
+
+                            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                                <Typography variant="subtitle2">Published</Typography>
+                                {didcommStatus
+                                    ? <>
+                                        {didcommStatus.endpoint
+                                            ? <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
+                                                <strong>Endpoint:</strong> {didcommStatus.endpoint}
+                                            </Typography>
+                                            : <Typography variant="body2">
+                                                <strong>Endpoint:</strong> key only (others can encrypt to this identity but have nowhere to deliver)
+                                            </Typography>
+                                        }
+                                        {didcommStatus.routingKeys.length > 0 &&
+                                            <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
+                                                <strong>Routing keys:</strong> {didcommStatus.routingKeys.join(', ')}
+                                            </Typography>
+                                        }
+                                        <Typography variant="body2">
+                                            <strong>Key agreement:</strong> {didcommStatus.keyAgreement ? 'published' : 'missing'}
+                                        </Typography>
+                                    </>
+                                    : <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                        Nothing published for this identity yet.
+                                    </Typography>
+                                }
+                            </Box>
+
+                            <TextField
+                                label="Endpoint URL (optional)"
+                                value={didcommEndpoint}
+                                onChange={(e) => setDidcommEndpoint(e.target.value)}
+                                disabled={didcommBusy}
+                                placeholder="https://relay.example/didcomm"
+                                helperText="Leave blank to use this node's own relay."
+                                fullWidth
+                            />
+
+                            <TextField
+                                label="Routing keys (optional, comma separated)"
+                                value={didcommRoutingKeys}
+                                onChange={(e) => setDidcommRoutingKeys(e.target.value)}
+                                disabled={didcommBusy}
+                                placeholder="did:cid:mediator#key-agreement-1"
+                                helperText="Set these when delivery goes through a mediator; senders then wrap messages in a Forward."
+                                fullWidth
+                            />
+
+                            <Box sx={{ display: 'flex', gap: 1 }}>
+                                <Button
+                                    variant="contained"
+                                    color="primary"
+                                    onClick={publishDidComm}
+                                    disabled={didcommBusy}
+                                >
+                                    {didcommStatus ? 'Update' : 'Publish'}
+                                </Button>
+                                <Button
+                                    variant="outlined"
+                                    color="primary"
+                                    onClick={unpublishDidComm}
+                                    disabled={didcommBusy || !didcommStatus}
+                                >
+                                    Unpublish
+                                </Button>
+                            </Box>
                         </Box>
                     }
                     {tab === 'wallet' &&

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -418,8 +418,11 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [didcommMessages, setDidcommMessages] = useState([]);
     const [didcommInboxLoading, setDidcommInboxLoading] = useState(false);
     // A ref, not the loading flag: the poll's interval callback closes over the
-    // render that created it, so a state read there would always be stale.
-    const didcommPollingRef = useRef(false);
+    // render that created it, so a state read there would always be stale. Keyed
+    // by identity, so an in-flight read neither blocks nor overwrites a read for a
+    // different identity.
+    const didcommInFlightRef = useRef(null);
+    const didcommActiveIdRef = useRef('');
     const [didcommStatus, setDidcommStatus] = useState(null);
     const [didcommEndpoint, setDidcommEndpoint] = useState('');
     const [didcommRoutingKeys, setDidcommRoutingKeys] = useState('');
@@ -460,6 +463,10 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     }, [tab]);
 
     useEffect(() => {
+        didcommActiveIdRef.current = currentId;
+        // Drop the previous identity's mail immediately rather than leaving it on
+        // screen under the new name until the fetch returns.
+        setDidcommMessages([]);
         if (tab === 'didcomm') {
             refreshDidComm();
             refreshDidCommInbox({ quiet: true });
@@ -519,19 +526,27 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     // the whole mailbox. The list is replaced rather than accumulated: what is on
     // screen is exactly what is still in the mailbox.
     async function refreshDidCommInbox(options = {}) {
-        if (!currentId) {
+        const requested = currentId;
+
+        if (!requested) {
             setDidcommMessages([]);
             return;
         }
 
-        if (didcommPollingRef.current) {
+        if (didcommInFlightRef.current === requested) {
             return;
         }
-        didcommPollingRef.current = true;
+        didcommInFlightRef.current = requested;
         setDidcommInboxLoading(true);
 
         try {
-            const received = await keymaster.receiveDidComm({ name: currentId, ack: false });
+            const received = await keymaster.receiveDidComm({ name: requested, ack: false });
+            // A read that finishes after the identity changed belongs to nobody on
+            // screen; committing it would show one identity's mail under another's
+            // name, and with polling off it would stay there.
+            if (didcommActiveIdRef.current !== requested) {
+                return;
+            }
             setDidcommMessages(received);
         } catch (error) {
             // A polled failure is usually a node that is briefly unreachable; only
@@ -540,7 +555,9 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                 showError(error);
             }
         } finally {
-            didcommPollingRef.current = false;
+            if (didcommInFlightRef.current === requested) {
+                didcommInFlightRef.current = null;
+            }
             setDidcommInboxLoading(false);
         }
     }
@@ -614,9 +631,13 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
 
     async function respondToDidCommPing(received) {
         const message = received.message || {};
+        // Only the envelope's authenticated sender is safe to address. The
+        // plaintext `from` is the sender's own claim, so responding to it could
+        // send the answer to a party who never pinged.
+        const sender = didcommAuthenticatedSender(received);
 
-        if (!message.from || !message.id) {
-            showError('This ping carries no sender to respond to');
+        if (!sender || !message.id) {
+            showError('This ping has no authenticated sender to respond to');
             return;
         }
 
@@ -624,7 +645,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         try {
             await keymaster.sendDidComm(
                 { type: TRUST_PING_RESPONSE_TYPE, body: {}, thid: message.id },
-                message.from,
+                sender,
                 { name: currentId },
             );
             showSuccess('Ping response sent');
@@ -633,6 +654,17 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         } finally {
             setDidcommBusy(false);
         }
+    }
+
+    // Authcrypt binds the sender to the envelope; `message.from` is an unverified
+    // claim inside it. unpack now rejects a mismatch outright, so this is the
+    // second line of the same rule: never address or display a claim as if the
+    // envelope vouched for it.
+    function didcommAuthenticatedSender(received) {
+        if (!received.metadata?.authenticated || !received.metadata?.sender) {
+            return undefined;
+        }
+        return received.metadata.sender.split('#')[0];
     }
 
     function didcommMessageLabel(type) {
@@ -7875,7 +7907,8 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                         </Typography>
                                         : didcommMessages.map((received) => {
                                             const message = received.message || {};
-                                            const sender = message.from || received.metadata?.sender;
+                                            const sender = didcommAuthenticatedSender(received);
+                                            const claimed = typeof message.from === 'string' ? message.from : undefined;
                                             // DIDComm created_time is seconds since the epoch, not milliseconds.
                                             const time = message.created_time
                                                 ? new Date(message.created_time * 1000).toLocaleString()
@@ -7898,7 +7931,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                             </Typography>
                                                         }
                                                         <Box sx={{ ml: 'auto', display: 'flex', gap: 1 }}>
-                                                            {message.type === TRUST_PING_TYPE &&
+                                                            {message.type === TRUST_PING_TYPE && sender &&
                                                                 <Button
                                                                     size="small"
                                                                     onClick={() => respondToDidCommPing(received)}
@@ -7927,7 +7960,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                         </Box>
                                                     </Box>
                                                     <Typography variant="body2" sx={{ opacity: 0.7, wordBreak: 'break-all' }}>
-                                                        From: {sender || 'unknown'}
+                                                        From: {sender || (claimed ? `${claimed} (unverified)` : 'unknown')}
                                                     </Typography>
                                                     {message.type === BASIC_MESSAGE_TYPE
                                                         ? <Typography variant="body1" sx={{ mt: 1, whiteSpace: 'pre-wrap' }}>

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -411,6 +411,10 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const TRUST_PING_RESPONSE_TYPE = 'https://didcomm.org/trust-ping/2.0/ping-response';
 
     const [didcommTab, setDidcommTab] = useState('inbox');
+    const [didcommComposeTo, setDidcommComposeTo] = useState('');
+    const [didcommComposeKind, setDidcommComposeKind] = useState('message');
+    const [didcommComposeContent, setDidcommComposeContent] = useState('');
+    const [didcommComposeAnoncrypt, setDidcommComposeAnoncrypt] = useState(false);
     const [didcommMessages, setDidcommMessages] = useState([]);
     const [didcommInboxLoading, setDidcommInboxLoading] = useState(false);
     // A ref, not the loading flag: the poll's interval callback closes over the
@@ -539,6 +543,56 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             didcommPollingRef.current = false;
             setDidcommInboxLoading(false);
         }
+    }
+
+    async function sendDidCommMessage() {
+        const recipient = didcommComposeTo.trim();
+
+        if (!recipient) {
+            showError('Enter a recipient DID or alias');
+            return;
+        }
+
+        if (didcommComposeKind === 'message' && !didcommComposeContent.trim()) {
+            showError('Enter a message to send');
+            return;
+        }
+
+        setDidcommBusy(true);
+        try {
+            // Resolve first: an alias must not travel in the envelope, which
+            // addresses recipients by DID. This also turns an unknown name into a
+            // clear error before any crypto happens.
+            const docs = await keymaster.resolveDID(recipient);
+            const recipientDid = docs.didDocument?.id;
+
+            if (!recipientDid) {
+                showError(`Could not resolve ${recipient}`);
+                return;
+            }
+
+            const message = didcommComposeKind === 'ping'
+                ? { type: TRUST_PING_TYPE, body: { response_requested: true } }
+                : { type: BASIC_MESSAGE_TYPE, body: { content: didcommComposeContent } };
+
+            await keymaster.sendDidComm(message, recipientDid, {
+                name: currentId,
+                anoncrypt: didcommComposeAnoncrypt,
+            });
+
+            showSuccess(didcommComposeKind === 'ping' ? 'Ping sent' : 'Message sent');
+            setDidcommComposeContent('');
+        } catch (error) {
+            showError(error);
+        } finally {
+            setDidcommBusy(false);
+        }
+    }
+
+    function replyToDidComm(sender) {
+        setDidcommComposeTo(sender);
+        setDidcommComposeKind('message');
+        setDidcommTab('compose');
     }
 
     async function dismissDidComm(ids) {
@@ -7790,6 +7844,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                 textColor="primary"
                             >
                                 <Tab label="Inbox" value="inbox" />
+                                <Tab label="Compose" value="compose" />
                                 <Tab label="Endpoint" value="endpoint" />
                             </Tabs>
 
@@ -7852,6 +7907,15 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                                     Respond
                                                                 </Button>
                                                             }
+                                                            {message.type === BASIC_MESSAGE_TYPE && sender &&
+                                                                <Button
+                                                                    size="small"
+                                                                    onClick={() => replyToDidComm(sender)}
+                                                                    disabled={didcommBusy}
+                                                                >
+                                                                    Reply
+                                                                </Button>
+                                                            }
                                                             <Button
                                                                 size="small"
                                                                 color="error"
@@ -7880,6 +7944,75 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                             );
                                         })
                                     }
+                                </Box>
+                            }
+
+                            {didcommTab === 'compose' &&
+                                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                                    <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                        Send a DIDComm message to any agent that publishes a messaging endpoint.
+                                    </Typography>
+
+                                    <TextField
+                                        label="To (DID or alias)"
+                                        value={didcommComposeTo}
+                                        onChange={(e) => setDidcommComposeTo(e.target.value)}
+                                        disabled={didcommBusy}
+                                        placeholder="did:cid:... or a wallet alias"
+                                        fullWidth
+                                    />
+
+                                    <TextField
+                                        select
+                                        label="Type"
+                                        value={didcommComposeKind}
+                                        onChange={(e) => setDidcommComposeKind(e.target.value)}
+                                        disabled={didcommBusy}
+                                        fullWidth
+                                    >
+                                        <MenuItem value="message">Message</MenuItem>
+                                        <MenuItem value="ping">Trust ping</MenuItem>
+                                    </TextField>
+
+                                    {didcommComposeKind === 'message' &&
+                                        <TextField
+                                            label="Message"
+                                            value={didcommComposeContent}
+                                            onChange={(e) => setDidcommComposeContent(e.target.value)}
+                                            disabled={didcommBusy}
+                                            multiline
+                                            minRows={4}
+                                            fullWidth
+                                        />
+                                    }
+
+                                    <Box>
+                                        <FormControlLabel
+                                            control={
+                                                <Checkbox
+                                                    checked={didcommComposeAnoncrypt}
+                                                    onChange={(e) => setDidcommComposeAnoncrypt(e.target.checked)}
+                                                    disabled={didcommBusy}
+                                                />
+                                            }
+                                            label="Send anonymously"
+                                        />
+                                        <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                            {didcommComposeAnoncrypt
+                                                ? 'The recipient cannot tell who sent this, and cannot reply to it.'
+                                                : 'The recipient can verify this came from the current identity.'}
+                                        </Typography>
+                                    </Box>
+
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
+                                        onClick={sendDidCommMessage}
+                                        disabled={didcommBusy}
+                                        sx={{ alignSelf: 'start' }}
+                                    >
+                                        Send
+                                    </Button>
                                 </Box>
                             }
 

--- a/apps/react-wallet/src/BrowserContent.tsx
+++ b/apps/react-wallet/src/BrowserContent.tsx
@@ -20,6 +20,7 @@ import {
     Badge,
     Bolt,
     Email,
+    Forum,
     Key,
     List as ListIcon,
     ManageSearch,
@@ -47,6 +48,7 @@ import AliasedDIDs from "./components/AliasedDIDs";
 import AssetsTab from "./components/AssetsTab";
 import DmailTab from "./components/DmailTab";
 import LightningTab from "./components/LightningTab";
+import DidCommTab from "./components/DidCommTab";
 import PollTab from "./components/PollTab";
 import AuthTab from "./components/AuthTab";
 import PropertiesTab from "./components/PropertiesTab";
@@ -59,7 +61,7 @@ function BrowserContent() {
     const [menuOpen, setMenuOpen] = useState<boolean>(false);
     const { isTabletUp } = useThemeContext();
 
-    const { hasLightning } = useWalletContext();
+    const { hasLightning, hasDidComm } = useWalletContext();
     const { currentId, validId } = useVariablesContext();
     const {
         selectedTab,
@@ -204,6 +206,12 @@ function BrowserContent() {
             {displayComponent && hasLightning && (
                 <TabPanel value="lightning" sx={{ p: 0 }}>
                     <LightningTab />
+                </TabPanel>
+            )}
+
+            {displayComponent && hasDidComm && (
+                <TabPanel value="didcomm" sx={{ p: 0 }}>
+                    <DidCommTab />
                 </TabPanel>
             )}
 
@@ -389,6 +397,17 @@ function BrowserContent() {
                                                 menuOpen ? "Lightning" : ""
                                             }
                                             value="lightning"
+                                            iconPosition="start"
+                                        />
+                                    )}
+
+                                    {displayComponent && hasDidComm && (
+                                        <Tab
+                                            icon={<Forum />}
+                                            label={
+                                                menuOpen ? "DIDComm" : ""
+                                            }
+                                            value="didcomm"
                                             iconPosition="start"
                                         />
                                     )}
@@ -623,6 +642,17 @@ function BrowserContent() {
                                         <Bolt />
                                     </ListItemIcon>
                                     <ListItemText primary="Lightning" />
+                                </ListItemButton>
+                            )}
+
+                            {hasDidComm && (
+                                <ListItemButton
+                                    onClick={() => selectFromMore("didcomm")}
+                                >
+                                    <ListItemIcon>
+                                        <Forum />
+                                    </ListItemIcon>
+                                    <ListItemText primary="DIDComm" />
                                 </ListItemButton>
                             )}
 

--- a/apps/react-wallet/src/components/DidCommTab.tsx
+++ b/apps/react-wallet/src/components/DidCommTab.tsx
@@ -1,9 +1,14 @@
-import { useCallback, useEffect, useState } from "react";
-import { Box, Button, Chip, CircularProgress, TextField, Typography } from "@mui/material";
-import { Forum } from "@mui/icons-material";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+    Box, Button, Chip, CircularProgress, Divider, Tab, Tabs, TextField, Typography
+} from "@mui/material";
+import { Forum, Inbox } from "@mui/icons-material";
+import { BASIC_MESSAGE_TYPE, TRUST_PING_TYPE, trustPingResponse } from "@didcid/keymaster/didcomm-protocols";
+import type { DidCommReceivedMessage } from "@didcid/keymaster/types";
 import { useWalletContext } from "../contexts/WalletProvider";
 import { useVariablesContext } from "../contexts/VariablesProvider";
 import { useSnackbar } from "../contexts/SnackbarProvider";
+import { loadRefreshIntervalSeconds } from "../contexts/UIContext";
 import PageHeader from "./layout/PageHeader";
 import Section from "./layout/Section";
 import EmptyState from "./layout/EmptyState";
@@ -17,6 +22,15 @@ interface DidCommStatus {
     keyAgreement: boolean;
     endpoint?: string;
     routingKeys: string[];
+}
+
+interface DidCommPlaintext {
+    id?: string;
+    type?: string;
+    from?: string;
+    thid?: string;
+    created_time?: number;
+    body?: Record<string, unknown>;
 }
 
 function readStatus(
@@ -40,17 +54,37 @@ function readStatus(
     };
 }
 
+function messageLabel(type?: string): string {
+    if (type === BASIC_MESSAGE_TYPE) {
+        return "Message";
+    }
+    if (type === TRUST_PING_TYPE) {
+        return "Trust ping";
+    }
+    return type || "Unknown";
+}
+
+function formatTime(created?: number): string {
+    // DIDComm created_time is seconds since the epoch, not milliseconds.
+    return created ? new Date(created * 1000).toLocaleString() : "";
+}
+
 function DidCommTab() {
+    const [activeTab, setActiveTab] = useState<string>("inbox");
     const [status, setStatus] = useState<DidCommStatus | null>(null);
     const [loading, setLoading] = useState<boolean>(true);
     const [busy, setBusy] = useState<boolean>(false);
     const [endpoint, setEndpoint] = useState<string>("");
     const [routingKeys, setRoutingKeys] = useState<string>("");
+    const [messages, setMessages] = useState<DidCommReceivedMessage[]>([]);
+    const [inboxLoading, setInboxLoading] = useState<boolean>(true);
+    const [refreshIntervalSeconds, setRefreshIntervalSeconds] = useState<number>(() => loadRefreshIntervalSeconds());
+    const pollingRef = useRef<boolean>(false);
     const { keymaster } = useWalletContext();
     const { currentId, currentDID } = useVariablesContext();
     const { setError, setSuccess } = useSnackbar();
 
-    const refresh = useCallback(async () => {
+    const refreshStatus = useCallback(async () => {
         if (!keymaster || !currentDID) {
             setStatus(null);
             setLoading(false);
@@ -72,10 +106,69 @@ function DidCommTab() {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [keymaster, currentDID]);
 
+    // Reading with ack: false leaves everything on the server, so each poll returns
+    // the whole mailbox. The list is therefore replaced, not accumulated -- what is
+    // on screen is exactly what is still in the mailbox. Messages that fail to
+    // unpack stay on the server and never appear here.
+    const refreshInbox = useCallback(async (options: { quiet?: boolean } = {}) => {
+        if (!keymaster || !currentId) {
+            setMessages([]);
+            setInboxLoading(false);
+            return;
+        }
+
+        // A slow fetch must not overlap with the next tick of the poll.
+        if (pollingRef.current) {
+            return;
+        }
+        pollingRef.current = true;
+
+        try {
+            const received = await keymaster.receiveDidComm({ name: currentId, ack: false });
+            setMessages(received);
+        } catch (error: any) {
+            // A quiet (polled) failure is usually a node that is briefly
+            // unreachable; only an explicit refresh should raise a snackbar.
+            if (!options.quiet) {
+                setError(error);
+            }
+        } finally {
+            pollingRef.current = false;
+            setInboxLoading(false);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [keymaster, currentId]);
+
     useEffect(() => {
         setLoading(true);
-        refresh();
-    }, [refresh]);
+        refreshStatus();
+    }, [refreshStatus]);
+
+    useEffect(() => {
+        setInboxLoading(true);
+        refreshInbox({ quiet: true });
+    }, [refreshInbox]);
+
+    useEffect(() => {
+        // Poll only while this screen is mounted, at the interval the user set in
+        // Settings. Zero means "manual refresh only", matching the wallet's own
+        // background refresh.
+        if (refreshIntervalSeconds === 0) {
+            return;
+        }
+
+        const interval = setInterval(() => {
+            refreshInbox({ quiet: true });
+        }, refreshIntervalSeconds * 1000);
+
+        return () => clearInterval(interval);
+    }, [refreshInbox, refreshIntervalSeconds]);
+
+    useEffect(() => {
+        const handleIntervalChange = () => setRefreshIntervalSeconds(loadRefreshIntervalSeconds());
+        window.addEventListener('archon:refresh-interval-change', handleIntervalChange);
+        return () => window.removeEventListener('archon:refresh-interval-change', handleIntervalChange);
+    }, []);
 
     async function publish() {
         if (!keymaster) return;
@@ -93,7 +186,7 @@ function DidCommTab() {
             setSuccess("DIDComm endpoint published");
             setEndpoint("");
             setRoutingKeys("");
-            await refresh();
+            await refreshStatus();
         } catch (error: any) {
             setError(error);
         } finally {
@@ -108,12 +201,113 @@ function DidCommTab() {
         try {
             await keymaster.unpublishDidComm(currentId);
             setSuccess("DIDComm endpoint unpublished");
-            await refresh();
+            await refreshStatus();
         } catch (error: any) {
             setError(error);
         } finally {
             setBusy(false);
         }
+    }
+
+    async function dismiss(ids: string[]) {
+        if (!keymaster || !ids.length) return;
+
+        setBusy(true);
+        try {
+            const removed = await keymaster.ackDidComm(ids, { name: currentId });
+            setSuccess(removed === 1 ? "Message dismissed" : `${removed} messages dismissed`);
+            await refreshInbox();
+        } catch (error: any) {
+            setError(error);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    async function respondToPing(received: DidCommReceivedMessage) {
+        if (!keymaster) return;
+
+        const message = received.message as DidCommPlaintext;
+        const sender = message.from;
+
+        if (!sender || !message.id) {
+            setError("This ping carries no sender to respond to");
+            return;
+        }
+
+        setBusy(true);
+        try {
+            await keymaster.sendDidComm(trustPingResponse(message.id) as unknown as Record<string, unknown>, sender, { name: currentId });
+            setSuccess("Ping response sent");
+        } catch (error: any) {
+            setError(error);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    function renderMessage(received: DidCommReceivedMessage) {
+        const message = received.message as DidCommPlaintext;
+        const sender = message.from || received.metadata.sender;
+        const time = formatTime(message.created_time);
+
+        return (
+            <Box key={received.id} sx={{ mb: 2 }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap", mb: 0.5 }}>
+                    <Chip label={messageLabel(message.type)} size="small" />
+                    {/* Anoncrypt hides the sender entirely, so "who sent this" and
+                        "is that claim verified" are two different questions. */}
+                    <Chip
+                        label={received.metadata.authenticated ? "Authenticated" : "Anonymous"}
+                        size="small"
+                        color={received.metadata.authenticated ? "success" : "default"}
+                        variant="outlined"
+                    />
+                    {time && (
+                        <Typography variant="caption" color="text.secondary">
+                            {time}
+                        </Typography>
+                    )}
+                    <Box sx={{ ml: "auto", display: "flex", gap: 1 }}>
+                        {message.type === TRUST_PING_TYPE && (
+                            <Button size="small" onClick={() => respondToPing(received)} disabled={busy}>
+                                Respond
+                            </Button>
+                        )}
+                        <Button size="small" color="error" onClick={() => dismiss([received.id])} disabled={busy}>
+                            Dismiss
+                        </Button>
+                    </Box>
+                </Box>
+
+                <Typography variant="body2" color="text.secondary" sx={{ wordBreak: "break-all" }}>
+                    From: {sender || "unknown"}
+                </Typography>
+
+                {message.type === BASIC_MESSAGE_TYPE ? (
+                    <Typography variant="body1" sx={{ mt: 1, whiteSpace: "pre-wrap" }}>
+                        {String(message.body?.content ?? "")}
+                    </Typography>
+                ) : (
+                    <Box
+                        component="pre"
+                        sx={{
+                            mt: 1,
+                            p: 1,
+                            borderRadius: 1,
+                            bgcolor: "action.hover",
+                            fontSize: "0.75rem",
+                            overflowX: "auto",
+                            m: 0,
+                        }}
+                    >
+                        {JSON.stringify(message.body ?? {}, null, 2)}
+                    </Box>
+                )}
+
+                <Divider sx={{ mt: 2 }} />
+            </Box>
+        );
     }
 
     if (loading) {
@@ -125,114 +319,165 @@ function DidCommTab() {
     }
 
     return (
-        <Box sx={{ p: 2 }}>
+        <Box>
             <PageHeader
                 title="DIDComm"
-                description="Publish a messaging endpoint so other agents can send encrypted DIDComm messages to this identity."
-                actions={
-                    <>
-                        <Button variant="contained" onClick={publish} disabled={busy}>
-                            {status ? "Update" : "Publish"}
-                        </Button>
-                        {status && (
-                            <ActionMenu
-                                items={[{
-                                    label: "Unpublish",
-                                    onClick: unpublish,
-                                    disabled: busy,
-                                    destructive: true,
-                                }]}
-                            />
-                        )}
-                    </>
-                }
+                description="Read encrypted DIDComm messages sent to this identity, and publish the endpoint others deliver them to."
             />
 
-            {status ? (
+            <Tabs
+                value={activeTab}
+                onChange={(_, value) => setActiveTab(value)}
+                sx={{ borderBottom: 1, borderColor: "divider", mb: 2, minHeight: 40 }}
+            >
+                <Tab label="Inbox" value="inbox" />
+                <Tab label="Endpoint" value="endpoint" />
+            </Tabs>
+
+            {activeTab === "inbox" && (
                 <Section
-                    title="Published"
-                    description="What this identity's DID document currently advertises."
+                    title="Mailbox"
+                    description="Messages stay on the node until dismissed."
+                    actions={
+                        <>
+                            <Button variant="outlined" onClick={() => refreshInbox()} disabled={busy}>
+                                Refresh
+                            </Button>
+                            {messages.length > 0 && (
+                                <ActionMenu
+                                    items={[{
+                                        label: "Dismiss all",
+                                        onClick: () => dismiss(messages.map(message => message.id)),
+                                        disabled: busy,
+                                        destructive: true,
+                                    }]}
+                                />
+                            )}
+                        </>
+                    }
                 >
-                    <Box sx={{ mb: 2 }}>
-                        <Typography variant="body2" color="text.secondary">
-                            Endpoint
-                        </Typography>
-                        {status.endpoint ? (
-                            <Typography variant="body1" sx={{ wordBreak: "break-all" }}>
-                                {status.endpoint}
-                            </Typography>
-                        ) : (
-                            <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 0.5 }}>
-                                <Chip label="Key only" size="small" color="warning" />
-                                <Typography variant="body2" color="text.secondary">
-                                    Others can encrypt to this identity but have nowhere to deliver.
-                                </Typography>
-                            </Box>
-                        )}
-                    </Box>
-
-                    {status.routingKeys.length > 0 && (
-                        <Box sx={{ mb: 2 }}>
-                            <Typography variant="body2" color="text.secondary">
-                                Routing keys
-                            </Typography>
-                            {status.routingKeys.map(key => (
-                                <Typography
-                                    key={key}
-                                    variant="body2"
-                                    sx={{ wordBreak: "break-all", fontFamily: "monospace", fontSize: "0.75rem" }}
-                                >
-                                    {key}
-                                </Typography>
-                            ))}
+                    {inboxLoading && messages.length === 0 ? (
+                        <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+                            <CircularProgress size={24} />
                         </Box>
-                    )}
-
-                    <Box>
-                        <Typography variant="body2" color="text.secondary">
-                            Key agreement
-                        </Typography>
-                        <Chip
-                            label={status.keyAgreement ? "Published" : "Missing"}
-                            size="small"
-                            color={status.keyAgreement ? "success" : "warning"}
-                            sx={{ mt: 0.5 }}
+                    ) : messages.length === 0 ? (
+                        <EmptyState
+                            icon={<Inbox />}
+                            title="No messages"
+                            description={status?.endpoint
+                                ? "Nothing in the mailbox for this identity."
+                                : "Publish an endpoint so others have somewhere to deliver messages."}
                         />
-                    </Box>
-                </Section>
-            ) : (
-                <Section dense>
-                    <EmptyState
-                        icon={<Forum />}
-                        title="No DIDComm endpoint published"
-                        description="Publish to add a key agreement key and a messaging endpoint to this identity's DID document."
-                    />
+                    ) : (
+                        messages.map(renderMessage)
+                    )}
                 </Section>
             )}
 
-            <Section
-                title="Endpoint"
-                description="Leave blank to use this node's own relay. Set one explicitly to publish a mediator or an endpoint the node cannot discover."
-            >
-                <TextField
-                    fullWidth
-                    label="Endpoint URL (optional)"
-                    value={endpoint}
-                    onChange={event => setEndpoint(event.target.value)}
-                    disabled={busy}
-                    placeholder="https://relay.example/didcomm"
-                    sx={{ mb: 2 }}
-                />
-                <TextField
-                    fullWidth
-                    label="Routing keys (optional, comma separated)"
-                    value={routingKeys}
-                    onChange={event => setRoutingKeys(event.target.value)}
-                    disabled={busy}
-                    placeholder="did:cid:mediator#key-agreement-1"
-                    helperText="Set these when delivery goes through a mediator; senders then wrap messages in a Forward."
-                />
-            </Section>
+            {activeTab === "endpoint" && (
+                <>
+                    {status ? (
+                        <Section
+                            title="Published"
+                            description="What this identity's DID document currently advertises."
+                            actions={
+                                <ActionMenu
+                                    items={[{
+                                        label: "Unpublish",
+                                        onClick: unpublish,
+                                        disabled: busy,
+                                        destructive: true,
+                                    }]}
+                                />
+                            }
+                        >
+                            <Box sx={{ mb: 2 }}>
+                                <Typography variant="body2" color="text.secondary">
+                                    Endpoint
+                                </Typography>
+                                {status.endpoint ? (
+                                    <Typography variant="body1" sx={{ wordBreak: "break-all" }}>
+                                        {status.endpoint}
+                                    </Typography>
+                                ) : (
+                                    <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 0.5 }}>
+                                        <Chip label="Key only" size="small" color="warning" />
+                                        <Typography variant="body2" color="text.secondary">
+                                            Others can encrypt to this identity but have nowhere to deliver.
+                                        </Typography>
+                                    </Box>
+                                )}
+                            </Box>
+
+                            {status.routingKeys.length > 0 && (
+                                <Box sx={{ mb: 2 }}>
+                                    <Typography variant="body2" color="text.secondary">
+                                        Routing keys
+                                    </Typography>
+                                    {status.routingKeys.map(key => (
+                                        <Typography
+                                            key={key}
+                                            variant="body2"
+                                            sx={{ wordBreak: "break-all", fontFamily: "monospace", fontSize: "0.75rem" }}
+                                        >
+                                            {key}
+                                        </Typography>
+                                    ))}
+                                </Box>
+                            )}
+
+                            <Box>
+                                <Typography variant="body2" color="text.secondary">
+                                    Key agreement
+                                </Typography>
+                                <Chip
+                                    label={status.keyAgreement ? "Published" : "Missing"}
+                                    size="small"
+                                    color={status.keyAgreement ? "success" : "warning"}
+                                    sx={{ mt: 0.5 }}
+                                />
+                            </Box>
+                        </Section>
+                    ) : (
+                        <Section dense>
+                            <EmptyState
+                                icon={<Forum />}
+                                title="No DIDComm endpoint published"
+                                description="Publish to add a key agreement key and a messaging endpoint to this identity's DID document."
+                            />
+                        </Section>
+                    )}
+
+                    <Section
+                        title="Endpoint"
+                        description="Leave blank to use this node's own relay. Set one explicitly to publish a mediator or an endpoint the node cannot discover."
+                        actions={
+                            <Button variant="contained" onClick={publish} disabled={busy}>
+                                {status ? "Update" : "Publish"}
+                            </Button>
+                        }
+                    >
+                        <TextField
+                            fullWidth
+                            label="Endpoint URL (optional)"
+                            value={endpoint}
+                            onChange={event => setEndpoint(event.target.value)}
+                            disabled={busy}
+                            placeholder="https://relay.example/didcomm"
+                            sx={{ mb: 2 }}
+                        />
+                        <TextField
+                            fullWidth
+                            label="Routing keys (optional, comma separated)"
+                            value={routingKeys}
+                            onChange={event => setRoutingKeys(event.target.value)}
+                            disabled={busy}
+                            placeholder="did:cid:mediator#key-agreement-1"
+                            helperText="Set these when delivery goes through a mediator; senders then wrap messages in a Forward."
+                        />
+                    </Section>
+                </>
+            )}
         </Box>
     );
 }

--- a/apps/react-wallet/src/components/DidCommTab.tsx
+++ b/apps/react-wallet/src/components/DidCommTab.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
-    Box, Button, Chip, CircularProgress, Divider, Tab, Tabs, TextField, Typography
+    Box, Button, Checkbox, Chip, CircularProgress, Divider, FormControlLabel, MenuItem,
+    Tab, Tabs, TextField, Typography
 } from "@mui/material";
 import { Forum, Inbox } from "@mui/icons-material";
-import { BASIC_MESSAGE_TYPE, TRUST_PING_TYPE, trustPingResponse } from "@didcid/keymaster/didcomm-protocols";
+import {
+    BASIC_MESSAGE_TYPE, TRUST_PING_TYPE, basicMessage, trustPing, trustPingResponse
+} from "@didcid/keymaster/didcomm-protocols";
 import type { DidCommReceivedMessage } from "@didcid/keymaster/types";
 import { useWalletContext } from "../contexts/WalletProvider";
 import { useVariablesContext } from "../contexts/VariablesProvider";
@@ -79,6 +82,10 @@ function DidCommTab() {
     const [messages, setMessages] = useState<DidCommReceivedMessage[]>([]);
     const [inboxLoading, setInboxLoading] = useState<boolean>(true);
     const [refreshIntervalSeconds, setRefreshIntervalSeconds] = useState<number>(() => loadRefreshIntervalSeconds());
+    const [composeTo, setComposeTo] = useState<string>("");
+    const [composeKind, setComposeKind] = useState<string>("message");
+    const [composeContent, setComposeContent] = useState<string>("");
+    const [composeAnoncrypt, setComposeAnoncrypt] = useState<boolean>(false);
     const pollingRef = useRef<boolean>(false);
     const { keymaster } = useWalletContext();
     const { currentId, currentDID } = useVariablesContext();
@@ -209,6 +216,58 @@ function DidCommTab() {
         }
     }
 
+    async function send() {
+        if (!keymaster) return;
+
+        const recipient = composeTo.trim();
+
+        if (!recipient) {
+            setError("Enter a recipient DID or alias");
+            return;
+        }
+
+        if (composeKind === "message" && !composeContent.trim()) {
+            setError("Enter a message to send");
+            return;
+        }
+
+        setBusy(true);
+        try {
+            // Resolve first: an alias must not travel in the envelope, which
+            // addresses recipients by DID. This also turns an unknown name into a
+            // clear error before any crypto happens.
+            const docs = await keymaster.resolveDID(recipient);
+            const recipientDid = docs.didDocument?.id;
+
+            if (!recipientDid) {
+                setError(`Could not resolve ${recipient}`);
+                return;
+            }
+
+            const message = composeKind === "ping"
+                ? trustPing()
+                : basicMessage(composeContent);
+
+            await keymaster.sendDidComm(message as unknown as Record<string, unknown>, recipientDid, {
+                name: currentId,
+                anoncrypt: composeAnoncrypt,
+            });
+
+            setSuccess(composeKind === "ping" ? "Ping sent" : "Message sent");
+            setComposeContent("");
+        } catch (error: any) {
+            setError(error);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    function replyTo(sender: string) {
+        setComposeTo(sender);
+        setComposeKind("message");
+        setActiveTab("compose");
+    }
+
     async function dismiss(ids: string[]) {
         if (!keymaster || !ids.length) return;
 
@@ -274,6 +333,11 @@ function DidCommTab() {
                                 Respond
                             </Button>
                         )}
+                        {message.type === BASIC_MESSAGE_TYPE && sender && (
+                            <Button size="small" onClick={() => replyTo(sender)} disabled={busy}>
+                                Reply
+                            </Button>
+                        )}
                         <Button size="small" color="error" onClick={() => dismiss([received.id])} disabled={busy}>
                             Dismiss
                         </Button>
@@ -331,6 +395,7 @@ function DidCommTab() {
                 sx={{ borderBottom: 1, borderColor: "divider", mb: 2, minHeight: 40 }}
             >
                 <Tab label="Inbox" value="inbox" />
+                <Tab label="Compose" value="compose" />
                 <Tab label="Endpoint" value="endpoint" />
             </Tabs>
 
@@ -371,6 +436,70 @@ function DidCommTab() {
                     ) : (
                         messages.map(renderMessage)
                     )}
+                </Section>
+            )}
+
+            {activeTab === "compose" && (
+                <Section
+                    title="New message"
+                    description="Send a DIDComm message to any agent that publishes a messaging endpoint."
+                    actions={
+                        <Button variant="contained" onClick={send} disabled={busy}>
+                            Send
+                        </Button>
+                    }
+                >
+                    <TextField
+                        fullWidth
+                        label="To (DID or alias)"
+                        value={composeTo}
+                        onChange={event => setComposeTo(event.target.value)}
+                        disabled={busy}
+                        placeholder="did:cid:... or a wallet alias"
+                        sx={{ mb: 2 }}
+                    />
+
+                    <TextField
+                        select
+                        fullWidth
+                        label="Type"
+                        value={composeKind}
+                        onChange={event => setComposeKind(event.target.value)}
+                        disabled={busy}
+                        sx={{ mb: 2 }}
+                    >
+                        <MenuItem value="message">Message</MenuItem>
+                        <MenuItem value="ping">Trust ping</MenuItem>
+                    </TextField>
+
+                    {composeKind === "message" && (
+                        <TextField
+                            fullWidth
+                            multiline
+                            minRows={4}
+                            label="Message"
+                            value={composeContent}
+                            onChange={event => setComposeContent(event.target.value)}
+                            disabled={busy}
+                            sx={{ mb: 1 }}
+                        />
+                    )}
+
+                    <FormControlLabel
+                        control={
+                            <Checkbox
+                                checked={composeAnoncrypt}
+                                onChange={event => setComposeAnoncrypt(event.target.checked)}
+                                disabled={busy}
+                            />
+                        }
+                        label="Send anonymously"
+                    />
+                    <Typography variant="body2" color="text.secondary">
+                        {composeAnoncrypt
+                            ? "The recipient cannot tell who sent this, and cannot reply to it."
+                            : "The recipient can verify this came from the current identity."}
+                    </Typography>
                 </Section>
             )}
 

--- a/apps/react-wallet/src/components/DidCommTab.tsx
+++ b/apps/react-wallet/src/components/DidCommTab.tsx
@@ -67,6 +67,17 @@ function messageLabel(type?: string): string {
     return type || "Unknown";
 }
 
+// Authcrypt binds the sender to the envelope; `message.from` is an unverified
+// claim inside it. unpackDidComm now rejects a mismatch outright, so this is the
+// second line of the same rule: never address or display a claim as if the
+// envelope vouched for it.
+function authenticatedSender(received: DidCommReceivedMessage): string | undefined {
+    if (!received.metadata.authenticated || !received.metadata.sender) {
+        return undefined;
+    }
+    return received.metadata.sender.split('#')[0];
+}
+
 function formatTime(created?: number): string {
     // DIDComm created_time is seconds since the epoch, not milliseconds.
     return created ? new Date(created * 1000).toLocaleString() : "";
@@ -86,7 +97,11 @@ function DidCommTab() {
     const [composeKind, setComposeKind] = useState<string>("message");
     const [composeContent, setComposeContent] = useState<string>("");
     const [composeAnoncrypt, setComposeAnoncrypt] = useState<boolean>(false);
-    const pollingRef = useRef<boolean>(false);
+    // Keyed by identity, not a bare boolean: an in-flight read must not block a
+    // read for a *different* identity, and must not commit its result after the
+    // identity has changed.
+    const inFlightRef = useRef<string | null>(null);
+    const activeIdRef = useRef<string>("");
     const { keymaster } = useWalletContext();
     const { currentId, currentDID } = useVariablesContext();
     const { setError, setSuccess } = useSnackbar();
@@ -118,20 +133,30 @@ function DidCommTab() {
     // on screen is exactly what is still in the mailbox. Messages that fail to
     // unpack stay on the server and never appear here.
     const refreshInbox = useCallback(async (options: { quiet?: boolean } = {}) => {
-        if (!keymaster || !currentId) {
+        const requested = currentId;
+
+        if (!keymaster || !requested) {
             setMessages([]);
             setInboxLoading(false);
             return;
         }
 
-        // A slow fetch must not overlap with the next tick of the poll.
-        if (pollingRef.current) {
+        // A slow fetch must not overlap with the next tick of the poll -- but only
+        // for the same identity, or switching identity while a read is in flight
+        // would silently skip the new read.
+        if (inFlightRef.current === requested) {
             return;
         }
-        pollingRef.current = true;
+        inFlightRef.current = requested;
 
         try {
-            const received = await keymaster.receiveDidComm({ name: currentId, ack: false });
+            const received = await keymaster.receiveDidComm({ name: requested, ack: false });
+            // A read that finishes after the identity changed belongs to nobody on
+            // screen; committing it would show one identity's mail under another's
+            // name, and with polling off it would stay there.
+            if (activeIdRef.current !== requested) {
+                return;
+            }
             setMessages(received);
         } catch (error: any) {
             // A quiet (polled) failure is usually a node that is briefly
@@ -140,7 +165,9 @@ function DidCommTab() {
                 setError(error);
             }
         } finally {
-            pollingRef.current = false;
+            if (inFlightRef.current === requested) {
+                inFlightRef.current = null;
+            }
             setInboxLoading(false);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -152,9 +179,14 @@ function DidCommTab() {
     }, [refreshStatus]);
 
     useEffect(() => {
+        activeIdRef.current = currentId;
+        // Drop the previous identity's mail immediately rather than leaving it on
+        // screen under the new name until the fetch returns.
+        setMessages([]);
         setInboxLoading(true);
         refreshInbox({ quiet: true });
-    }, [refreshInbox]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [refreshInbox, currentId]);
 
     useEffect(() => {
         // Poll only while this screen is mounted, at the interval the user set in
@@ -287,10 +319,13 @@ function DidCommTab() {
         if (!keymaster) return;
 
         const message = received.message as DidCommPlaintext;
-        const sender = message.from;
+        // Only the envelope's authenticated sender is safe to address. The
+        // plaintext `from` is the sender's own claim, so responding to it could
+        // send the answer to a party who never pinged.
+        const sender = authenticatedSender(received);
 
         if (!sender || !message.id) {
-            setError("This ping carries no sender to respond to");
+            setError("This ping has no authenticated sender to respond to");
             return;
         }
 
@@ -307,7 +342,8 @@ function DidCommTab() {
 
     function renderMessage(received: DidCommReceivedMessage) {
         const message = received.message as DidCommPlaintext;
-        const sender = message.from || received.metadata.sender;
+        const sender = authenticatedSender(received);
+        const claimed = typeof message.from === 'string' ? message.from : undefined;
         const time = formatTime(message.created_time);
 
         return (
@@ -328,7 +364,7 @@ function DidCommTab() {
                         </Typography>
                     )}
                     <Box sx={{ ml: "auto", display: "flex", gap: 1 }}>
-                        {message.type === TRUST_PING_TYPE && (
+                        {message.type === TRUST_PING_TYPE && sender && (
                             <Button size="small" onClick={() => respondToPing(received)} disabled={busy}>
                                 Respond
                             </Button>
@@ -345,7 +381,7 @@ function DidCommTab() {
                 </Box>
 
                 <Typography variant="body2" color="text.secondary" sx={{ wordBreak: "break-all" }}>
-                    From: {sender || "unknown"}
+                    From: {sender || (claimed ? `${claimed} (unverified)` : "unknown")}
                 </Typography>
 
                 {message.type === BASIC_MESSAGE_TYPE ? (

--- a/apps/react-wallet/src/components/DidCommTab.tsx
+++ b/apps/react-wallet/src/components/DidCommTab.tsx
@@ -1,0 +1,240 @@
+import { useCallback, useEffect, useState } from "react";
+import { Box, Button, Chip, CircularProgress, TextField, Typography } from "@mui/material";
+import { Forum } from "@mui/icons-material";
+import { useWalletContext } from "../contexts/WalletProvider";
+import { useVariablesContext } from "../contexts/VariablesProvider";
+import { useSnackbar } from "../contexts/SnackbarProvider";
+import PageHeader from "./layout/PageHeader";
+import Section from "./layout/Section";
+import EmptyState from "./layout/EmptyState";
+import ActionMenu from "./layout/ActionMenu";
+
+// What publishDidComm writes into the DID document, read back so the screen can
+// say what the identity currently advertises. Two states are both "published":
+// with an endpoint (others can deliver to a mailbox) and key-only (others can
+// encrypt to this identity but have nowhere to deliver).
+interface DidCommStatus {
+    keyAgreement: boolean;
+    endpoint?: string;
+    routingKeys: string[];
+}
+
+function readStatus(
+    service: { id: string; type: string; serviceEndpoint: string | { uri: string; accept?: string[]; routingKeys?: string[] } } | undefined,
+    keyAgreement: boolean,
+): DidCommStatus {
+    if (!service) {
+        return { keyAgreement, routingKeys: [] };
+    }
+
+    // The plain string form carries no routing keys; the object form is what
+    // publishDidComm writes when the identity sits behind a mediator.
+    if (typeof service.serviceEndpoint === "string") {
+        return { keyAgreement, endpoint: service.serviceEndpoint, routingKeys: [] };
+    }
+
+    return {
+        keyAgreement,
+        endpoint: service.serviceEndpoint.uri,
+        routingKeys: service.serviceEndpoint.routingKeys ?? [],
+    };
+}
+
+function DidCommTab() {
+    const [status, setStatus] = useState<DidCommStatus | null>(null);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [busy, setBusy] = useState<boolean>(false);
+    const [endpoint, setEndpoint] = useState<string>("");
+    const [routingKeys, setRoutingKeys] = useState<string>("");
+    const { keymaster } = useWalletContext();
+    const { currentId, currentDID } = useVariablesContext();
+    const { setError, setSuccess } = useSnackbar();
+
+    const refresh = useCallback(async () => {
+        if (!keymaster || !currentDID) {
+            setStatus(null);
+            setLoading(false);
+            return;
+        }
+
+        try {
+            const docs = await keymaster.resolveDID(currentDID);
+            const didDocument = docs.didDocument;
+            const service = didDocument?.service?.find(entry => entry.type === "DIDCommMessaging");
+            const keyAgreement = Boolean(didDocument?.keyAgreement?.length);
+            setStatus(service || keyAgreement ? readStatus(service, keyAgreement) : null);
+        } catch (error: any) {
+            setError(error);
+            setStatus(null);
+        } finally {
+            setLoading(false);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [keymaster, currentDID]);
+
+    useEffect(() => {
+        setLoading(true);
+        refresh();
+    }, [refresh]);
+
+    async function publish() {
+        if (!keymaster) return;
+
+        setBusy(true);
+        try {
+            const keys = routingKeys
+                .split(",")
+                .map(key => key.trim())
+                .filter(Boolean);
+
+            // An empty endpoint is not "no endpoint" -- it asks the node to
+            // supply its own relay, which is the path most identities want.
+            await keymaster.publishDidComm(endpoint.trim() || undefined, currentId, keys.length ? keys : undefined);
+            setSuccess("DIDComm endpoint published");
+            setEndpoint("");
+            setRoutingKeys("");
+            await refresh();
+        } catch (error: any) {
+            setError(error);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    async function unpublish() {
+        if (!keymaster) return;
+
+        setBusy(true);
+        try {
+            await keymaster.unpublishDidComm(currentId);
+            setSuccess("DIDComm endpoint unpublished");
+            await refresh();
+        } catch (error: any) {
+            setError(error);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    if (loading) {
+        return (
+            <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+                <CircularProgress />
+            </Box>
+        );
+    }
+
+    return (
+        <Box sx={{ p: 2 }}>
+            <PageHeader
+                title="DIDComm"
+                description="Publish a messaging endpoint so other agents can send encrypted DIDComm messages to this identity."
+                actions={
+                    <>
+                        <Button variant="contained" onClick={publish} disabled={busy}>
+                            {status ? "Update" : "Publish"}
+                        </Button>
+                        {status && (
+                            <ActionMenu
+                                items={[{
+                                    label: "Unpublish",
+                                    onClick: unpublish,
+                                    disabled: busy,
+                                    destructive: true,
+                                }]}
+                            />
+                        )}
+                    </>
+                }
+            />
+
+            {status ? (
+                <Section
+                    title="Published"
+                    description="What this identity's DID document currently advertises."
+                >
+                    <Box sx={{ mb: 2 }}>
+                        <Typography variant="body2" color="text.secondary">
+                            Endpoint
+                        </Typography>
+                        {status.endpoint ? (
+                            <Typography variant="body1" sx={{ wordBreak: "break-all" }}>
+                                {status.endpoint}
+                            </Typography>
+                        ) : (
+                            <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 0.5 }}>
+                                <Chip label="Key only" size="small" color="warning" />
+                                <Typography variant="body2" color="text.secondary">
+                                    Others can encrypt to this identity but have nowhere to deliver.
+                                </Typography>
+                            </Box>
+                        )}
+                    </Box>
+
+                    {status.routingKeys.length > 0 && (
+                        <Box sx={{ mb: 2 }}>
+                            <Typography variant="body2" color="text.secondary">
+                                Routing keys
+                            </Typography>
+                            {status.routingKeys.map(key => (
+                                <Typography
+                                    key={key}
+                                    variant="body2"
+                                    sx={{ wordBreak: "break-all", fontFamily: "monospace", fontSize: "0.75rem" }}
+                                >
+                                    {key}
+                                </Typography>
+                            ))}
+                        </Box>
+                    )}
+
+                    <Box>
+                        <Typography variant="body2" color="text.secondary">
+                            Key agreement
+                        </Typography>
+                        <Chip
+                            label={status.keyAgreement ? "Published" : "Missing"}
+                            size="small"
+                            color={status.keyAgreement ? "success" : "warning"}
+                            sx={{ mt: 0.5 }}
+                        />
+                    </Box>
+                </Section>
+            ) : (
+                <Section dense>
+                    <EmptyState
+                        icon={<Forum />}
+                        title="No DIDComm endpoint published"
+                        description="Publish to add a key agreement key and a messaging endpoint to this identity's DID document."
+                    />
+                </Section>
+            )}
+
+            <Section
+                title="Endpoint"
+                description="Leave blank to use this node's own relay. Set one explicitly to publish a mediator or an endpoint the node cannot discover."
+            >
+                <TextField
+                    fullWidth
+                    label="Endpoint URL (optional)"
+                    value={endpoint}
+                    onChange={event => setEndpoint(event.target.value)}
+                    disabled={busy}
+                    placeholder="https://relay.example/didcomm"
+                    sx={{ mb: 2 }}
+                />
+                <TextField
+                    fullWidth
+                    label="Routing keys (optional, comma separated)"
+                    value={routingKeys}
+                    onChange={event => setRoutingKeys(event.target.value)}
+                    disabled={busy}
+                    placeholder="did:cid:mediator#key-agreement-1"
+                    helperText="Set these when delivery goes through a mediator; senders then wrap messages in a Forward."
+                />
+            </Section>
+        </Box>
+    );
+}
+
+export default DidCommTab;

--- a/apps/react-wallet/src/contexts/UIContext.tsx
+++ b/apps/react-wallet/src/contexts/UIContext.tsx
@@ -24,7 +24,9 @@ import WalletWeb from "@didcid/keymaster/wallet/web";
 const REFRESH_INTERVAL_STORAGE_KEY = 'ARCHON_REFRESH_INTERVAL_SECONDS';
 const DEFAULT_REFRESH_INTERVAL_SECONDS = 30;
 
-function loadRefreshIntervalSeconds() {
+// Exported so a screen that polls only while it is open (the DIDComm inbox) can
+// honour the same interval the background refresh uses.
+export function loadRefreshIntervalSeconds() {
     const saved = localStorage.getItem(REFRESH_INTERVAL_STORAGE_KEY);
     const parsed = Number(saved);
 

--- a/apps/react-wallet/src/contexts/WalletProvider.tsx
+++ b/apps/react-wallet/src/contexts/WalletProvider.tsx
@@ -45,6 +45,7 @@ interface WalletContextValue {
     refreshFlag: number;
     keymaster: Keymaster | null;
     hasLightning: boolean;
+    hasDidComm: boolean;
 }
 
 const WalletContext = createContext<WalletContextValue | null>(null);
@@ -66,6 +67,10 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     const [showRecoverSetup, setShowRecoverSetup] = useState(false);
     const [refreshFlag, setRefreshFlag] = useState<number>(0);
     const [hasLightning, setHasLightning] = useState<boolean>(false);
+    // Unknown (a node that serves no capability manifest) is permissive, matching
+    // the gate inside Keymaster: show the surface and let the operation fail late
+    // rather than hiding it against every older node.
+    const [hasDidComm, setHasDidComm] = useState<boolean>(true);
 
     const keymasterRef = useRef<Keymaster | null>(null);
 
@@ -139,6 +144,12 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         setUploadAction(null);
         setPassphraseErrorText("");
         keymasterRef.current = instance;
+        try {
+            const capabilities = await instance.getNodeCapabilities();
+            setHasDidComm(capabilities?.didcomm !== false);
+        } catch (error) {
+            console.error('Failed to read node capabilities:', error);
+        }
         setRefreshFlag(r => r + 1);
         setIsReady(true);
         setSessionPassphrase(passphrase);
@@ -360,6 +371,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         refreshFlag,
         keymaster: keymasterRef.current,
         hasLightning,
+        hasDidComm,
     };
 
     return (

--- a/apps/react-wallet/vite.config.ts
+++ b/apps/react-wallet/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
             "@didcid/keymaster/wallet/typeGuards": path.resolve(__dirname, "../../packages/keymaster/dist/esm/db/typeGuards.js"),
             "@didcid/keymaster/types": path.resolve(__dirname, "../../packages/keymaster/dist/types/types.d.js"),
             "@didcid/keymaster/search": path.resolve(__dirname, "../../packages/keymaster/dist/esm/search-client.js"),
+            "@didcid/keymaster/didcomm-protocols": path.resolve(__dirname, "../../packages/keymaster/dist/esm/didcomm-protocols.js"),
 
             "@didcid/keymaster": path.resolve(__dirname, "../../packages/keymaster/dist/esm/keymaster.js"),
             buffer: 'buffer',

--- a/docs/keymaster-api.json
+++ b/docs/keymaster-api.json
@@ -163,6 +163,59 @@
         }
       }
     },
+    "/capabilities": {
+      "get": {
+        "summary": "Report which optional services the node offers.",
+        "description": "Reads the node's capability manifest. `capabilities` is null when the node serves no manifest (an older node, or a bare gatekeeper), which callers should treat as unknown rather than unsupported.\n",
+        "responses": {
+          "200": {
+            "description": "The node's capability manifest, or null if it serves none.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "capabilities": {
+                      "type": "object",
+                      "nullable": true,
+                      "additionalProperties": {
+                        "type": "boolean"
+                      },
+                      "properties": {
+                        "didcomm": {
+                          "type": "boolean"
+                        },
+                        "lightning": {
+                          "type": "boolean"
+                        },
+                        "names": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/wallet": {
       "get": {
         "summary": "Retrieve the current wallet.",

--- a/packages/clients/src/keymaster-client.ts
+++ b/packages/clients/src/keymaster-client.ts
@@ -26,6 +26,7 @@ import {
     IssueCredentialsOptions,
     KeymasterClientOptions,
     KeymasterInterface,
+    NodeCapabilities,
     LightningConfig,
     LightningBalance,
     LightningInvoice,
@@ -543,6 +544,16 @@ export default class KeymasterClient implements KeymasterInterface {
         try {
             const response = await this.axios.delete(`${this.API}/addresses/publish`, { data: { name } });
             return response.data.ok;
+        }
+        catch (error) {
+            throwError(error);
+        }
+    }
+
+    async getNodeCapabilities(): Promise<NodeCapabilities | null> {
+        try {
+            const response = await this.axios.get(`${this.API}/capabilities`);
+            return response.data.capabilities;
         }
         catch (error) {
             throwError(error);

--- a/packages/clients/src/keymaster-types.ts
+++ b/packages/clients/src/keymaster-types.ts
@@ -382,6 +382,17 @@ export interface DidCommReceivedMessage extends DidCommUnpackResult {
     id: string;
 }
 
+// The node's optional-service manifest, served by Drawbridge at
+// `GET /api/v1/capabilities`. Each flag is true iff the node has that service
+// wired up; a node that serves no manifest at all is reported as null (unknown)
+// rather than all-false, so callers stay permissive against older nodes.
+export interface NodeCapabilities {
+    didcomm: boolean;
+    lightning: boolean;
+    names: boolean;
+    [capability: string]: boolean;
+}
+
 export interface KeymasterInterface {
     // Wallet
     loadWallet(): Promise<WalletFile>;
@@ -421,6 +432,9 @@ export interface KeymasterInterface {
     removeAddress(address: string): Promise<boolean>;
     publishAddress(address?: string, name?: string): Promise<boolean>;
     unpublishAddress(name?: string): Promise<boolean>;
+
+    // Node
+    getNodeCapabilities(): Promise<NodeCapabilities | null>;
 
     // DIDComm
     publishDidComm(endpoint?: string, name?: string, routingKeys?: string[]): Promise<boolean>;

--- a/packages/keymaster/package.json
+++ b/packages/keymaster/package.json
@@ -37,6 +37,11 @@
       "require": "./dist/cjs/keymaster-client.cjs",
       "types": "./dist/types/keymaster-client.d.ts"
     },
+    "./didcomm-protocols": {
+      "import": "./dist/esm/didcomm-protocols.js",
+      "require": "./dist/cjs/didcomm-protocols.cjs",
+      "types": "./dist/types/didcomm-protocols.d.ts"
+    },
     "./wallet/json": {
       "import": "./dist/esm/db/json.js",
       "require": "./dist/cjs/db/json.cjs",

--- a/packages/keymaster/rollup.cjs.config.js
+++ b/packages/keymaster/rollup.cjs.config.js
@@ -16,6 +16,7 @@ const config = {
         'node': 'dist/esm/node.js',
         'keymaster': 'dist/esm/keymaster.js',
         'keymaster-client': 'dist/esm/keymaster-client.js',
+        'didcomm-protocols': 'dist/esm/didcomm-protocols.js',
         'db/abstract-base': 'dist/esm/db/abstract-base.js',
         'db/json': 'dist/esm/db/json.js',
         'db/json-memory': 'dist/esm/db/json-memory.js',

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -49,6 +49,7 @@ import {
     IssueCredentialsOptions,
     KeymasterInterface,
     KeymasterOptions,
+    NodeCapabilities,
     LightningConfig,
     LightningBalance,
     LightningInvoice,
@@ -204,7 +205,7 @@ export default class Keymaster implements KeymasterInterface {
     // Node capability manifest (`<nodeURL>/api/v1/capabilities`), fetched once and
     // memoized. `undefined` = not yet fetched; `null` = node has no manifest
     // (older node / not a gateway) → callers proceed lazily rather than regress.
-    private _nodeCapabilities?: Record<string, boolean> | null;
+    private _nodeCapabilities?: NodeCapabilities | null;
     private _walletCache?: WalletFile;
     private _hdkeyCache?: any;
     // Identity of the wallet whose seed `_hdkeyCache` was derived from, so a
@@ -2661,8 +2662,10 @@ export default class Keymaster implements KeymasterInterface {
 
     // Fetch (once, memoized) the node's capability manifest. Returns null when the
     // node exposes no manifest (older node, or the node URL is a bare gatekeeper) —
-    // callers then proceed lazily so we never regress against existing nodes.
-    private async getNodeCapabilities(): Promise<Record<string, boolean> | null> {
+    // callers then proceed lazily so we never regress against existing nodes. Public
+    // so clients (wallet UIs) can gate optional-feature surfaces on the same signal
+    // the gated operations use; null means "unknown", which callers treat as allowed.
+    async getNodeCapabilities(): Promise<NodeCapabilities | null> {
         if (this._nodeCapabilities !== undefined) {
             return this._nodeCapabilities;
         }

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -206,6 +206,9 @@ export default class Keymaster implements KeymasterInterface {
     // memoized. `undefined` = not yet fetched; `null` = node has no manifest
     // (older node / not a gateway) → callers proceed lazily rather than regress.
     private _nodeCapabilities?: NodeCapabilities | null;
+    // This node's own public DIDComm endpoint, fetched once and memoized.
+    // `undefined` = not yet fetched; `null` = the node advertises none.
+    private _nodeDidCommEndpoint?: string | null;
     private _walletCache?: WalletFile;
     private _hdkeyCache?: any;
     // Identity of the wallet whose seed `_hdkeyCache` was derived from, so a
@@ -2618,6 +2621,42 @@ export default class Keymaster implements KeymasterInterface {
         return { message: inner, metadata };
     }
 
+    // The public DIDComm endpoint this node advertises (the same value
+    // publishDidComm auto-discovers), used to recognise mail bound for a mailbox
+    // that lives here. Memoized; null when the node advertises none.
+    private async nodeDidCommEndpoint(): Promise<string | null> {
+        if (this._nodeDidCommEndpoint !== undefined) {
+            return this._nodeDidCommEndpoint;
+        }
+        const gateway = this.gatekeeper as Partial<DrawbridgeInterface>;
+        if (typeof gateway.getDidCommEndpoint !== 'function') {
+            this._nodeDidCommEndpoint = null;
+            return null;
+        }
+        try {
+            this._nodeDidCommEndpoint = (await gateway.getDidCommEndpoint()) || null;
+        }
+        catch {
+            this._nodeDidCommEndpoint = null;
+        }
+        return this._nodeDidCommEndpoint;
+    }
+
+    // Compare endpoints the way two publishers of the same node would write them:
+    // case-insensitive scheme and host, trailing slashes ignored.
+    private static sameDidCommEndpoint(a: string, b: string): boolean {
+        const normalize = (value: string): string => {
+            try {
+                const url = new URL(value);
+                return `${url.protocol.toLowerCase()}//${url.host.toLowerCase()}${url.pathname.replace(/\/+$/, '')}`;
+            }
+            catch {
+                return value.replace(/\/+$/, '');
+            }
+        };
+        return normalize(a) === normalize(b);
+    }
+
     private async resolveDidCommEndpoint(did: string): Promise<{ uri: string; routingKeys: string[] } | undefined> {
         const doc = await this.resolveDidForDidComm(did);
         const service = (doc.didDocument?.service || []).find(s => s.type === 'DIDCommMessaging');
@@ -2776,6 +2815,34 @@ export default class Keymaster implements KeymasterInterface {
                 envelope = wrapForward(packed, recipientKa.kid, { kid: routing.kid, publicJwk: routing.publicJwk });
             }
 
+            // A recipient whose mailbox is on this node needs no egress: deposit
+            // straight into the local relay. Without this, sending to your own
+            // identity leaves the node and comes back -- and with an
+            // auto-discovered `.onion` endpoint that means a full Tor round trip,
+            // which fails outright on a node that runs no Tor. Mirror of
+            // receive/mediate, which read the local gateway rather than the
+            // published endpoint. Skipped when a mediator is in the path, whose
+            // Forward envelope is addressed elsewhere by design.
+            const nodeEndpoint = await this.nodeDidCommEndpoint();
+            if (endpoint.routingKeys.length === 0 && nodeEndpoint
+                && Keymaster.sameDidCommEndpoint(endpoint.uri, nodeEndpoint)) {
+                const localResponse = await fetch(`${serviceBase}/api/v1/messages`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/didcomm-encrypted+json' },
+                    body: envelope,
+                });
+                if (!localResponse.ok) {
+                    const localDetail = await localResponse.json().then(body => body?.error).catch(() => undefined);
+                    const localSuffix = localDetail ? ` (${localDetail})` : '';
+                    throw new KeymasterError(
+                        `DIDComm delivery to ${recipientDid} failed: ${localResponse.status}${localSuffix}`
+                    );
+                }
+                const localData = await localResponse.json();
+                ids.push(...(localData.ids || []));
+                continue;
+            }
+
             // Authenticated hand-off to the service (signed challenge proving we
             // control senderDid), which delivers the opaque envelope to the recipient.
             const challenge = await this.fetchDidCommChallenge(serviceBase, `DIDComm delivery to ${recipientDid} failed`);
@@ -2786,7 +2853,12 @@ export default class Keymaster implements KeymasterInterface {
                 body: JSON.stringify({ did: senderDid, challenge, signature, endpoint: endpoint.uri, message: envelope }),
             });
             if (!response.ok) {
-                throw new KeymasterError(`DIDComm delivery to ${recipientDid} failed: ${response.status}`);
+                // The status alone cannot tell a missing Tor proxy from a recipient
+                // that rejected the envelope -- the service says which in the body,
+                // so carry it through instead of discarding it.
+                const detail = await response.json().then(body => body?.error).catch(() => undefined);
+                const suffix = detail ? ` (${detail})` : '';
+                throw new KeymasterError(`DIDComm delivery to ${recipientDid} failed: ${response.status}${suffix}`);
             }
             const data = await response.json();
             ids.push(...(data.ids || []));

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2556,6 +2556,30 @@ export default class Keymaster implements KeymasterInterface {
         return packDidCommMessage(envelope, recipients, packOptions);
     }
 
+    // Authcrypt binds the sender to the envelope's `skid`; the plaintext `from`
+    // header is just a claim inside it, and nothing else checks the two agree.
+    // Without this, an authenticated sender can name any DID as `from` and every
+    // consumer that trusts that header -- a wallet showing "authenticated", a
+    // reply, an auto-response -- is addressing the wrong party.
+    private static assertSenderMatchesEnvelope(
+        message: any,
+        metadata: { authenticated: boolean; sender?: string }
+    ): void {
+        if (!metadata.authenticated || !metadata.sender) {
+            return;
+        }
+        const from = message?.from;
+        if (typeof from !== 'string' || from.length === 0) {
+            return;
+        }
+        const authenticatedDid = metadata.sender.split('#')[0];
+        if (from !== authenticatedDid) {
+            throw new KeymasterError(
+                `DIDComm sender mismatch: message claims ${from} but is authenticated as ${authenticatedDid}`
+            );
+        }
+    }
+
     async unpackDidComm(
         packed: string,
         options: { name?: string } = {}
@@ -2615,9 +2639,12 @@ export default class Keymaster implements KeymasterInterface {
             const { payload } = verifyJws(text, signerVm.publicKeyJwk);
             metadata.nonRepudiation = true;
             metadata.signer = jwsKid;
-            return { message: JSON.parse(new TextDecoder().decode(payload)), metadata };
+            const signedMessage = JSON.parse(new TextDecoder().decode(payload));
+            Keymaster.assertSenderMatchesEnvelope(signedMessage, metadata);
+            return { message: signedMessage, metadata };
         }
 
+        Keymaster.assertSenderMatchesEnvelope(inner, metadata);
         return { message: inner, metadata };
     }
 

--- a/python/keymaster/src/keymaster/core.py
+++ b/python/keymaster/src/keymaster/core.py
@@ -3681,6 +3681,24 @@ class Keymaster:
 
         return dc.pack_didcomm_message(envelope, recipients, sender=sender, signer=signer, enc=options.get("encryption"))
 
+    @staticmethod
+    def _assert_sender_matches_envelope(message: Any, metadata: dict[str, Any]) -> None:
+        # Authcrypt binds the sender to the envelope's `skid`; the plaintext `from`
+        # header is just a claim inside it, and nothing else checks the two agree.
+        # Without this, an authenticated sender can name any DID as `from` and every
+        # consumer that trusts that header -- a wallet showing "authenticated", a
+        # reply, an auto-response -- is addressing the wrong party.
+        if not metadata.get("authenticated") or not metadata.get("sender"):
+            return
+        sender_from = message.get("from") if isinstance(message, dict) else None
+        if not isinstance(sender_from, str) or not sender_from:
+            return
+        authenticated_did = metadata["sender"].split("#")[0]
+        if sender_from != authenticated_did:
+            raise KeymasterError(
+                f"DIDComm sender mismatch: message claims {sender_from} but is authenticated as {authenticated_did}"
+            )
+
     async def unpack_didcomm(self, packed: str, options: dict[str, Any] | None = None) -> dict[str, Any]:
         options = options or {}
         name = options.get("name")
@@ -3730,8 +3748,11 @@ class Keymaster:
             result = dc.verify_jws(text, public_jwk)
             metadata["nonRepudiation"] = True
             metadata["signer"] = jws_kid
-            return {"message": json.loads(result["payload"].decode("utf-8")), "metadata": metadata}
+            signed_message = json.loads(result["payload"].decode("utf-8"))
+            self._assert_sender_matches_envelope(signed_message, metadata)
+            return {"message": signed_message, "metadata": metadata}
 
+        self._assert_sender_matches_envelope(inner, metadata)
         return {"message": inner, "metadata": metadata}
 
     def _didcomm_gateway_base(self, override: str | None = None) -> str:

--- a/python/keymaster/src/keymaster/core.py
+++ b/python/keymaster/src/keymaster/core.py
@@ -3544,7 +3544,7 @@ class Keymaster:
         # If the node doesn't offer DIDComm, don't advertise a dead endpoint:
         # publish key-only (an explicit endpoint still overrides this).
         if endpoint is None:
-            caps = await self._get_node_capabilities()
+            caps = await self.get_node_capabilities()
             if caps is None or caps.get("didcomm") is not False:
                 getter = getattr(self.gatekeeper, "get_didcomm_endpoint", None)
                 if getter:
@@ -3715,10 +3715,12 @@ class Keymaster:
             raise KeymasterError("cannot reach the DIDComm gateway: no node URL configured")
         return base.rstrip("/")
 
-    async def _get_node_capabilities(self) -> dict[str, bool] | None:
+    async def get_node_capabilities(self) -> dict[str, bool] | None:
         # Fetch (once, memoized) the node's capability manifest. None when the node
         # exposes no manifest (older node, or node URL is a bare gatekeeper) — callers
-        # then proceed lazily so we never regress against existing nodes.
+        # then proceed lazily so we never regress against existing nodes. Public so
+        # clients (wallet UIs) can gate optional-feature surfaces on the same signal
+        # the gated operations use; None means "unknown", which callers treat as allowed.
         if self._node_capabilities is not _UNFETCHED:
             return self._node_capabilities
         node_url = getattr(self.gatekeeper, "url", None)
@@ -3737,7 +3739,7 @@ class Keymaster:
     async def _require_node_capability(self, capability: str, human_name: str) -> None:
         # Throw clearly when the node explicitly does not offer a capability. Unknown
         # (no manifest) is permissive — the op proceeds and fails later if truly absent.
-        caps = await self._get_node_capabilities()
+        caps = await self.get_node_capabilities()
         if caps is not None and caps.get(capability) is False:
             raise KeymasterError(f"this node does not offer {human_name}")
 

--- a/python/keymaster/src/keymaster/core.py
+++ b/python/keymaster/src/keymaster/core.py
@@ -8,6 +8,7 @@ import logging
 import os
 import struct
 from typing import Any, Protocol, cast
+from urllib.parse import urlparse
 
 import httpx
 from bolt11 import decode as decode_bolt11
@@ -140,6 +141,9 @@ class Keymaster:
         # memoized. _UNFETCHED until first read; None = node has no manifest (older
         # node / not a gateway) → callers proceed lazily rather than regress.
         self._node_capabilities: Any = _UNFETCHED
+        # This node's own public DIDComm endpoint, fetched once and memoized.
+        # _UNFETCHED until first read; None = the node advertises none.
+        self._node_didcomm_endpoint: Any = _UNFETCHED
 
     def _upgrade_wallet(self, wallet: dict[str, Any]) -> dict[str, Any]:
         version = wallet.get("version")
@@ -3499,6 +3503,34 @@ class Keymaster:
             }
         return await self.resolve_did(did)
 
+    async def _node_didcomm_endpoint_uri(self) -> str | None:
+        # The public DIDComm endpoint this node advertises (the same value
+        # publish_didcomm auto-discovers), used to recognise mail bound for a
+        # mailbox that lives here. Memoized; None when the node advertises none.
+        if self._node_didcomm_endpoint is not _UNFETCHED:
+            return self._node_didcomm_endpoint
+        getter = getattr(self.gatekeeper, "get_didcomm_endpoint", None)
+        if not getter:
+            self._node_didcomm_endpoint = None
+            return None
+        try:
+            self._node_didcomm_endpoint = await getter() or None
+        except Exception:
+            self._node_didcomm_endpoint = None
+        return self._node_didcomm_endpoint
+
+    @staticmethod
+    def _same_didcomm_endpoint(a: str, b: str) -> bool:
+        # Compare endpoints the way two publishers of the same node would write
+        # them: case-insensitive scheme and host, trailing slashes ignored.
+        def normalize(value: str) -> str:
+            parsed = urlparse(value)
+            if not parsed.scheme or not parsed.netloc:
+                return value.rstrip("/")
+            return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}{parsed.path.rstrip('/')}"
+
+        return normalize(a) == normalize(b)
+
     async def _resolve_didcomm_endpoint(self, did: str) -> dict[str, Any] | None:
         doc = await self._resolve_did_for_didcomm(did)
         service = next((s for s in doc.get("didDocument", {}).get("service") or [] if s.get("type") == "DIDCommMessaging"), None)
@@ -3784,6 +3816,34 @@ class Keymaster:
                     routing = await self._resolve_routing_key(endpoint["routingKeys"][0])
                     envelope = dc.wrap_forward(packed, recipient_ka["kid"], {"kid": routing["kid"], "publicJwk": routing["publicJwk"]})
 
+                # A recipient whose mailbox is on this node needs no egress: deposit
+                # straight into the local relay. Without this, sending to your own
+                # identity leaves the node and comes back -- and with an
+                # auto-discovered .onion endpoint that means a full Tor round trip,
+                # which fails outright on a node that runs no Tor. Mirror of
+                # receive/mediate, which read the local gateway rather than the
+                # published endpoint. Skipped when a mediator is in the path, whose
+                # Forward envelope is addressed elsewhere by design.
+                node_endpoint = await self._node_didcomm_endpoint_uri()
+                if not endpoint["routingKeys"] and node_endpoint and self._same_didcomm_endpoint(endpoint["uri"], node_endpoint):
+                    local_response = await client.post(
+                        f"{service_base}/api/v1/messages",
+                        content=envelope,
+                        headers={"Content-Type": "application/didcomm-encrypted+json"},
+                    )
+                    if local_response.status_code >= 400:
+                        local_detail = None
+                        try:
+                            local_detail = local_response.json().get("error")
+                        except Exception:
+                            local_detail = None
+                        local_suffix = f" ({local_detail})" if local_detail else ""
+                        raise KeymasterError(
+                            f"DIDComm delivery to {recipient_did} failed: {local_response.status_code}{local_suffix}"
+                        )
+                    ids.extend(local_response.json().get("ids") or [])
+                    continue
+
                 # Authenticated hand-off to the service (signed challenge proving
                 # control of sender_did); it delivers the opaque envelope.
                 try:
@@ -3799,7 +3859,16 @@ class Keymaster:
                     json={"did": sender_did, "challenge": challenge, "signature": signature, "endpoint": endpoint["uri"], "message": envelope},
                 )
                 if response.status_code >= 400:
-                    raise KeymasterError(f"DIDComm delivery to {recipient_did} failed: {response.status_code}")
+                    # The status alone cannot tell a missing Tor proxy from a recipient
+                    # that rejected the envelope -- the service says which in the body,
+                    # so carry it through instead of discarding it.
+                    detail = None
+                    try:
+                        detail = response.json().get("error")
+                    except Exception:
+                        detail = None
+                    suffix = f" ({detail})" if detail else ""
+                    raise KeymasterError(f"DIDComm delivery to {recipient_did} failed: {response.status_code}{suffix}")
                 ids.extend(response.json().get("ids") or [])
         return ids
 

--- a/python/keymaster/tests/test_didcomm.py
+++ b/python/keymaster/tests/test_didcomm.py
@@ -318,6 +318,64 @@ def test_capability_gating_permissive_when_manifest_absent():
     assert "does not offer" not in str(exc.value)
 
 
+def test_get_node_capabilities_is_public_and_memoized(monkeypatch):
+    # The same signal the gates use, exposed so a wallet can hide a surface instead
+    # of offering it and failing. Mirrors the JS Keymaster.getNodeCapabilities.
+    import asyncio
+    import httpx
+    from keymaster.core import Keymaster
+
+    class _Gw:
+        url = "http://node.test"
+
+    calls: list[str] = []
+
+    class _Response:
+        is_success = True
+
+        @staticmethod
+        def json():
+            return {"didcomm": True, "lightning": False, "names": True}
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def get(self, url):
+            calls.append(url)
+            return _Response()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+    km = Keymaster(gatekeeper=_Gw(), wallet_store=object(), passphrase="pass")
+
+    async def run():
+        first = await km.get_node_capabilities()
+        second = await km.get_node_capabilities()
+        return first, second
+
+    first, second = asyncio.run(run())
+    assert first == {"didcomm": True, "lightning": False, "names": True}
+    assert second == first
+    assert calls == ["http://node.test/api/v1/capabilities"]  # memoized, fetched once
+
+
+def test_get_node_capabilities_none_without_node_url():
+    import asyncio
+    from keymaster.core import Keymaster
+
+    class _Gw:
+        url = None
+
+    km = Keymaster(gatekeeper=_Gw(), wallet_store=object(), passphrase="pass")
+    assert asyncio.run(km.get_node_capabilities()) is None
+
+
 def test_coordinate_mediation_builders():
     assert p.mediate_request()["type"] == p.MEDIATE_REQUEST_TYPE
     grant = p.mediate_grant("did:cid:mediator", "req-1")

--- a/python/keymaster/tests/test_didcomm.py
+++ b/python/keymaster/tests/test_didcomm.py
@@ -169,6 +169,10 @@ class _FakeResponse:
         self._payload = payload
         self.status_code = status_code
 
+    @property
+    def is_success(self):
+        return self.status_code < 400
+
     def json(self):
         return self._payload
 
@@ -226,6 +230,118 @@ def test_ack_didcomm_reports_the_relay_count_not_the_requested_count(monkeypatch
     km = _mailbox_keymaster(monkeypatch, calls, lambda url, kw: _FakeResponse({"removed": 1}))
 
     assert asyncio.run(km.ack_didcomm(["msg-1", "msg-gone"])) == 1
+
+
+def test_send_didcomm_deposits_locally_for_a_mailbox_on_this_node(monkeypatch):
+    # Sending to your own identity must not leave the node. With an auto-discovered
+    # .onion endpoint that would be a full Tor round trip out and back -- and no
+    # delivery at all on a node running no Tor. Mirrors the JS keymaster.
+    import asyncio
+
+    onion = "http://abcdefghijklmnop.onion:4222/didcomm"
+    calls: list = []
+
+    def responses(url, kw):
+        return _FakeResponse({"ids": ["local-1"]})
+
+    km = _mailbox_keymaster(monkeypatch, calls, responses)
+    monkeypatch.setattr(km, "pack_didcomm", _async_return("envelope"))
+    monkeypatch.setattr(km, "_resolve_didcomm_endpoint", _async_return({"uri": onion, "routingKeys": []}))
+    monkeypatch.setattr(km, "_node_didcomm_endpoint_uri", _async_return(onion))
+
+    assert asyncio.run(km.send_didcomm({"type": "t", "body": {}}, "did:cid:alice")) == ["local-1"]
+
+    urls = [url for _method, url, _kw in calls]
+    assert urls == ["https://gateway.example/didcomm/api/v1/messages"]
+    assert not any("/deliver" in url for url in urls)
+    assert not any("/challenge" in url for url in urls)
+
+
+def test_send_didcomm_uses_the_service_for_a_mailbox_elsewhere(monkeypatch):
+    import asyncio
+
+    calls: list = []
+
+    def responses(url, kw):
+        if url.endswith("/challenge"):
+            return _FakeResponse({"challenge": "c"})
+        return _FakeResponse({"ids": ["remote-1"]})
+
+    km = _mailbox_keymaster(monkeypatch, calls, responses)
+    monkeypatch.setattr(km, "pack_didcomm", _async_return("envelope"))
+    monkeypatch.setattr(km, "_resolve_didcomm_endpoint", _async_return({"uri": "https://othernode.example/didcomm", "routingKeys": []}))
+    monkeypatch.setattr(km, "_node_didcomm_endpoint_uri", _async_return("https://mynode.example/didcomm"))
+    monkeypatch.setattr("keymaster.core.sign_hash", lambda *args, **kwargs: "sig")
+
+    assert asyncio.run(km.send_didcomm({"type": "t", "body": {}}, "did:cid:bob")) == ["remote-1"]
+
+    urls = [url for _method, url, _kw in calls]
+    assert any("/deliver" in url for url in urls)
+    assert not any(url.endswith("/api/v1/messages") for url in urls)
+
+
+def test_same_didcomm_endpoint_ignores_case_and_trailing_slash():
+    from keymaster.core import Keymaster
+
+    assert Keymaster._same_didcomm_endpoint("https://Node.Example/didcomm/", "https://node.example/didcomm")
+    assert not Keymaster._same_didcomm_endpoint("https://node.example/didcomm", "https://other.example/didcomm")
+
+
+def test_delivery_failure_carries_the_service_error_body(monkeypatch):
+    # 502 alone cannot tell a missing Tor proxy from a recipient that rejected the
+    # envelope; the reason lives in the body. Mirrors the JS keymaster.
+    import asyncio
+    import pytest
+    from keymaster.core import KeymasterError
+
+    def responses(url, kw):
+        if url.endswith("/challenge"):
+            return _FakeResponse({"challenge": "c"})
+        return _FakeResponse(
+            {"error": "onion endpoint requires a Tor proxy (set ARCHON_DIDCOMM_TOR_PROXY)"},
+            status_code=502,
+        )
+
+    calls: list = []
+    km = _mailbox_keymaster(monkeypatch, calls, responses)
+    monkeypatch.setattr(km, "pack_didcomm", _async_return("envelope"))
+    monkeypatch.setattr(km, "_resolve_didcomm_endpoint", _async_return({"uri": "https://bob.example/didcomm", "routingKeys": []}))
+    monkeypatch.setattr("keymaster.core.sign_hash", lambda *args, **kwargs: "sig")
+
+    with pytest.raises(KeymasterError) as exc:
+        asyncio.run(km.send_didcomm({"type": "t", "body": {}}, "did:cid:bob"))
+
+    assert "502 (onion endpoint requires a Tor proxy" in str(exc.value)
+
+
+def test_delivery_failure_without_a_body_still_reports_the_status(monkeypatch):
+    import asyncio
+    import pytest
+    from keymaster.core import KeymasterError
+
+    class _NoBody:
+        status_code = 504
+        is_success = False
+
+        @staticmethod
+        def json():
+            raise ValueError("not json")
+
+    def responses(url, kw):
+        if url.endswith("/challenge"):
+            return _FakeResponse({"challenge": "c"})
+        return _NoBody()
+
+    calls: list = []
+    km = _mailbox_keymaster(monkeypatch, calls, responses)
+    monkeypatch.setattr(km, "pack_didcomm", _async_return("envelope"))
+    monkeypatch.setattr(km, "_resolve_didcomm_endpoint", _async_return({"uri": "https://bob.example/didcomm", "routingKeys": []}))
+    monkeypatch.setattr("keymaster.core.sign_hash", lambda *args, **kwargs: "sig")
+
+    with pytest.raises(KeymasterError) as exc:
+        asyncio.run(km.send_didcomm({"type": "t", "body": {}}, "did:cid:bob"))
+
+    assert str(exc.value).endswith("failed: 504")
 
 
 def test_receive_didcomm_acks_unless_ack_is_explicitly_false(monkeypatch):

--- a/python/keymaster/tests/test_didcomm.py
+++ b/python/keymaster/tests/test_didcomm.py
@@ -232,6 +232,32 @@ def test_ack_didcomm_reports_the_relay_count_not_the_requested_count(monkeypatch
     assert asyncio.run(km.ack_didcomm(["msg-1", "msg-gone"])) == 1
 
 
+def test_unpack_rejects_a_from_that_contradicts_the_authenticated_sender():
+    # Authcrypt binds the sender to skid; the plaintext `from` is an unchecked
+    # claim inside the envelope. Mirrors the JS keymaster.
+    import pytest
+    from keymaster.core import Keymaster, KeymasterError
+
+    metadata = {"authenticated": True, "sender": "did:cid:mallory#key-agreement-1"}
+
+    with pytest.raises(KeymasterError, match="sender mismatch"):
+        Keymaster._assert_sender_matches_envelope({"from": "did:cid:bob"}, metadata)
+
+    # Matching from, and a message with no from at all, both pass.
+    Keymaster._assert_sender_matches_envelope({"from": "did:cid:mallory"}, metadata)
+    Keymaster._assert_sender_matches_envelope({"body": {}}, metadata)
+
+
+def test_unpack_leaves_an_anoncrypt_from_alone():
+    # No skid means no authenticated sender to contradict; the claim is simply
+    # unverified, and callers must present it that way rather than reject it.
+    from keymaster.core import Keymaster
+
+    Keymaster._assert_sender_matches_envelope(
+        {"from": "did:cid:bob"}, {"authenticated": False, "sender": None}
+    )
+
+
 def test_send_didcomm_deposits_locally_for_a_mailbox_on_this_node(monkeypatch):
     # Sending to your own identity must not leave the node. With an auto-discovered
     # .onion endpoint that would be a full Tor round trip out and back -- and no

--- a/python/keymaster_sdk/src/keymaster_sdk/__init__.py
+++ b/python/keymaster_sdk/src/keymaster_sdk/__init__.py
@@ -58,6 +58,7 @@ from .keymaster_sdk import (
     get_ipfs_data,
     get_lightning_balance,
     get_lightning_payments,
+    get_node_capabilities,
     get_vault,
     get_vault_item,
     get_image,

--- a/python/keymaster_sdk/src/keymaster_sdk/keymaster_sdk.py
+++ b/python/keymaster_sdk/src/keymaster_sdk/keymaster_sdk.py
@@ -1380,6 +1380,11 @@ def get_lightning_payments(id=None):
     return response["payments"]
 
 
+def get_node_capabilities():
+    response = proxy_request("GET", f"{_keymaster_api}/capabilities")
+    return response["capabilities"]
+
+
 # DIDComm v2
 
 

--- a/python/keymaster_sdk/tests/test_keymaster_sdk_contract_unit.py
+++ b/python/keymaster_sdk/tests/test_keymaster_sdk_contract_unit.py
@@ -290,6 +290,29 @@ def test_create_returns_configured_sdk_module(monkeypatch):
     assert connect_calls == [{"url": "http://unit.test", "apiKey": "secret"}]
 
 
+def test_get_node_capabilities_forwards_expected_request(monkeypatch):
+    calls: list[tuple[str, str, dict]] = []
+
+    def fake_proxy_request(method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        return {"capabilities": {"didcomm": True, "lightning": False, "names": True}}
+
+    monkeypatch.setattr(sdk, "proxy_request", fake_proxy_request)
+    monkeypatch.setattr(sdk, "_keymaster_api", "http://unit.test/api/v1")
+
+    assert sdk.get_node_capabilities() == {"didcomm": True, "lightning": False, "names": True}
+    assert calls == [("GET", "http://unit.test/api/v1/capabilities", {})]
+
+
+def test_get_node_capabilities_returns_none_without_a_manifest(monkeypatch):
+    # A node that serves no manifest reports null, which callers treat as unknown
+    # (permissive) rather than unsupported.
+    monkeypatch.setattr(sdk, "proxy_request", lambda method, url, **kwargs: {"capabilities": None})
+    monkeypatch.setattr(sdk, "_keymaster_api", "http://unit.test/api/v1")
+
+    assert sdk.get_node_capabilities() is None
+
+
 def test_didcomm_wrappers_forward_expected_requests(monkeypatch):
     calls: list[tuple[str, str, dict]] = []
 

--- a/services/keymaster/server/src/keymaster-core-router.ts
+++ b/services/keymaster/server/src/keymaster-core-router.ts
@@ -43,6 +43,54 @@ export function createCoreRouter(options: CreateKeymasterRouterOptions): express
 
     /**
      * @swagger
+     * /capabilities:
+     *   get:
+     *     summary: Report which optional services the node offers.
+     *     description: >
+     *       Reads the node's capability manifest. `capabilities` is null when the
+     *       node serves no manifest (an older node, or a bare gatekeeper), which
+     *       callers should treat as unknown rather than unsupported.
+     *     responses:
+     *       200:
+     *         description: The node's capability manifest, or null if it serves none.
+     *         content:
+     *           application/json:
+     *             schema:
+     *               type: object
+     *               properties:
+     *                 capabilities:
+     *                   type: object
+     *                   nullable: true
+     *                   additionalProperties:
+     *                     type: boolean
+     *                   properties:
+     *                     didcomm:
+     *                       type: boolean
+     *                     lightning:
+     *                       type: boolean
+     *                     names:
+     *                       type: boolean
+     *       500:
+     *         description: Internal server error.
+     *         content:
+     *           application/json:
+     *             schema:
+     *               type: object
+     *               properties:
+     *                 error:
+     *                   type: string
+     */
+    router.get('/capabilities', async (req, res) => {
+        try {
+            const capabilities = await getKeymaster().getNodeCapabilities();
+            res.json({ capabilities });
+        } catch (error: any) {
+            res.status(500).send({ error: error.toString() });
+        }
+    });
+
+    /**
+     * @swagger
      * /wallet:
      *   get:
      *     summary: Retrieve the current wallet.

--- a/tests/keymaster/client.test.ts
+++ b/tests/keymaster/client.test.ts
@@ -17,6 +17,7 @@ const Endpoints = {
     wallet_mnemonic: '/api/v1/wallet/mnemonic',
     wallet_passphrase: '/api/v1/wallet/passphrase',
     registries: '/api/v1/registries',
+    capabilities: '/api/v1/capabilities',
     ids: '/api/v1/ids',
     ids_current: '/api/v1/ids/current',
     keys_rotate: '/api/v1/keys/rotate',
@@ -1362,6 +1363,46 @@ describe('unpublishAddress', () => {
 
         try {
             await keymaster.unpublishAddress();
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
+describe('getNodeCapabilities', () => {
+    it('should return the node capability manifest', async () => {
+        nock(KeymasterURL)
+            .get(Endpoints.capabilities)
+            .reply(200, { capabilities: { didcomm: true, lightning: false, names: true } });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const capabilities = await keymaster.getNodeCapabilities();
+
+        expect(capabilities).toStrictEqual({ didcomm: true, lightning: false, names: true });
+    });
+
+    it('should return null when the node serves no manifest', async () => {
+        nock(KeymasterURL)
+            .get(Endpoints.capabilities)
+            .reply(200, { capabilities: null });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const capabilities = await keymaster.getNodeCapabilities();
+
+        expect(capabilities).toBeNull();
+    });
+
+    it('should throw exception on getNodeCapabilities server error', async () => {
+        nock(KeymasterURL)
+            .get(Endpoints.capabilities)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.getNodeCapabilities();
             throw new ExpectedExceptionError();
         }
         catch (error: any) {

--- a/tests/keymaster/didcomm.test.ts
+++ b/tests/keymaster/didcomm.test.ts
@@ -6,6 +6,7 @@ import DbJsonMemory from '@didcid/gatekeeper/db/json-memory';
 import WalletJsonMemory from '@didcid/keymaster/wallet/json-memory';
 import HeliaClient from '@didcid/ipfs/helia';
 import {
+    packDidCommMessage,
     packEncrypted,
     unpackEncrypted,
     didKeyToX25519,
@@ -302,6 +303,85 @@ describe('packDidComm / unpackDidComm (cross-method: Archon did:cid <-> did:key)
         expect(out.body).toEqual(body);
         expect(metadata.authenticated).toBe(true);
         expect(metadata.sender).toBe(bob.kid);
+    });
+});
+
+describe('authenticated sender binding', () => {
+    // packDidComm already strips a caller-supplied `from` and sets it itself, so
+    // the threat is a foreign agent: anyone may send us DIDComm, and an envelope
+    // authenticated as Mallory can carry `from: alice` in its plaintext.
+    async function forgeEnvelope(senderName: string, recipientDid: string, claimedFrom: string) {
+        const senderKa = await keymaster.fetchDidCommKeyPair(senderName);
+        const senderDid = (await keymaster.fetchIdInfo(senderName)).did;
+        const recipientDoc = await keymaster.resolveDID(recipientDid);
+        const recipientKa = (keymaster as any).resolveKeyAgreement(recipientDoc);
+
+        return packDidCommMessage(
+            {
+                id: 'forged-1',
+                typ: 'application/didcomm-plain+json',
+                type: 'https://didcomm.org/basicmessage/2.0/message',
+                to: [recipientDid],
+                from: claimedFrom,
+                body: { content: 'trust me' },
+            },
+            [recipientKa],
+            { sender: { kid: `${senderDid}#key-agreement-1`, privateJwk: senderKa.privateJwk } },
+        );
+    }
+
+    it('rejects a message whose from does not match the authenticated sender', async () => {
+        const aliceDid = await keymaster.createId('Alice');
+        await keymaster.createId('Mallory');
+        const bobDid = await keymaster.createId('Bob');
+        await keymaster.publishDidComm('https://alice.example/didcomm', 'Alice');
+        await keymaster.publishDidComm('https://mallory.example/didcomm', 'Mallory');
+        await keymaster.publishDidComm('https://bob.example/didcomm', 'Bob');
+
+        const packed = await forgeEnvelope('Mallory', aliceDid, bobDid);
+
+        await expect(keymaster.unpackDidComm(packed, { name: 'Alice' }))
+            .rejects.toThrow(/sender mismatch/);
+    });
+
+    it('accepts a message whose from matches the authenticated sender', async () => {
+        const aliceDid = await keymaster.createId('Alice');
+        const malloryDid = await keymaster.createId('Mallory');
+        await keymaster.publishDidComm('https://alice.example/didcomm', 'Alice');
+        await keymaster.publishDidComm('https://mallory.example/didcomm', 'Mallory');
+
+        const packed = await forgeEnvelope('Mallory', aliceDid, malloryDid);
+        const { message, metadata } = await keymaster.unpackDidComm(packed, { name: 'Alice' });
+
+        expect(metadata.authenticated).toBe(true);
+        expect(message.from).toBe(malloryDid);
+    });
+
+    it('leaves an anoncrypt from alone, since nothing authenticates it', async () => {
+        // No skid means no authenticated sender to contradict; the claim is simply
+        // unverified, and callers must present it that way rather than reject it.
+        const aliceDid = await keymaster.createId('Alice');
+        const bobDid = await keymaster.createId('Bob');
+        await keymaster.publishDidComm('https://alice.example/didcomm', 'Alice');
+        await keymaster.publishDidComm('https://bob.example/didcomm', 'Bob');
+
+        const recipientDoc = await keymaster.resolveDID(aliceDid);
+        const recipientKa = (keymaster as any).resolveKeyAgreement(recipientDoc);
+        const packed = packDidCommMessage(
+            {
+                id: 'anon-1',
+                typ: 'application/didcomm-plain+json',
+                type: 'https://didcomm.org/basicmessage/2.0/message',
+                to: [aliceDid],
+                from: bobDid,
+                body: { content: 'anonymous' },
+            },
+            [recipientKa],
+            {},
+        );
+
+        const { metadata } = await keymaster.unpackDidComm(packed, { name: 'Alice' });
+        expect(metadata.authenticated).toBe(false);
     });
 });
 

--- a/tests/keymaster/didcomm.test.ts
+++ b/tests/keymaster/didcomm.test.ts
@@ -691,4 +691,38 @@ describe('node capability gating', () => {
         const err = await keymaster.sendDidComm({ type: 'x', body: {} } as any, alice).catch(e => e);
         expect(String(err)).not.toMatch(/does not offer/);
     });
+
+    // The same signal the gates use, exposed so a wallet can hide a surface instead
+    // of offering it and failing.
+    it('reports the manifest and fetches it only once', async () => {
+        const nodeURL = 'https://node.example';
+        (gatekeeper as any).url = nodeURL;
+
+        const requests: string[] = [];
+        jest.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+            requests.push(String(input));
+            return jsonResponse({ didcomm: true, lightning: false, names: true });
+        });
+
+        await expect(keymaster.getNodeCapabilities()).resolves.toEqual({
+            didcomm: true,
+            lightning: false,
+            names: true,
+        });
+        await keymaster.getNodeCapabilities();
+
+        expect(requests).toEqual([`${nodeURL}/api/v1/capabilities`]);
+    });
+
+    it('reports null when the node serves no manifest', async () => {
+        (gatekeeper as any).url = 'https://node.example';
+        jest.spyOn(globalThis, 'fetch').mockImplementation(async () => jsonResponse({ error: 'not found' }, 404));
+
+        await expect(keymaster.getNodeCapabilities()).resolves.toBeNull();
+    });
+
+    it('reports null when no node URL is configured', async () => {
+        (gatekeeper as any).url = undefined;
+        await expect(keymaster.getNodeCapabilities()).resolves.toBeNull();
+    });
 });

--- a/tests/keymaster/didcomm.test.ts
+++ b/tests/keymaster/didcomm.test.ts
@@ -608,6 +608,150 @@ describe('DIDComm gateway transport helpers', () => {
             .rejects.toThrow('DIDComm ack failed: 500');
     });
 
+    it('deposits locally when the recipient mailbox lives on this node', async () => {
+        // Sending to your own identity must not leave the node. With an
+        // auto-discovered .onion endpoint, egress would mean a full Tor round trip
+        // out and back -- and no delivery at all on a node running no Tor.
+        const base = useDidCommGateway();
+        const onion = 'http://abcdefghijklmnop.onion:4222/didcomm';
+        (gatekeeper as any).getDidCommEndpoint = async () => onion;
+
+        const aliceDid = await keymaster.createId('Alice');
+        await keymaster.publishDidComm(onion, 'Alice');
+
+        const posted: string[] = [];
+        jest.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+            const url = String(input);
+            posted.push(url);
+            if (url === `${base}/api/v1/messages`) {
+                expect(String(init?.body)).toContain('protected');
+                return jsonResponse({ ids: ['local-1'] });
+            }
+            throw new Error(`unexpected fetch ${url}`);
+        });
+
+        await expect(
+            keymaster.sendDidComm({ type: 'https://x/1/msg', body: {} }, aliceDid, { name: 'Alice' })
+        ).resolves.toEqual(['local-1']);
+
+        expect(posted).toEqual([`${base}/api/v1/messages`]);
+        expect(posted).not.toContain(`${base}/api/v1/deliver`);
+        expect(posted).not.toContain(`${base}/api/v1/challenge`);
+    });
+
+    it('still goes through the service when the recipient is on another node', async () => {
+        const base = useDidCommGateway();
+        (gatekeeper as any).getDidCommEndpoint = async () => 'https://mynode.example/didcomm';
+
+        await keymaster.createId('Alice');
+        const bobDid = await keymaster.createId('Bob');
+        await keymaster.publishDidComm('https://mynode.example/didcomm', 'Alice');
+        await keymaster.publishDidComm('https://othernode.example/didcomm', 'Bob');
+
+        const posted: string[] = [];
+        jest.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+            const url = String(input);
+            posted.push(url);
+            if (url === `${base}/api/v1/challenge`) {
+                return jsonResponse({ challenge: 'remote-challenge' });
+            }
+            if (url === `${base}/api/v1/deliver`) {
+                return jsonResponse({ ids: ['remote-1'] });
+            }
+            throw new Error(`unexpected fetch ${url}`);
+        });
+
+        await expect(
+            keymaster.sendDidComm({ type: 'https://x/1/msg', body: {} }, bobDid, { name: 'Alice' })
+        ).resolves.toEqual(['remote-1']);
+
+        expect(posted).toContain(`${base}/api/v1/deliver`);
+        expect(posted).not.toContain(`${base}/api/v1/messages`);
+    });
+
+    it('sends through the service when a mediator is in the path, even on this node', async () => {
+        // The Forward envelope is addressed to the mediator, not to us; depositing
+        // it here would put an envelope this node cannot unpack in a local mailbox.
+        const base = useDidCommGateway();
+        const nodeEndpoint = 'https://mynode.example/didcomm';
+        (gatekeeper as any).getDidCommEndpoint = async () => nodeEndpoint;
+
+        await keymaster.createId('Alice');
+        const mediatorDid = await keymaster.createId('Mediator');
+        const bobDid = await keymaster.createId('Bob');
+        await keymaster.publishDidComm(nodeEndpoint, 'Alice');
+        await keymaster.publishDidComm(nodeEndpoint, 'Mediator');
+        await keymaster.publishDidComm(nodeEndpoint, 'Bob', [mediatorDid]);
+
+        const posted: string[] = [];
+        jest.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+            const url = String(input);
+            posted.push(url);
+            if (url === `${base}/api/v1/challenge`) {
+                return jsonResponse({ challenge: 'mediated-challenge' });
+            }
+            if (url === `${base}/api/v1/deliver`) {
+                return jsonResponse({ ids: ['mediated-1'] });
+            }
+            throw new Error(`unexpected fetch ${url}`);
+        });
+
+        await expect(
+            keymaster.sendDidComm({ type: 'https://x/1/msg', body: {} }, bobDid, { name: 'Alice' })
+        ).resolves.toEqual(['mediated-1']);
+
+        expect(posted).toContain(`${base}/api/v1/deliver`);
+        expect(posted).not.toContain(`${base}/api/v1/messages`);
+    });
+
+    it('carries the service error body into a failed delivery', async () => {
+        // 502 alone cannot tell a missing Tor proxy from a recipient that rejected
+        // the envelope; the reason lives in the body.
+        const base = useDidCommGateway();
+        await keymaster.createId('Alice');
+        const bobDid = await keymaster.createId('Bob');
+        await keymaster.publishDidComm('https://alice.example/didcomm', 'Alice');
+        await keymaster.publishDidComm('https://bob.example/didcomm', 'Bob');
+
+        jest.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+            const url = String(input);
+            if (url === `${base}/api/v1/challenge`) {
+                return jsonResponse({ challenge: 'delivery-challenge' });
+            }
+            if (url === `${base}/api/v1/deliver`) {
+                return jsonResponse({ error: 'onion endpoint requires a Tor proxy (set ARCHON_DIDCOMM_TOR_PROXY)' }, 502);
+            }
+            throw new Error(`unexpected fetch ${url}`);
+        });
+
+        await expect(
+            keymaster.sendDidComm({ type: 'https://x/1/msg', body: {} }, bobDid, { name: 'Alice' })
+        ).rejects.toThrow(/502 \(onion endpoint requires a Tor proxy/);
+    });
+
+    it('still reports a failed delivery when the service sends no error body', async () => {
+        const base = useDidCommGateway();
+        await keymaster.createId('Alice');
+        const bobDid = await keymaster.createId('Bob');
+        await keymaster.publishDidComm('https://alice.example/didcomm', 'Alice');
+        await keymaster.publishDidComm('https://bob.example/didcomm', 'Bob');
+
+        jest.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+            const url = String(input);
+            if (url === `${base}/api/v1/challenge`) {
+                return jsonResponse({ challenge: 'delivery-challenge' });
+            }
+            if (url === `${base}/api/v1/deliver`) {
+                return new Response('gateway timeout', { status: 504 });
+            }
+            throw new Error(`unexpected fetch ${url}`);
+        });
+
+        await expect(
+            keymaster.sendDidComm({ type: 'https://x/1/msg', body: {} }, bobDid, { name: 'Alice' })
+        ).rejects.toThrow(/failed: 504$/);
+    });
+
     it('surfaces DIDComm gateway challenge failures clearly', async () => {
         const base = useDidCommGateway();
         await keymaster.createId('Alice');

--- a/tests/keymaster/server-routers.test.ts
+++ b/tests/keymaster/server-routers.test.ts
@@ -124,6 +124,7 @@ const ROUTES: Array<[Method, string, number]> = [
     ['POST', '/challenge', 400],
     // core
     ['GET', '/registries', 500],
+    ['GET', '/capabilities', 500],
     ['GET', '/wallet', 500],
     ['PUT', '/wallet', 500],
     ['POST', '/wallet/new', 500],


### PR DESCRIPTION
DIDComm in the wallets, Phases 0–3: the capability plumbing, endpoint management, the inbox, and compose/send. Both wallet code paths — the in-browser Keymaster and KeymasterClient over REST — are covered throughout.

## The problem

`Keymaster.getNodeCapabilities` was private. Every DIDComm and Lightning verb gates on it internally, so a wallet could only find out that a node lacks a service by calling the verb and catching "this node does not offer DIDComm". That is the wrong way round for a tab: you want to not render it.

Lightning got around this with a bespoke `DrawbridgeClient.isLightningSupported()` → `/lightning/supported`. That only works for wallets holding a Drawbridge client. `apps/keymaster-client` has only a `KeymasterClient`, which is why its Lightning tab has never rendered — `App.jsx` has no `hasLightning` to pass. Reading the manifest through the keymaster surface instead works for both wallet shapes.

## What changed

- `getNodeCapabilities` is public on `Keymaster`, typed `NodeCapabilities | null`. Memoization, the 5s `AbortController` timeout, and the permissive null are unchanged — this is a visibility change, not a behaviour change.
- New `NodeCapabilities` type in `@didcid/clients`, added to `KeymasterInterface`.
- `KeymasterClient.getNodeCapabilities()` → `GET /api/v1/capabilities`.
- New REST route on the keymaster service core router, with Swagger; `docs/keymaster-api.json` regenerated.
- Python parity: `_get_node_capabilities` → `get_node_capabilities` on the pure-Python `Keymaster`; new `get_node_capabilities()` in `keymaster_sdk`, exported from `__init__`.
- `react-wallet`'s `WalletProvider` exposes `hasDidComm` alongside `hasLightning`, read once when the Keymaster is built.

## Null means unknown, not unsupported

A node that serves no manifest — an older node, or a node URL pointing at a bare gatekeeper on :4224 rather than Drawbridge on :4222 — returns null. `hasDidComm` initialises to `true` and only goes false on an explicit `didcomm: false`, matching `requireNodeCapability`. Hiding the surface against every older node would be a regression; letting the operation fail late is the existing contract.

# Phase 1 — endpoint management

A DIDComm tab, gated on `hasDidComm`, that does three things: show what the current identity's DID document advertises, publish, and unpublish.

- **Blank endpoint is not "no endpoint".** It asks the node for its own relay via `getDidCommEndpoint`, which is the path most identities want. An explicit endpoint overrides it — for a mediator, or an endpoint the node cannot discover.
- **Routing keys** switch `publishDidComm` to the object service form, so senders wrap messages in a Forward. Entered comma-separated, empty means none.
- **Two states are both "published"**: with an endpoint, and key-only. Key-only means others can encrypt to this identity but have nowhere to deliver, so it is called out rather than shown as a blank field.

Both wallet code paths are covered:

- `apps/react-wallet` — new `DidCommTab.tsx` using the `PageHeader`/`Section`/`EmptyState` primitives from #893, registered in `BrowserContent` (panel, tab strip, and overflow menu, each gated).
- `apps/keymaster-client` and `apps/gatekeeper-client` — the same screen in the shared `KeymasterUI.jsx`, kept byte-identical between the two per AGENTS.md. This is what exercises the flow through `KeymasterClient` over REST rather than an in-browser Keymaster.

Both demo apps now read capabilities from their Keymaster once it exists, and pass `hasDidComm` down.

# Phase 2 — inbox

The DIDComm tab gains sub-tabs: **Inbox** and **Endpoint**.

**Reading is non-destructive.** `receiveDidComm({ ack: false })` leaves everything on the node; a message goes away only when dismissed. That has a consequence worth stating: every poll returns the whole mailbox, so the list is *replaced*, never accumulated. What is on screen is exactly what is still on the node. Messages that fail to unpack stay server-side and never appear here — the count on screen can legitimately be lower than the count in the mailbox.

**Polling is scoped and quiet.** It runs only while the screen is open, at the interval already configured in Settings (`0` = manual only), rather than joining the wallet's global refresh loop — a mailbox fetch signs a challenge and makes two round trips, which is not worth doing every 30s for users who never open the tab. A polled failure is usually a briefly unreachable node, so it stays silent; only an explicit **Refresh** raises a snackbar. Overlap is guarded with a ref, not the loading flag: an interval callback closes over the render that created it, so a state read there would always be stale.

**Rendering follows the message type.** Basic messages show their text, trust pings offer a one-click response, everything else falls back to its JSON body. Sender and authentication are separate chips on purpose — anoncrypt hides the sender entirely, so "who sent this" and "is that claim verified" are different questions and a single line conflating them would be misleading.

`@didcid/keymaster/didcomm-protocols` is now a real export subpath (ESM, CJS, and types, with the CJS entry added to the rollup config) so the wallet can recognise and build protocol messages without reaching into package internals. The shared `KeymasterUI.jsx` inlines the three protocol URIs instead, because the server-wallet demo deliberately depends only on the thin client package.

# Phase 3 — compose and send

A **Compose** sub-tab: send a basic message or a trust ping to any agent that publishes a messaging endpoint.

**The recipient is resolved before packing.** An alias must not travel in the envelope — DIDComm addresses recipients by DID — and resolving up front also turns an unknown name into a clear error before any crypto runs, rather than a confusing failure deeper in the send path.

**Anoncrypt is offered with the trade stated, not implied.** "Send anonymously" carries a line of copy that changes with the checkbox: the recipient cannot tell who sent it *and cannot reply to it*. That second half is the part a user would otherwise discover only after sending. Authcrypt remains the default.

A basic message in the inbox now offers **Reply**, which prefills the recipient and switches to Compose.

# Field fix — self-delivery

Found while testing this branch: sending a DIDComm message to your own alias failed with a 502.

The recipient endpoint was `http://<onion>:4222/didcomm` — the Tor fallback `publishDidComm` auto-discovers when `ARCHON_DRAWBRIDGE_PUBLIC_HOST` is unset. So a message to yourself left the node and came back through Tor, and on a node running no Tor it did not arrive at all.

`sendDidComm` now recognises a recipient whose mailbox lives on this node — comparing their published endpoint against the one the node advertises, via the same `getDidCommEndpoint()` call auto-discovery already uses — and deposits straight into the local relay. No challenge, no egress, no Tor. This is the send-side counterpart to #646, which made *reading* your own mailbox a local-gateway operation for the same reason.

| Recipient's endpoint | Path |
| --- | --- |
| Same as this node's | Local deposit |
| Another node | `/deliver`, unchanged |
| Behind a mediator | `/deliver`, unchanged — the Forward envelope is addressed to the mediator, and depositing it here would leave an envelope this node cannot unpack in a local mailbox |

Also: a failed delivery now carries the relay's error body. A bare `502` could not distinguish a missing Tor proxy from a recipient that rejected the envelope, and the relay says which — that ambiguity is what made this take a round of diagnosis instead of a glance at the error.

Both changes are mirrored in the Python port.

# Review findings

Copilot raised three, all valid; two were bugs in code this PR adds.

**Sender spoofing (fixed).** `metadata.sender` is the envelope's `skid`, bound cryptographically by ECDH-1PU. `message.from` is a plaintext claim inside that envelope, and `unpackDidComm` never compared them — so an authenticated sender could put any DID in `from`, and the inbox displayed it beside the **Authenticated** chip with Reply and the ping response both aimed at the claimed party.

Fixed in `unpackDidComm` rather than only in the three wallet copies: the CLI, MCP, Python SDK and any external consumer had the same exposure. An authcrypt `from` that contradicts the `skid` is now rejected; an anoncrypt `from` has no authenticated sender to contradict, so it stays an unverified claim. The wallets apply the same rule at the surface — sender derived from `metadata.sender`, an unverified `from` rendered as `… (unverified)`, and Reply/Respond offered only when there is an authenticated party to address.

`packDidComm` already strips a caller-supplied `from`, so this was never reachable through our own send path — the vector is a foreign agent, and anyone may send us DIDComm. The tests forge exactly that, building an envelope authenticated as one identity while claiming another.

**Identity race in the inbox (fixed).** The previous identity's mail stayed on screen while the new read ran, and the overlap guard was a bare boolean — a read already in flight skipped the new identity's read and then committed its own result under the new name, permanently when polling is off. The guard is now keyed by identity, a completion whose identity is no longer active does not commit, and the list clears on identity change.

**Admin auth header (filed as #904, not fixed here).** `keymaster-client` sends the admin key as `Authorization: Bearer`, which the service never reads — it checks `X-Archon-Admin-Key` only. Real bug, but it predates this PR and breaks every protected call in that demo, not just the capability probe.

## Scope

Not included, deliberately:
- No CLI command, so the three-CLI parity rule stays satisfied.
- `python/keymaster_service` gets no route. It implements no DIDComm endpoints at all today, so adding `/capabilities` there alone would not make it usable for this; its parity gap is pre-existing and separate.
- `hasLightning` still reads `/lightning/supported`. Rerouting it through the manifest is a behaviour change on a working path and belongs in its own PR. `keymaster-client` still never passes it, so its Lightning tab stays hidden — the same pre-existing bug, untouched.
- `apps/browser-extension` gets nothing. Porting it is the follow-up under #894.
- No out-of-band invitations or QR, and no credential exchange over DIDComm (issue-credential 3.0 / present-proof 3.0). Both are worth doing; neither is needed for messaging to work end to end.
- Nothing about egress to *other* nodes. An onion recipient elsewhere still needs the `tor` profile, and the SSRF guard on private egress is untouched — #645 covers making that guard actually work (today its literal-hostname regex is bypassable by DNS rebinding, so it blocks honest local use and not an attacker).
- `sign` (non-repudiation) is not exposed. Authcrypt already authenticates the sender to the recipient; a separately signed message is a different guarantee that needs its own UI explanation.

Closes #649.

## Testing

- `tests/keymaster/didcomm.test.ts` — manifest reported, fetched once, null on 404, null with no node URL
- `tests/keymaster/client.test.ts` — manifest, null manifest, server error
- `tests/keymaster/server-routers.test.ts` — new route in the error-contract table
- `python/keymaster/tests/test_didcomm.py` — public and memoized, null without a node URL
- `python/keymaster_sdk/tests/test_keymaster_sdk_contract_unit.py` — request shape, null manifest

1177 JS tests across `tests/keymaster`, `tests/didcomm`, `tests/clients` and `tests/cipher`, 182 Python keymaster tests, 12 SDK contract tests, all passing. Run `--runInBand`, matching CI — parallel workers on a loaded machine starve the DB-backed suites into timeouts. `npm run lint` clean, and react-wallet, keymaster-client and gatekeeper-client all build.

The UI itself has no automated coverage: the repo has no React component testing setup, so `LightningTab` and every other tab are likewise untested. The DIDComm screen needs manual verification against a node running the `didcomm` profile (`COMPOSE_PROFILES` including `didcomm`, `ARCHON_DIDCOMM_URL=http://didcomm:4236`) with the wallet's node URL on Drawbridge :4222.
