### PR TITLE
fix: Drop the egress address filter, keep the scheme checks

### DIFF
--- a/docs/didcomm-design.md
+++ b/docs/didcomm-design.md
@@ -319,8 +319,16 @@ direct-dial fallback**. (As with Lightning, sends work only when the keymaster's
 gateway/Drawbridge, not a bare gatekeeper.) This lets the CLI and in-browser wallet reach `.onion`
 recipients (they delegate transport) and keeps the keymaster free of network egress. *Validated:*
 the relay e2e routes every send through `/deliver`; a unit test asserts the no-gateway hard error.
-Privacy: the service sees recipient DIDs + timing, not content. (`ARCHON_DIDCOMM_ALLOW_PRIVATE_EGRESS=true`
-permits loopback destinations for dev/test.)
+Privacy: the service sees recipient DIDs + timing, not content.
+
+**Egress is unrestricted, deliberately.** The relay filters destinations by neither scheme nor
+address. An earlier guard rejected non-https and private/loopback hosts unless
+`ARCHON_DIDCOMM_ALLOW_PRIVATE_EGRESS` was set, but it matched hostnames with a literal regex, so
+`127.0.0.1.nip.io` and mapped IPv6 forms passed while honest same-host and LAN delivery did not.
+It stopped the wrong party, and was removed rather than left half-enforced (#645). Note what
+follows: `POST /deliver` authenticates any *resolvable* DID, not only local identities, so anyone
+able to create a DID can make the relay POST a body of their choosing to any host it can reach.
+Run it where that is acceptable.
 
 **Reading your own mailbox uses the same local gateway.** `receiveDidComm`/`mediateDidComm`
 (challenge → fetch → unpack → ack) connect to **`<nodeURL>/didcomm`** as well — *not* the identity's

--- a/docs/didcomm-design.md
+++ b/docs/didcomm-design.md
@@ -321,14 +321,14 @@ recipients (they delegate transport) and keeps the keymaster free of network egr
 the relay e2e routes every send through `/deliver`; a unit test asserts the no-gateway hard error.
 Privacy: the service sees recipient DIDs + timing, not content.
 
-**Egress is unrestricted, deliberately.** The relay filters destinations by neither scheme nor
-address. An earlier guard rejected non-https and private/loopback hosts unless
-`ARCHON_DIDCOMM_ALLOW_PRIVATE_EGRESS` was set, but it matched hostnames with a literal regex, so
-`127.0.0.1.nip.io` and mapped IPv6 forms passed while honest same-host and LAN delivery did not.
-It stopped the wrong party, and was removed rather than left half-enforced (#645). Note what
-follows: `POST /deliver` authenticates any *resolvable* DID, not only local identities, so anyone
-able to create a DID can make the relay POST a body of their choosing to any host it can reach.
-Run it where that is acceptable.
+**Clearnet egress is https-only, and not filtered by address** (#645). The old guard did both, behind
+`ARCHON_DIDCOMM_ALLOW_PRIVATE_EGRESS`; only the scheme half was worth keeping. The address half
+matched hostnames with a literal regex, so `127.0.0.1.nip.io` and mapped IPv6 forms passed it while
+honest same-host and LAN delivery did not — it restricted only callers not trying to evade it. The
+scheme check no DNS name can forge, and it is what keeps plaintext internal services out of reach
+(`http://redis:6379` with inline commands in the body being the usual shape). Residual exposure:
+`POST /deliver` authenticates any *resolvable* DID, not only a local identity, so anyone able to
+create a DID can make the relay POST a body of their choosing to any https host it can reach.
 
 **Reading your own mailbox uses the same local gateway.** `receiveDidComm`/`mediateDidComm`
 (challenge → fetch → unpack → ack) connect to **`<nodeURL>/didcomm`** as well — *not* the identity's

--- a/docs/didcomm-design.md
+++ b/docs/didcomm-design.md
@@ -325,8 +325,10 @@ Privacy: the service sees recipient DIDs + timing, not content.
 `ARCHON_DIDCOMM_ALLOW_PRIVATE_EGRESS`; only the scheme half was worth keeping. The address half
 matched hostnames with a literal regex, so `127.0.0.1.nip.io` and mapped IPv6 forms passed it while
 honest same-host and LAN delivery did not — it restricted only callers not trying to evade it. The
-scheme check no DNS name can forge, and it is what keeps plaintext internal services out of reach
-(`http://redis:6379` with inline commands in the body being the usual shape). Residual exposure:
+scheme check is what keeps plaintext internal services out of reach (`http://redis:6379` with
+inline commands in the body being the usual shape), and the relay does **not follow redirects**,
+without which the check would be worthless: 307/308 preserve method and body, so an https endpoint
+answering `307 -> http://redis:6379` would reach it regardless. Residual exposure:
 `POST /deliver` authenticates any *resolvable* DID, not only a local identity, so anyone able to
 create a DID can make the relay POST a body of their choosing to any https host it can reach.
 

--- a/docs/services/didcomm/README.md
+++ b/docs/services/didcomm/README.md
@@ -170,10 +170,15 @@ refused with `502`.
 > mapped IPv6 form — passed it, while honest same-host and LAN delivery did not.
 > It restricted only callers who were not trying to evade it.
 >
-> The **scheme** check stays, because a DNS name cannot forge it. It is what
-> keeps plaintext internal services out of reach: the usual SSRF target is
-> `http://redis:6379` with inline commands in the body, and an https fetch to
-> redis dies in the TLS handshake.
+> The **scheme** check stays. It is what keeps plaintext internal services out
+> of reach: the usual SSRF target is `http://redis:6379` with inline commands in
+> the body, and an https fetch to redis dies in the TLS handshake.
+>
+> **Redirects are not followed** (`redirect: 'manual'`), because the scheme check
+> is worthless without that. `fetch` follows by default and 307/308 preserve
+> method and body, so an https endpoint answering `307 -> http://redis:6379`
+> would hand the caller's bytes to the plaintext service. A mailbox has no reason
+> to redirect; a 3xx from the endpoint answers `502`.
 >
 > Residual exposure, unchanged by that removal: challenge auth here proves
 > control of *some* resolvable DID, not of a local identity, so anyone able to

--- a/docs/services/didcomm/README.md
+++ b/docs/services/didcomm/README.md
@@ -161,17 +161,24 @@ recipient. Destinations ending in `.onion` are dialled through the SOCKS proxy
 in `ARCHON_DIDCOMM_TOR_PROXY`; without one configured, an onion destination is
 refused with `502`.
 
-> **Egress is unrestricted.** Destinations are filtered by neither scheme nor
-> address — https and http, public and private, all forwarded. An earlier guard
-> rejected non-https and private/loopback hosts, but matched hostnames with a
-> literal regex, so `127.0.0.1.nip.io` and mapped IPv6 forms passed it while
-> honest same-host and LAN delivery did not; it was removed rather than left
-> half-enforced (#645).
+> **Clearnet destinations must be https; they are not filtered by address.**
+> The two halves of the old guard were not equally useful, and only one survived
+> (#645).
 >
-> The challenge auth here proves control of *some* resolvable DID, not of a
-> local identity, so anyone able to create a DID can make the relay issue a POST,
-> with a body of their choosing, to any host it can reach. Deploy it where that
-> is acceptable, and keep it off segments carrying services that would answer.
+> The **address** filter is gone. It matched hostnames with a literal regex, so
+> `127.0.0.1.nip.io` — or any attacker-controlled name pointing inward, or a
+> mapped IPv6 form — passed it, while honest same-host and LAN delivery did not.
+> It restricted only callers who were not trying to evade it.
+>
+> The **scheme** check stays, because a DNS name cannot forge it. It is what
+> keeps plaintext internal services out of reach: the usual SSRF target is
+> `http://redis:6379` with inline commands in the body, and an https fetch to
+> redis dies in the TLS handshake.
+>
+> Residual exposure, unchanged by that removal: challenge auth here proves
+> control of *some* resolvable DID, not of a local identity, so anyone able to
+> create a DID can make the relay POST a body of their choosing to any **https**
+> host it can reach, private ones included.
 
 ---
 

--- a/docs/services/didcomm/README.md
+++ b/docs/services/didcomm/README.md
@@ -151,6 +151,28 @@ There is no `/metrics` endpoint and no admin API.
 and `express.json` are both capped at `ARCHON_DIDCOMM_UPLOAD_LIMIT`
 (default `5mb`).
 
+### 2.7 Outbound delivery (DID-control auth)
+
+`POST /api/v1/deliver` takes `{ did, challenge, signature, endpoint, message }`
+and forwards the opaque envelope to `<endpoint>/api/v1/messages`. This is the
+single egress path: the keymaster performs crypto only and never dials
+recipients itself, which is what lets a browser wallet reach a `.onion`
+recipient. Destinations ending in `.onion` are dialled through the SOCKS proxy
+in `ARCHON_DIDCOMM_TOR_PROXY`; without one configured, an onion destination is
+refused with `502`.
+
+> **Egress is unrestricted.** Destinations are filtered by neither scheme nor
+> address — https and http, public and private, all forwarded. An earlier guard
+> rejected non-https and private/loopback hosts, but matched hostnames with a
+> literal regex, so `127.0.0.1.nip.io` and mapped IPv6 forms passed it while
+> honest same-host and LAN delivery did not; it was removed rather than left
+> half-enforced (#645).
+>
+> The challenge auth here proves control of *some* resolvable DID, not of a
+> local identity, so anyone able to create a DID can make the relay issue a POST,
+> with a body of their choosing, to any host it can reach. Deploy it where that
+> is acceptable, and keep it off segments carrying services that would answer.
+
 ---
 
 ## 3. Authentication

--- a/docs/services/mediators/lightning/README.md
+++ b/docs/services/mediators/lightning/README.md
@@ -156,17 +156,19 @@ Detected by `did.includes('@') && !did.startsWith('did:')`. Flow:
 
 1. Parse `<name>@<domain>`, construct
    `https://<domain>/.well-known/lnurlp/<urlencode(name)>`.
-2. Reject if `domain` resolves to a private address
-   (`localhost|127.*|10.*|172.(16-31).*|192.168.*`).
-3. Fetch the LNURL-pay endpoint JSON. Reject if `status === "ERROR"` or
-   missing `callback`.
-4. Validate the callback URL is `https:` and not a private address.
-5. Enforce `amountMsats = amount * 1000` against `minSendable` /
+2. Fetch the LNURL-pay endpoint JSON. Destinations are **not** filtered by
+   address; the scheme is what is enforced, and it is enforced across
+   redirects — each hop must be `https:`, at most 5 hops. Reject if
+   `status === "ERROR"` or missing `callback`.
+3. Validate the callback URL is `https:`. It comes from the remote response,
+   so it is attacker-influenced; the same per-hop rule applies when fetching
+   it.
+4. Enforce `amountMsats = amount * 1000` against `minSendable` /
    `maxSendable` from the LNURL response.
-6. Append `?amount=<msats>&comment=<memo>` to the callback if it has no
+5. Append `?amount=<msats>&comment=<memo>` to the callback if it has no
    existing query string, otherwise append `&amount=<msats>&comment=<memo>`
    (comment only if memo is non-empty) and fetch it.
-7. The response's `pr` field is the BOLT11 invoice.
+6. The response's `pr` field is the BOLT11 invoice.
 
 ### 4.2 DID (`did:cid:...`)
 
@@ -176,7 +178,8 @@ Detected by `did.includes('@') && !did.startsWith('did:')`. Flow:
    endpoint" }`.
 3. Validate the endpoint URL:
    - `.onion` hosts MUST use `http:`.
-   - Non-`.onion` MUST use `https:` and MUST NOT be a private host.
+   - Non-`.onion` MUST use `https:`. The address is **not** checked; a
+     private https endpoint is allowed.
 4. Build `<serviceEndpoint>?amount=<sats>&memo=<memo>`.
 5. If the mediator has a `publicHost` (see [§6.3](#63-public-host-resolution))
    and the endpoint's hostname matches, shortcut through the internal
@@ -184,7 +187,10 @@ Detected by `did.includes('@') && !did.startsWith('did:')`. Flow:
    looping back through our own onion.
 6. Fetch the invoice URL (through the Tor SOCKS proxy at
    `ARCHON_LIGHTNING_MEDIATOR_TOR_PROXY` when the destination is
-   `.onion`).
+   `.onion`). Redirects are **not followed**: this hop may legitimately be
+   onion-`http:` or the internal loopback shortcut, so there is no single
+   scheme rule to re-apply, and an invoice endpoint has no reason to
+   redirect. A 3xx answers `502`.
 7. Extract `paymentRequest` from the response.
 
 ### 4.3 Payment
@@ -347,7 +353,7 @@ A conformant third implementation MUST:
 - Use the Redis key schema in [§5](#5-redis-key-schema) if sharing a
   Redis namespace with the reference service.
 - Enforce the LUD-16 / DID validation rules in [§4](#4-zap-flow)
-  (private-host rejection, .onion-only http, etc.).
+  (https-only clearnet including across redirects, .onion-only http, etc.).
 - Use constant-time admin-key comparison.
 - Preserve the `/invoice/:did` public endpoint's shape so external
   zappers can pay published DIDs unchanged.

--- a/sample.env
+++ b/sample.env
@@ -301,10 +301,10 @@ ARCHON_DIDCOMM_DB=memory
 # BLANK this when that profile is off: empty gives a clean 502 explaining the
 # proxy is unset, whereas a stale `tor:9050` fails on connect.
 ARCHON_DIDCOMM_TOR_PROXY=tor:9050
-# Clearnet egress is unrestricted: the relay delivers to any scheme and any
-# address, including private and loopback ones. POST /deliver authenticates any
-# resolvable DID, so treat the relay as able to POST attacker-chosen bytes to
-# anything on its network segment, and place it accordingly.
+# Clearnet delivery must be https, and is not filtered by address: private and
+# loopback https destinations are allowed. POST /deliver authenticates any
+# resolvable DID rather than a local identity, so the relay can be made to POST
+# attacker-chosen bytes to any https host it can reach. Place it accordingly.
 
 # Lightning mediator
 ARCHON_LIGHTNING_MEDIATOR_CLN_REST_URL=https://cln:3001

--- a/sample.env
+++ b/sample.env
@@ -301,8 +301,10 @@ ARCHON_DIDCOMM_DB=memory
 # BLANK this when that profile is off: empty gives a clean 502 explaining the
 # proxy is unset, whereas a stale `tor:9050` fails on connect.
 ARCHON_DIDCOMM_TOR_PROXY=tor:9050
-# Dev/test only — allow delivery to private/loopback endpoints (default: off).
-# ARCHON_DIDCOMM_ALLOW_PRIVATE_EGRESS=true
+# Clearnet egress is unrestricted: the relay delivers to any scheme and any
+# address, including private and loopback ones. POST /deliver authenticates any
+# resolvable DID, so treat the relay as able to POST attacker-chosen bytes to
+# anything on its network segment, and place it accordingly.
 
 # Lightning mediator
 ARCHON_LIGHTNING_MEDIATOR_CLN_REST_URL=https://cln:3001

--- a/services/didcomm/server/src/config.js
+++ b/services/didcomm/server/src/config.js
@@ -42,10 +42,8 @@ const config = {
     maxChallenges: positiveInt('ARCHON_DIDCOMM_MAX_CHALLENGES',
         process.env.ARCHON_DIDCOMM_MAX_CHALLENGES, 10000),
     redisURL: process.env.ARCHON_REDIS_URL || 'redis://localhost:6379',
-    // Outbound egress (POST /deliver): SOCKS5 Tor proxy for .onion destinations,
-    // and an opt-in to allow private/loopback destinations (dev/test only).
+    // Outbound egress (POST /deliver): SOCKS5 Tor proxy for .onion destinations.
     torProxy: process.env.ARCHON_DIDCOMM_TOR_PROXY || '',
-    allowPrivateEgress: process.env.ARCHON_DIDCOMM_ALLOW_PRIVATE_EGRESS === 'true',
 };
 
 export default config;

--- a/services/didcomm/server/src/didcomm-api.ts
+++ b/services/didcomm/server/src/didcomm-api.ts
@@ -15,15 +15,8 @@ export interface AppDeps {
     resolver: Resolver;
     cipher: Cipher;
     uploadLimit?: string;
-    // Outbound egress (POST /deliver): SOCKS5 Tor proxy for .onion destinations,
-    // and whether to permit private/loopback destinations (dev/test only).
+    // Outbound egress (POST /deliver): SOCKS5 Tor proxy for .onion destinations.
     torProxy?: string;
-    allowPrivateEgress?: boolean;
-}
-
-// SSRF guard: block loopback/private/link-local hosts for clearnet egress.
-function isPrivateHost(hostname: string): boolean {
-    return /^(localhost|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|169\.254\.|0\.0\.0\.0|\[?::1\]?$)/.test(hostname);
 }
 
 export function createApp(deps: AppDeps): Express {
@@ -187,14 +180,19 @@ export function createApp(deps: AppDeps): Express {
             }
             const onion = url.hostname.endsWith('.onion');
 
-            if (!onion && !deps.allowPrivateEgress) {
-                if (url.protocol !== 'https:') {
-                    return res.status(400).send({ error: 'clearnet endpoint must use https' });
-                }
-                if (isPrivateHost(url.hostname)) {
-                    return res.status(400).send({ error: 'private/loopback endpoint not allowed' });
-                }
-            }
+            // Egress is deliberately unrestricted: destinations are filtered by
+            // neither scheme nor address. The previous guard rejected non-https and
+            // private/loopback hosts unless ARCHON_DIDCOMM_ALLOW_PRIVATE_EGRESS was
+            // set, but it matched hostnames with a literal regex, so an attacker's
+            // `127.0.0.1.nip.io` (or a mapped IPv6 form) walked through it while
+            // honest same-host and LAN delivery was blocked. It stopped the wrong
+            // party, so it is gone rather than half-enforced -- see #645.
+            //
+            // What this means for operators: POST /deliver authenticates any
+            // resolvable DID, so anyone able to create a DID can make this relay
+            // issue a POST, with a body they control, to any host it can reach. Do
+            // not run it on a network segment carrying services you would not want
+            // reachable that way.
 
             const fetchOptions: any = {
                 method: 'POST',

--- a/services/didcomm/server/src/didcomm-api.ts
+++ b/services/didcomm/server/src/didcomm-api.ts
@@ -17,6 +17,11 @@ export interface AppDeps {
     uploadLimit?: string;
     // Outbound egress (POST /deliver): SOCKS5 Tor proxy for .onion destinations.
     torProxy?: string;
+    // Allow clearnet delivery over plain http. In-process tests only, which
+    // deliver to their own localhost relay. Deliberately has NO environment
+    // binding and is not read from config: a running node cannot turn this on,
+    // so it cannot become the deployment footgun the old opt-in flag was.
+    allowInsecureEgress?: boolean;
 }
 
 export function createApp(deps: AppDeps): Express {
@@ -180,19 +185,22 @@ export function createApp(deps: AppDeps): Express {
             }
             const onion = url.hostname.endsWith('.onion');
 
-            // Egress is deliberately unrestricted: destinations are filtered by
-            // neither scheme nor address. The previous guard rejected non-https and
-            // private/loopback hosts unless ARCHON_DIDCOMM_ALLOW_PRIVATE_EGRESS was
-            // set, but it matched hostnames with a literal regex, so an attacker's
-            // `127.0.0.1.nip.io` (or a mapped IPv6 form) walked through it while
-            // honest same-host and LAN delivery was blocked. It stopped the wrong
-            // party, so it is gone rather than half-enforced -- see #645.
+            // Clearnet egress is https-only. Destinations are NOT filtered by
+            // address: the old private/loopback check matched hostnames with a
+            // literal regex, so `127.0.0.1.nip.io` and mapped IPv6 forms walked
+            // through it while honest same-host and LAN delivery did not. It
+            // stopped the wrong party and was removed (#645).
             //
-            // What this means for operators: POST /deliver authenticates any
-            // resolvable DID, so anyone able to create a DID can make this relay
-            // issue a POST, with a body they control, to any host it can reach. Do
-            // not run it on a network segment carrying services you would not want
-            // reachable that way.
+            // The scheme check stays because it is the half that holds. A DNS name
+            // cannot forge it, and it is what keeps plaintext internal services out
+            // of reach: the usual SSRF target is `http://redis:6379` with inline
+            // commands in the body, and an https fetch to redis dies in the TLS
+            // handshake. POST /deliver authenticates any *resolvable* DID rather
+            // than a local identity, so without this anyone able to create a DID
+            // could aim the relay at anything on its network segment.
+            if (!onion && url.protocol !== 'https:' && !deps.allowInsecureEgress) {
+                return res.status(400).send({ error: 'clearnet endpoint must use https' });
+            }
 
             const fetchOptions: any = {
                 method: 'POST',

--- a/services/didcomm/server/src/didcomm-api.ts
+++ b/services/didcomm/server/src/didcomm-api.ts
@@ -191,13 +191,12 @@ export function createApp(deps: AppDeps): Express {
             // through it while honest same-host and LAN delivery did not. It
             // stopped the wrong party and was removed (#645).
             //
-            // The scheme check stays because it is the half that holds. A DNS name
-            // cannot forge it, and it is what keeps plaintext internal services out
-            // of reach: the usual SSRF target is `http://redis:6379` with inline
-            // commands in the body, and an https fetch to redis dies in the TLS
-            // handshake. POST /deliver authenticates any *resolvable* DID rather
-            // than a local identity, so without this anyone able to create a DID
-            // could aim the relay at anything on its network segment.
+            // The scheme check keeps plaintext internal services out of reach --
+            // the usual SSRF target is `http://redis:6379` with inline commands in
+            // the body, and an https fetch to redis dies in the TLS handshake.
+            // POST /deliver authenticates any *resolvable* DID rather than a local
+            // identity, so without this anyone able to create a DID could aim the
+            // relay at anything on its network segment.
             if (!onion && url.protocol !== 'https:' && !deps.allowInsecureEgress) {
                 return res.status(400).send({ error: 'clearnet endpoint must use https' });
             }
@@ -206,6 +205,13 @@ export function createApp(deps: AppDeps): Express {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/didcomm-encrypted+json' },
                 body: message,
+                // Checking the scheme is worthless if a redirect can undo it: fetch
+                // follows by default, and 307/308 preserve method and body, so an
+                // https endpoint answering 307 -> http://redis:6379 delivers the
+                // caller's bytes to the plaintext service the check exists to keep
+                // out. A DIDComm mailbox has no reason to redirect, so refuse
+                // rather than revalidate each hop.
+                redirect: 'manual',
             };
             if (onion) {
                 if (!deps.torProxy) {
@@ -217,6 +223,13 @@ export function createApp(deps: AppDeps): Express {
 
             const target = `${endpoint.replace(/\/+$/, '')}/api/v1/messages`;
             const response = await fetch(target, fetchOptions);
+            if (response.status >= 300 && response.status < 400) {
+                // Say what happened: a bare "failed: 307" reads like the recipient
+                // is broken rather than like a rule we enforce.
+                return res.status(502).send({
+                    error: `delivery to ${url.host} failed: endpoint redirected (${response.status}); redirects are not followed`,
+                });
+            }
             if (!response.ok) {
                 return res.status(502).send({ error: `delivery to ${url.host} failed: ${response.status}` });
             }

--- a/services/didcomm/server/src/index.ts
+++ b/services/didcomm/server/src/index.ts
@@ -29,7 +29,6 @@ async function main() {
         cipher,
         uploadLimit: config.uploadLimit,
         torProxy: config.torProxy,
-        allowPrivateEgress: config.allowPrivateEgress,
     });
 
     app.listen(config.didcommPort, config.bindAddress, () => {

--- a/services/mediators/lightning/src/lightning-mediator.ts
+++ b/services/mediators/lightning/src/lightning-mediator.ts
@@ -93,9 +93,40 @@ function normalizePath(path: string): string {
 // No address filter on outbound fetches. The one that used to live here matched
 // hostnames with a literal regex, so `127.0.0.1.nip.io` -- or any name an
 // attacker controls that points inward -- passed it while honest LAN use did
-// not. What remains, at each call site, is the scheme requirement: no DNS name
-// can forge that, and it is what keeps plaintext internal services out of reach.
-// Matches the DIDComm relay; see #645.
+// not. What remains, at each call site, is the scheme requirement, which keeps
+// plaintext internal services out of reach. Matches the DIDComm relay; see #645.
+
+// Checking the scheme is worthless if a redirect can undo it: fetch follows
+// redirects by default, and 307/308 preserve method and body, so an https
+// endpoint answering `307 -> http://redis:6379` reaches the plaintext service
+// the check exists to keep out. LNURL services do redirect in the wild, so
+// rather than refuse outright (as the DIDComm relay does, where nothing
+// legitimately redirects) follow each hop by hand and re-apply the rule.
+const MAX_LNURL_REDIRECTS = 5;
+
+async function fetchHttpsOnly(target: string, init?: RequestInit): Promise<Response> {
+    let current = target;
+
+    for (let hop = 0; hop <= MAX_LNURL_REDIRECTS; hop++) {
+        if (new URL(current).protocol !== 'https:') {
+            throw new Error(`refusing non-https hop to ${new URL(current).host}`);
+        }
+
+        const response = await fetch(current, { ...init, redirect: 'manual' });
+        if (response.status < 300 || response.status >= 400) {
+            return response;
+        }
+
+        const location = response.headers.get('location');
+        if (!location) {
+            throw new Error(`redirect with no location from ${new URL(current).host}`);
+        }
+        // Relative locations resolve against the hop we are on.
+        current = new URL(location, current).toString();
+    }
+
+    throw new Error(`too many redirects (${MAX_LNURL_REDIRECTS})`);
+}
 
 function parsePositiveInteger(value: unknown): number | null {
     const parsed = typeof value === 'number' ? value : parseInt(String(value), 10);
@@ -410,11 +441,18 @@ async function main(): Promise<void> {
                 }
 
                 const [name, domain] = parts;
-                // https by construction, so an internal plaintext service cannot be
-                // reached through this even though the address is not filtered.
+                // https by construction -- and fetchHttpsOnly keeps it that way
+                // across redirects, which plain fetch would follow down to http.
                 const lnurlUrl = new URL(`https://${domain}/.well-known/lnurlp/${encodeURIComponent(name)}`);
 
-                const lnurlResponse = await fetch(lnurlUrl.toString());
+                let lnurlResponse: Response;
+                try {
+                    lnurlResponse = await fetchHttpsOnly(lnurlUrl.toString());
+                }
+                catch (error: any) {
+                    res.status(502).json({ error: `Lightning Address lookup failed: ${error.message}` });
+                    return;
+                }
                 if (!lnurlResponse.ok) {
                     res.status(502).json({ error: `Lightning Address lookup failed: ${lnurlResponse.statusText}` });
                     return;
@@ -456,7 +494,14 @@ async function main(): Promise<void> {
                     invoiceUrl += `&comment=${encodeURIComponent(memo)}`;
                 }
 
-                const invoiceResponse = await fetch(invoiceUrl);
+                let invoiceResponse: Response;
+                try {
+                    invoiceResponse = await fetchHttpsOnly(invoiceUrl);
+                }
+                catch (error: any) {
+                    res.status(502).json({ error: `Invoice request failed: ${error.message}` });
+                    return;
+                }
                 if (!invoiceResponse.ok) {
                     const error = await invoiceResponse.json().catch(() => ({ error: invoiceResponse.statusText }));
                     res.status(502).json({ error: `Invoice request failed: ${error.error || invoiceResponse.statusText}` });
@@ -518,7 +563,13 @@ async function main(): Promise<void> {
                     }
                 }
 
-                const fetchOptions: any = {};
+                // Refuse redirects rather than re-check each hop: this endpoint may
+                // legitimately be onion-http or the internal loopback shortcut, so
+                // there is no single scheme rule to re-apply -- and an invoice
+                // endpoint is a machine API returning JSON, with no reason to
+                // redirect. Left as-is, a published https endpoint answering
+                // `307 -> http://redis:6379` would reach it with our request.
+                const fetchOptions: any = { redirect: 'manual' };
                 if (useTorProxy && config.torProxy) {
                     const [host, port] = config.torProxy.split(':');
                     fetchOptions.dispatcher = socksDispatcher({
@@ -529,6 +580,12 @@ async function main(): Promise<void> {
                 }
 
                 const invoiceResponse = await fetch(invoiceUrl.toString(), fetchOptions);
+                if (invoiceResponse.status >= 300 && invoiceResponse.status < 400) {
+                    res.status(502).json({
+                        error: `Invoice request failed: endpoint redirected (${invoiceResponse.status}); redirects are not followed`,
+                    });
+                    return;
+                }
                 if (!invoiceResponse.ok) {
                     const error = await invoiceResponse.json().catch(() => ({ error: invoiceResponse.statusText }));
                     res.status(502).json({ error: `Invoice request failed: ${error.error || invoiceResponse.statusText}` });

--- a/services/mediators/lightning/src/lightning-mediator.ts
+++ b/services/mediators/lightning/src/lightning-mediator.ts
@@ -90,9 +90,12 @@ function normalizePath(path: string): string {
         .replace(/\/invoice\/(?:did:[^/]+|did%3[aA][^/]+)/g, '/invoice/:did');
 }
 
-function isPrivateHost(hostname: string): boolean {
-    return /^(localhost|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/.test(hostname);
-}
+// No address filter on outbound fetches. The one that used to live here matched
+// hostnames with a literal regex, so `127.0.0.1.nip.io` -- or any name an
+// attacker controls that points inward -- passed it while honest LAN use did
+// not. What remains, at each call site, is the scheme requirement: no DNS name
+// can forge that, and it is what keeps plaintext internal services out of reach.
+// Matches the DIDComm relay; see #645.
 
 function parsePositiveInteger(value: unknown): number | null {
     const parsed = typeof value === 'number' ? value : parseInt(String(value), 10);
@@ -407,11 +410,9 @@ async function main(): Promise<void> {
                 }
 
                 const [name, domain] = parts;
+                // https by construction, so an internal plaintext service cannot be
+                // reached through this even though the address is not filtered.
                 const lnurlUrl = new URL(`https://${domain}/.well-known/lnurlp/${encodeURIComponent(name)}`);
-                if (isPrivateHost(lnurlUrl.hostname)) {
-                    res.status(400).json({ error: 'Invalid Lightning Address: private addresses not allowed' });
-                    return;
-                }
 
                 const lnurlResponse = await fetch(lnurlUrl.toString());
                 if (!lnurlResponse.ok) {
@@ -431,9 +432,12 @@ async function main(): Promise<void> {
                     return;
                 }
 
+                // The callback comes from the remote LNURL response, so it is
+                // attacker-influenced: hold the scheme line even though the
+                // address is not filtered.
                 const callbackUrl = new URL(callback);
-                if (callbackUrl.protocol !== 'https:' || isPrivateHost(callbackUrl.hostname)) {
-                    res.status(400).json({ error: 'Invalid callback URL' });
+                if (callbackUrl.protocol !== 'https:') {
+                    res.status(400).json({ error: 'Invalid callback URL: must use https' });
                     return;
                 }
 
@@ -492,10 +496,6 @@ async function main(): Promise<void> {
                 }
                 if (!isOnion && url.protocol !== 'https:') {
                     res.status(400).json({ error: 'Invalid service endpoint: must use https' });
-                    return;
-                }
-                if (!isOnion && isPrivateHost(url.hostname)) {
-                    res.status(400).json({ error: 'Invalid service endpoint: private addresses not allowed' });
                     return;
                 }
 

--- a/tests/didcomm/config.test.ts
+++ b/tests/didcomm/config.test.ts
@@ -14,18 +14,19 @@ describe('didcomm service config', () => {
             maxChallenges: expect.any(Number),
             redisURL: expect.any(String),
             torProxy: expect.any(String),
-            allowPrivateEgress: expect.any(Boolean),
         });
     });
 
-    it('defaults egress to Tor-less and private destinations disallowed', () => {
-        // These two gate outbound delivery, so their defaults are the safe ones:
-        // no proxy configured, and private/loopback destinations refused unless
-        // explicitly opted into for dev.
+    it('defaults egress to Tor-less', () => {
+        // Onion delivery needs a proxy and there is no sensible default host, so
+        // an unset value means "no onion egress" rather than a guessed one.
         expect(config.torProxy).toBe(process.env.ARCHON_DIDCOMM_TOR_PROXY || '');
-        expect(config.allowPrivateEgress).toBe(
-            process.env.ARCHON_DIDCOMM_ALLOW_PRIVATE_EGRESS === 'true',
-        );
+    });
+
+    it('carries no private-egress switch', () => {
+        // Removed with the guard it gated (#645): destinations are no longer
+        // filtered, so there is nothing left to opt into.
+        expect(config).not.toHaveProperty('allowPrivateEgress');
     });
 
     it('defaults the message TTL to seven days', () => {

--- a/tests/didcomm/e2e.test.ts
+++ b/tests/didcomm/e2e.test.ts
@@ -59,10 +59,16 @@ beforeEach(async () => {
     cipher = new CipherNode();
 
     // The relay both stores mail and (Phase 8) performs outbound delivery; these
-    // tests deliver to the same localhost relay, which needed an explicit
-    // allowPrivateEgress opt-in until the egress guard was removed (#645).
+    // tests deliver to their own localhost relay over plain http, which clearnet
+    // egress otherwise refuses. allowInsecureEgress has no environment binding,
+    // so it is reachable from an in-process test and from nowhere else (#645).
     const app = express();
-    app.use('/didcomm', createApp({ store: new MemoryMailboxStore(), resolver: gatekeeper, cipher }));
+    app.use('/didcomm', createApp({
+        store: new MemoryMailboxStore(),
+        resolver: gatekeeper,
+        cipher,
+        allowInsecureEgress: true,
+    }));
     await new Promise<void>(resolve => { server = app.listen(0, resolve); });
     const port = (server.address() as any).port;
     const nodeURL = `http://localhost:${port}`;

--- a/tests/didcomm/e2e.test.ts
+++ b/tests/didcomm/e2e.test.ts
@@ -58,10 +58,11 @@ beforeEach(async () => {
     gatekeeper = new Gatekeeper({ db, ipfs, registries: ['local', 'hyperswarm'] });
     cipher = new CipherNode();
 
-    // allowPrivateEgress: the relay both stores mail and (Phase 8) performs
-    // outbound delivery; tests deliver to the same localhost relay.
+    // The relay both stores mail and (Phase 8) performs outbound delivery; these
+    // tests deliver to the same localhost relay, which needed an explicit
+    // allowPrivateEgress opt-in until the egress guard was removed (#645).
     const app = express();
-    app.use('/didcomm', createApp({ store: new MemoryMailboxStore(), resolver: gatekeeper, cipher, allowPrivateEgress: true }));
+    app.use('/didcomm', createApp({ store: new MemoryMailboxStore(), resolver: gatekeeper, cipher }));
     await new Promise<void>(resolve => { server = app.listen(0, resolve); });
     const port = (server.address() as any).port;
     const nodeURL = `http://localhost:${port}`;

--- a/tests/didcomm/mailbox.test.ts
+++ b/tests/didcomm/mailbox.test.ts
@@ -199,6 +199,59 @@ describe('deposit route capacity', () => {
         expect(second.body.error).toMatch(/challenges/);
     });
 
+    // Egress checks sit behind challenge auth, so these need a relay that accepts
+    // the signature -- otherwise every request 401s before reaching them.
+    function appWithEgress(options: { allowInsecureEgress?: boolean } = {}) {
+        const store = new MemoryMailboxStore(1000, 1000, () => 1_000_000);
+        const resolver = {
+            resolveDID: async () => ({
+                didDocument: { verificationMethod: [{ publicKeyJwk: { kty: 'EC' } }] },
+            }),
+        };
+        const cipher = { hashMessage: () => 'hash', verifySig: () => true };
+        const app = express();
+        app.use('/didcomm', createApp({ store, resolver: resolver as any, cipher: cipher as any, ...options }));
+        return { app, store };
+    }
+
+    async function deliver(app: any, endpoint: string) {
+        const { body } = await request(app).get('/didcomm/api/v1/challenge');
+        return request(app)
+            .post('/didcomm/api/v1/deliver')
+            .send({ did: 'did:test:alice', challenge: body.challenge, signature: 's', endpoint, message: 'x' });
+    }
+
+    // The scheme check is the half of the old egress guard that held: a DNS name
+    // cannot forge it, and it keeps plaintext internal services (the usual SSRF
+    // target being http://redis:6379 with inline commands in the body) out of
+    // reach. The address half was removed in #645 -- it matched hostnames with a
+    // literal regex, so 127.0.0.1.nip.io passed while honest LAN delivery did not.
+    it('refuses clearnet delivery over plain http', async () => {
+        const { app } = appWithEgress();
+        const response = await deliver(app, 'http://redis:6379');
+
+        expect(response.status).toBe(400);
+        expect(response.body.error).toMatch(/https/);
+    });
+
+    it('does not filter clearnet delivery by address', async () => {
+        // A private https destination gets past the guard and fails at the fetch
+        // instead -- 502, not the 400 an address filter would return.
+        const { app } = appWithEgress();
+        const response = await deliver(app, 'https://192.168.0.255:9');
+
+        expect(response.status).toBe(502);
+    });
+
+    it('allows plain http only when the host app opts in', async () => {
+        // allowInsecureEgress exists for in-process tests and has no environment
+        // binding, so a deployed relay cannot reach this branch.
+        const { app } = appWithEgress({ allowInsecureEgress: true });
+        const response = await deliver(app, 'http://127.0.0.1:9');
+
+        expect(response.status).toBe(502);
+    });
+
     // A 429 says the envelope was not stored. If an earlier recipient's copy
     // were left behind, a retry would deliver to them twice.
     it('rolls back earlier recipients when a later one is full', async () => {

--- a/tests/didcomm/mailbox.test.ts
+++ b/tests/didcomm/mailbox.test.ts
@@ -235,21 +235,73 @@ describe('deposit route capacity', () => {
     });
 
     it('does not filter clearnet delivery by address', async () => {
-        // A private https destination gets past the guard and fails at the fetch
-        // instead -- 502, not the 400 an address filter would return.
-        const { app } = appWithEgress();
-        const response = await deliver(app, 'https://192.168.0.255:9');
+        // A private https destination gets past the guard and is actually
+        // attempted -- what an address filter would have refused outright.
+        // fetch is mocked: a real connection to a LAN address would hang or, on
+        // the wrong subnet, reach someone.
+        const attempted: string[] = [];
+        const realFetch = globalThis.fetch;
+        globalThis.fetch = (async (input: any) => {
+            attempted.push(String(input));
+            return new Response(JSON.stringify({ ids: ['x'] }), { status: 200 });
+        }) as any;
 
-        expect(response.status).toBe(502);
+        try {
+            const { app } = appWithEgress();
+            const response = await deliver(app, 'https://192.168.0.255');
+
+            expect(response.status).toBe(200);
+            expect(attempted).toEqual(['https://192.168.0.255/api/v1/messages']);
+        }
+        finally {
+            globalThis.fetch = realFetch;
+        }
+    });
+
+    it('does not follow a redirect off the https endpoint', async () => {
+        // The scheme check is worthless if a redirect can undo it: 307/308
+        // preserve method and body, so an https endpoint answering
+        // `307 -> http://redis:6379` would deliver the caller's bytes there.
+        const realFetch = globalThis.fetch;
+        let passedRedirect: string | undefined;
+        globalThis.fetch = (async (_input: any, init: any) => {
+            passedRedirect = init?.redirect;
+            return new Response(null, { status: 307, headers: { location: 'http://redis:6379/' } });
+        }) as any;
+
+        try {
+            const { app } = appWithEgress();
+            const response = await deliver(app, 'https://relay.example');
+
+            expect(passedRedirect).toBe('manual');
+            expect(response.status).toBe(502);
+            expect(response.body.error).toMatch(/redirect/);
+        }
+        finally {
+            globalThis.fetch = realFetch;
+        }
     });
 
     it('allows plain http only when the host app opts in', async () => {
         // allowInsecureEgress exists for in-process tests and has no environment
         // binding, so a deployed relay cannot reach this branch.
-        const { app } = appWithEgress({ allowInsecureEgress: true });
-        const response = await deliver(app, 'http://127.0.0.1:9');
+        const attempted: string[] = [];
+        const realFetch = globalThis.fetch;
+        globalThis.fetch = (async (input: any) => {
+            attempted.push(String(input));
+            return new Response(JSON.stringify({ ids: ['x'] }), { status: 200 });
+        }) as any;
 
-        expect(response.status).toBe(502);
+        try {
+            const { app } = appWithEgress({ allowInsecureEgress: true });
+            const response = await deliver(app, 'http://127.0.0.1:4236');
+
+            expect(response.status).toBe(200);
+            expect(attempted).toEqual(['http://127.0.0.1:4236/api/v1/messages']);
+        }
+        finally {
+            globalThis.fetch = realFetch;
+        }
     });
 
     // A 429 says the envelope was not stored. If an earlier recipient's copy


### PR DESCRIPTION
## The guard had two checks, and they were not equally useful

Clearnet destinations had to be `https:`, **and** had to not look private — both gated behind `ARCHON_DIDCOMM_ALLOW_PRIVATE_EGRESS`. Treating them as one thing is what made the original framing wrong; they get different verdicts.

### The address filter is removed

```js
/^(localhost|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|169\.254\.|0\.0\.0\.0|\[?::1\]?$)/
```

A literal hostname match. `127.0.0.1.nip.io` resolves to loopback and passes it, as does any attacker-controlled DNS name pointing inward, or a mapped IPv6 form. It restricted only callers who were not trying to evade it, while blocking honest same-host and LAN delivery — which is how it surfaced, breaking self-delivery during #901 testing.

Removing it changes nothing about what an attacker can reach. Hardening it properly means resolving the hostname and validating every resolved address against rebinding, which is real work for a restriction this service's threat model does not clearly want.

### The scheme check stays — and now actually holds

It is the part that keeps plaintext internal services out of reach: the usual SSRF shape is `http://redis:6379` with inline commands in the body, and an https fetch to redis dies in the TLS handshake. Dropping it would have been a genuine widening rather than the no-op the address filter's removal is.

An earlier revision of this PR removed both. That was wrong and is corrected in the second commit.

**A third commit closes the hole review found in the check itself.** `fetch` follows redirects by default and 307/308 preserve method and body, so an https endpoint answering `307 -> http://redis:6379` reached the plaintext service anyway. Verified rather than reasoned about — a real https origin redirecting to a plain-http server:

```
status: 200
plaintext target reached: {"method":"POST","body":"ATTACKER-BYTES"}
```

Two shapes of fix, because the paths differ:

| Path | Treatment | Why |
| --- | --- | --- |
| Relay `/deliver` | `redirect: 'manual'`, 3xx → 502 | A mailbox has no reason to redirect |
| Mediator DID-branch invoice fetch | `redirect: 'manual'`, 3xx → 502 | May legitimately be onion-`http:` or the internal loopback shortcut, so there is no single per-hop scheme rule to apply |
| Mediator LNURL lookup + callback | `fetchHttpsOnly` — follows up to 5 hops by hand, https required at each | LNURL services do redirect in the wild; refusing outright would break real payees |

## The env flag is gone (#902)

`sample.env` and the design doc documented `ARCHON_DIDCOMM_ALLOW_PRIVATE_EGRESS` as an operator knob, and `config.js` read it, but `docker/compose/didcomm.yml` never passed it through — so in Docker it was permanently false. With the address filter gone there is nothing left for it to disable, so it is deleted rather than wired up.

Plain http egress is now reachable only through an `allowInsecureEgress` dep on `createApp`, which the in-process e2e uses to deliver to its own localhost relay. It has **no environment binding and is not read from config**, so unlike the flag it replaces, a deployed relay cannot turn it on.

## Residual exposure, documented

`POST /deliver` authenticates any *resolvable* DID, not only a local identity. So anyone able to create a DID can make the relay POST a body of their choosing to any **https** host it can reach, private ones included. That was equally true before — the address filter did not prevent it — but nothing said so. Now stated in the service spec, `sample.env`, and the design doc.

## Also here

`docs/services/didcomm/README.md` never documented the outbound `/deliver` route; the spec predates Phase 8. Added as §2.7, since this change defines its security posture.

## lightning-mediator gets the same treatment

`services/mediators/lightning/src/lightning-mediator.ts` carried an identical `isPrivateHost` regex at three outbound call sites, with the identical weakness. The address filter is gone from all three; every scheme requirement stays.

| Call site | Before | After |
| --- | --- | --- |
| LNURL resolution | address filter only | nothing — the URL is `https://${domain}/…` by construction, so an internal plaintext service was never reachable and the filter added nothing |
| LNURL callback | https **and** address | https only. The error now names the rule it broke, which the combined condition could not |
| Published service endpoint | https, `.onion`-must-be-http, and address | https and `.onion`-must-be-http |

No behaviour change for any honest caller already on https.

**Docs corrected:** the mediator's own README specified private-address rejection in three places (§4.1 steps 2 and 4, §4.2 step 3, plus the alternative-implementation checklist). Review caught that too; they now describe the scheme rules and the redirect handling instead.

**Not touched:** `packages/keymaster/src/keymaster.ts:136` has a third copy of the same regex, guarding Herald remote *name* lookup (`.well-known/names/`). That is neither DIDComm nor Lightning egress, so it is outside #645 — but it has the same weakness and the same https-by-construction property, and is worth a follow-up.

## Testing

Three new cases in `tests/didcomm/mailbox.test.ts`, driven through a relay that accepts the challenge — the first draft asserted against a 401 and never reached the guard at all:

- `http://redis:6379` → 400, scheme rejected
- `https://192.168.0.255` → attempted, asserting the private address gets past the guard rather than being refused
- `307 -> http://redis:6379` → 502, and `redirect: 'manual'` is asserted to reach fetch
- `http://127.0.0.1:4236` with `allowInsecureEgress` → attempted, the opt-in reaching the same place

The address and opt-in cases mock `globalThis.fetch` and assert the attempted URL. An earlier draft relied on a real connection to `192.168.0.255:9` failing, which review flagged: fast here, but on a runner where that subnet routes it hangs or reaches a real host.

`tests/didcomm` unit: 44 pass. `test:didcomm-e2e`: 9/9. `tsc` and `npm run lint` clean.

**The lightning-mediator changes have no test coverage, before or after.** The service builds its express app inline and exports no factory, so there is no harness to drive those routes, and nothing in `tests/` touched the guards I removed — the existing lightning tests cover Drawbridge's *client* of the mediator, not the mediator. Verified by reading the three call sites and by typecheck and lint. Adding a harness is a refactor beyond this change; worth doing separately.

Fixes #902
Fixes #645

