### PR TITLE
fix(keymaster-client): Send the admin key in the header the service reads

### DIFF
--- a/apps/keymaster-client/src/App.jsx
+++ b/apps/keymaster-client/src/App.jsx
@@ -36,10 +36,11 @@ function App() {
 
             const { adminApiKey } = await res.json();
             const km = new KeymasterClient();
-            await km.connect({ url: keymasterUrl });
-            if (adminApiKey) {
-                km.addCustomHeader('Authorization', `Bearer ${adminApiKey}`);
-            }
+            // The admin key goes in X-Archon-Admin-Key, which is the only header
+            // the keymaster service reads; connect installs it. It was previously
+            // sent as an Authorization bearer token, which the service ignores, so
+            // every protected call 401'd whenever ARCHON_ADMIN_API_KEY was set.
+            await km.connect({ url: keymasterUrl, apiKey: adminApiKey });
             try {
                 const capabilities = await km.getNodeCapabilities();
                 setHasDidComm(capabilities?.didcomm !== false);

--- a/scripts/did-resolution-benchmark.js
+++ b/scripts/did-resolution-benchmark.js
@@ -28,7 +28,10 @@ function buildHeaders(adminKey) {
     };
 
     if (adminKey) {
-        headers.Authorization = `Bearer ${adminKey}`;
+        // Gatekeeper reads the admin key from this header only (v1-admin.ts).
+        // Inert on the routes this script calls, which are unguarded -- but a
+        // bearer token here would silently stop working the day one is guarded.
+        headers['X-Archon-Admin-Key'] = adminKey;
     }
 
     return headers;


### PR DESCRIPTION
## The bug

`apps/keymaster-client/src/App.jsx` installed the admin key as a bearer token:

```js
km.addCustomHeader('Authorization', `Bearer ${adminApiKey}`);
```

The keymaster service reads `x-archon-admin-key` and nothing else (`keymaster-admin.ts:4,18`), and `createRequireAdminKey` is mounted ahead of every non-public router (`keymaster-api.ts:177`).

So with `ARCHON_ADMIN_API_KEY` set, the demo logged in fine — `/login` is public and hands back the key — and then **every** subsequent call 401'd: wallet, identities, credentials, DIDComm, all of it. It only worked against a keymaster with no admin key configured, which is the common dev setup, which is why it went unnoticed.

## The fix

`KeymasterClient.connect` already accepts the key and installs the correct header (`keymaster-client.ts:92-100`), so:

```js
await km.connect({ url: keymasterUrl, apiKey: adminApiKey });
```

## Also in here

`scripts/did-resolution-benchmark.js` made the same mistake against Gatekeeper, whose admin middleware also reads `x-archon-admin-key` only (`v1-admin.ts:5`). It is **inert today** — `POST /dids/` and the resolve routes it calls carry no `requireAdminKey` — so this is not a live break, but a bearer token there would silently stop working the day one of those routes is guarded.

I checked the other `Authorization: Bearer` callers in the repo and left them alone: `keymaster.ts:2213,2249` (Herald address API) and `services/mediators/pinning/src/provider.ts:34` (external pinning provider) are both user/session-style flows against external services, which is what AGENTS.md reserves that header for.

## Testing

`npm run lint` clean, `keymaster-client` builds. No test covers the demo app's login flow — it has no test suite — so this was verified by reading the two header contracts against each other.

Fixes #904