### PR TITLE
test: Stop a cwd leak in wallet-db from failing cli-parity

### DIFF
--- a/tests/keymaster/cli-parity.test.ts
+++ b/tests/keymaster/cli-parity.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 // AGENTS.md requires the three CLIs to stay in parity:
 //
@@ -19,8 +20,14 @@ const SCRIPT_ONLY = new Set([
     'perf-test',
 ]);
 
+// Resolve from this file, not process.cwd(). cwd is process-global and the unit
+// suite runs --runInBand, so any test that chdirs -- and fails or times out
+// before restoring -- would otherwise make this suite fail with an ENOENT that
+// names an unrelated temp directory.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
 function readSource(relativePath: string): string {
-    return readFileSync(path.join(process.cwd(), relativePath), 'utf-8');
+    return readFileSync(path.join(REPO_ROOT, relativePath), 'utf-8');
 }
 
 const packageCli = readSource('packages/keymaster/src/cli.ts');

--- a/tests/keymaster/wallet-db.test.ts
+++ b/tests/keymaster/wallet-db.test.ts
@@ -115,6 +115,21 @@ describe('WalletSQLite', () => {
 });
 
 describe('WalletSQLite defaults and guards', () => {
+    // Two tests below chdir, because WalletSQLite's default path is relative to
+    // the working directory and that is the thing under test. cwd is
+    // process-global and the unit suite runs --runInBand, so a test that fails to
+    // restore it corrupts every later suite in the process. The paired finally
+    // covers a thrown assertion but NOT a jest timeout, which abandons the
+    // pending body and moves on -- hence this backstop, which jest runs either
+    // way.
+    const originalCwd = process.cwd();
+
+    afterEach(() => {
+        if (process.cwd() !== originalCwd) {
+            process.chdir(originalCwd);
+        }
+    });
+
     // NOTE: unlike WalletJson.saveWallet, which does mkdirSync(dataFolder,
     // {recursive:true}), WalletSQLite.connect never creates its folder — it opens
     // `${dataFolder}/${file}` directly and sqlite fails with SQLITE_CANTOPEN if the
@@ -147,6 +162,13 @@ describe('WalletSQLite defaults and guards', () => {
                 process.chdir(cwd);
             }
         });
+    });
+
+    it('leaves the working directory as it found it', () => {
+        // Regression guard for the cascade this backstop prevents: when this
+        // suite leaked cwd, the failure surfaced in cli-parity.test.ts as an
+        // ENOENT naming a temp directory, which points at the wrong file.
+        expect(process.cwd()).toBe(originalCwd);
     });
 
     it('create() applies the same defaults', async () => {


### PR DESCRIPTION
## The failure

A full `jest tests/keymaster` run produced this in a suite that touches none of the code under test:

```
FAIL tests/keymaster/cli-parity.test.ts
  ● Test suite failed to run

    ENOENT: no such file or directory, open '/tmp/archon-wallet-db-test-8YWMw9/packages/keymaster/src/cli.ts'
```

## The mechanism

`wallet-db.test.ts` chdirs into a temp dir, because `WalletSQLite`'s default path is relative to the working directory and that is the thing under test. The chdir is correctly paired:

```ts
const cwd = process.cwd();
process.chdir(dir);
try { ... } finally { process.chdir(cwd); }
```

That covers a thrown assertion. It does **not** cover a jest *timeout*: jest fails the test and proceeds while the async body is still pending, so `finally` has not run. The process stays in the temp directory.

`process.cwd()` is process-global and the unit suite runs `--runInBand`, so every later suite in that process inherits it — and `cli-parity.test.ts` read its sources relative to `process.cwd()`. One slow test in `wallet-db` therefore broke an unrelated suite, and the reported failure named the innocent one.

Only reproduces under load, where the SQLite tests time out. Not seen in CI yet, but CI runs `--runInBand` too, so it is reachable there.

## The fix, at both ends

- **Victim:** `cli-parity.test.ts` resolves from its own location via `import.meta.url`, so no other suite's cwd can reach it.
- **Cause:** `wallet-db.test.ts` restores cwd in `afterEach`, which jest runs even after a timeout.
- **Guard:** a test asserting the suite leaves cwd as it found it, so a regression reports as itself rather than as a stranger's ENOENT.

Either end alone would have fixed the observed failure. Both are here because the victim fix protects against any future chdir, and the cause fix removes the only current source.

## Verification

Not assumed — reproduced. A probe suite that leaks cwd on purpose, run ahead of `cli-parity` with `--runInBand`, made `cli-parity` fail with exactly that ENOENT before the change and pass after it.

`tests/keymaster` full: 28 suites, 1071 tests, 0 failures (192s, `--runInBand`). `npm run lint` clean.

Fixes #903