### PR TITLE
feat(wallet): Add out-of-band invitations to the wallets

### DIFF
--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -95,6 +95,11 @@ import { Buffer } from 'buffer';
 import { QRCodeSVG } from 'qrcode.react';
 import './App.css';
 import PollResultsModal from "./PollResultsModal";
+import {
+    decodeOutOfBandInvitation,
+    encodeOutOfBandInvitation,
+    outOfBandInvitation,
+} from './oobCodec.mjs';
 import TextInputModal from "./TextInputModal";
 import WarningModal from "./WarningModal";
 import packageJson from "../package.json";
@@ -409,7 +414,6 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const BASIC_MESSAGE_TYPE = 'https://didcomm.org/basicmessage/2.0/message';
     const TRUST_PING_TYPE = 'https://didcomm.org/trust-ping/2.0/ping';
     const TRUST_PING_RESPONSE_TYPE = 'https://didcomm.org/trust-ping/2.0/ping-response';
-    const OUT_OF_BAND_INVITATION_TYPE = 'https://didcomm.org/out-of-band/2.0/invitation';
 
     const [didcommTab, setDidcommTab] = useState('inbox');
     const [didcommComposeTo, setDidcommComposeTo] = useState('');
@@ -465,6 +469,16 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
         // eslint-disable-next-line
     }, [tab]);
+
+    useEffect(() => {
+        // An invitation names the identity that made it, so it must not survive a
+        // switch: leaving it on screen would offer a QR and a copyable link for
+        // the previous identity under the new one's name.
+        setDidcommInviteUrl('');
+        setDidcommInviteInput('');
+        setDidcommDecodedInvite(null);
+        // eslint-disable-next-line
+    }, [currentDID]);
 
     useEffect(() => {
         didcommActiveIdRef.current = currentId;
@@ -610,25 +624,6 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
     }
 
-    // Out-of-band invitation encoding, inlined for the same reason as the protocol
-    // URIs above: the server-wallet demo depends only on the thin client package.
-    // Mirrors encodeOutOfBandInvitation/decodeOutOfBandInvitation.
-    function encodeInvitation(invitation) {
-        const json = JSON.stringify(invitation);
-        const b64 = btoa(unescape(encodeURIComponent(json)))
-            .replace(/\+/g, '-')
-            .replace(/\//g, '_')
-            .replace(/=+$/, '');
-        return `https://didcomm.org?_oob=${b64}`;
-    }
-
-    function decodeInvitation(urlOrOob) {
-        const match = urlOrOob.match(/[?&]_oob=([^&]+)/);
-        const oob = match ? decodeURIComponent(match[1]) : urlOrOob;
-        const json = decodeURIComponent(escape(atob(oob.replace(/-/g, '+').replace(/_/g, '/'))));
-        return JSON.parse(json);
-    }
-
     function createDidCommInvitation() {
         if (!currentDID) {
             showError('Select an identity first');
@@ -637,15 +632,15 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
 
         // The invitation names the inviter; everything a recipient needs to reach
         // them is resolvable from that DID, so the URL carries no endpoint.
-        setDidcommInviteUrl(encodeInvitation({
-            type: OUT_OF_BAND_INVITATION_TYPE,
-            from: currentDID,
-            body: { accept: ['didcomm/v2'] },
-        }));
+        setDidcommInviteUrl(encodeOutOfBandInvitation(outOfBandInvitation(currentDID)));
     }
 
     function acceptDidCommInvitation() {
         const trimmed = didcommInviteInput.trim();
+
+        // Drop the previous result first: a failed decode must not leave the last
+        // inviter on screen with a live "Message Them" button.
+        setDidcommDecodedInvite(null);
 
         if (!trimmed) {
             showError('Paste an invitation URL first');
@@ -653,14 +648,22 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
 
         try {
-            const invitation = decodeInvitation(trimmed);
+            const invitation = decodeOutOfBandInvitation(trimmed);
 
-            if (!invitation?.from) {
+            // The payload is whatever the sender chose to encode, so nothing here
+            // is known to be a string. An object `from` would throw when React
+            // renders it, and would reach the compose field as a non-string.
+            const from = invitation?.from;
+            if (typeof from !== 'string' || !from.trim()) {
                 showError('That invitation names no inviter');
                 return;
             }
 
-            setDidcommDecodedInvite({ from: invitation.from, goal: invitation.body?.goal });
+            const goal = invitation?.body?.goal;
+            setDidcommDecodedInvite({
+                from: from.trim(),
+                goal: typeof goal === 'string' ? goal : undefined,
+            });
         } catch {
             showError('Could not read that invitation');
         }
@@ -8141,8 +8144,14 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                             <Button
                                                 size="small"
                                                 onClick={async () => {
-                                                    await navigator.clipboard.writeText(didcommInviteUrl);
-                                                    showSuccess('Invitation copied');
+                                                    try {
+                                                        await navigator.clipboard.writeText(didcommInviteUrl);
+                                                        showSuccess('Invitation copied');
+                                                    } catch {
+                                                        // Unavailable outside a secure context, and refusable;
+                                                        // the link is on screen to copy by hand either way.
+                                                        showError('Could not copy — select the link and copy it manually');
+                                                    }
                                                 }}
                                             >
                                                 Copy Link

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -409,12 +409,16 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const BASIC_MESSAGE_TYPE = 'https://didcomm.org/basicmessage/2.0/message';
     const TRUST_PING_TYPE = 'https://didcomm.org/trust-ping/2.0/ping';
     const TRUST_PING_RESPONSE_TYPE = 'https://didcomm.org/trust-ping/2.0/ping-response';
+    const OUT_OF_BAND_INVITATION_TYPE = 'https://didcomm.org/out-of-band/2.0/invitation';
 
     const [didcommTab, setDidcommTab] = useState('inbox');
     const [didcommComposeTo, setDidcommComposeTo] = useState('');
     const [didcommComposeKind, setDidcommComposeKind] = useState('message');
     const [didcommComposeContent, setDidcommComposeContent] = useState('');
     const [didcommComposeAnoncrypt, setDidcommComposeAnoncrypt] = useState(false);
+    const [didcommInviteUrl, setDidcommInviteUrl] = useState('');
+    const [didcommInviteInput, setDidcommInviteInput] = useState('');
+    const [didcommDecodedInvite, setDidcommDecodedInvite] = useState(null);
     const [didcommMessages, setDidcommMessages] = useState([]);
     const [didcommInboxLoading, setDidcommInboxLoading] = useState(false);
     // A ref, not the loading flag: the poll's interval callback closes over the
@@ -603,6 +607,62 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             showError(error);
         } finally {
             setDidcommBusy(false);
+        }
+    }
+
+    // Out-of-band invitation encoding, inlined for the same reason as the protocol
+    // URIs above: the server-wallet demo depends only on the thin client package.
+    // Mirrors encodeOutOfBandInvitation/decodeOutOfBandInvitation.
+    function encodeInvitation(invitation) {
+        const json = JSON.stringify(invitation);
+        const b64 = btoa(unescape(encodeURIComponent(json)))
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=+$/, '');
+        return `https://didcomm.org?_oob=${b64}`;
+    }
+
+    function decodeInvitation(urlOrOob) {
+        const match = urlOrOob.match(/[?&]_oob=([^&]+)/);
+        const oob = match ? decodeURIComponent(match[1]) : urlOrOob;
+        const json = decodeURIComponent(escape(atob(oob.replace(/-/g, '+').replace(/_/g, '/'))));
+        return JSON.parse(json);
+    }
+
+    function createDidCommInvitation() {
+        if (!currentDID) {
+            showError('Select an identity first');
+            return;
+        }
+
+        // The invitation names the inviter; everything a recipient needs to reach
+        // them is resolvable from that DID, so the URL carries no endpoint.
+        setDidcommInviteUrl(encodeInvitation({
+            type: OUT_OF_BAND_INVITATION_TYPE,
+            from: currentDID,
+            body: { accept: ['didcomm/v2'] },
+        }));
+    }
+
+    function acceptDidCommInvitation() {
+        const trimmed = didcommInviteInput.trim();
+
+        if (!trimmed) {
+            showError('Paste an invitation URL first');
+            return;
+        }
+
+        try {
+            const invitation = decodeInvitation(trimmed);
+
+            if (!invitation?.from) {
+                showError('That invitation names no inviter');
+                return;
+            }
+
+            setDidcommDecodedInvite({ from: invitation.from, goal: invitation.body?.goal });
+        } catch {
+            showError('Could not read that invitation');
         }
     }
 
@@ -7877,6 +7937,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                             >
                                 <Tab label="Inbox" value="inbox" />
                                 <Tab label="Compose" value="compose" />
+                                <Tab label="Invite" value="invite" />
                                 <Tab label="Endpoint" value="endpoint" />
                             </Tabs>
 
@@ -8046,6 +8107,93 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                     >
                                         Send
                                     </Button>
+                                </Box>
+                            }
+
+                            {didcommTab === 'invite' &&
+                                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                                    <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                        Share an out-of-band invitation so another agent can reach this identity without being handed a DID.
+                                    </Typography>
+
+                                    <Box sx={{ display: 'flex', gap: 1 }}>
+                                        <Button
+                                            variant="contained"
+                                            color="primary"
+                                            onClick={createDidCommInvitation}
+                                            disabled={didcommBusy}
+                                        >
+                                            {didcommInviteUrl ? 'Regenerate' : 'Create Invitation'}
+                                        </Button>
+                                    </Box>
+
+                                    {didcommInviteUrl &&
+                                        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
+                                            {/* White plate behind the code: a dark page
+                                                background breaks scanning, since readers
+                                                expect light quiet zones. */}
+                                            <Box sx={{ p: 2, backgroundColor: '#fff' }}>
+                                                <QRCodeSVG value={didcommInviteUrl} size={200} />
+                                            </Box>
+                                            <Typography variant="body2" sx={{ opacity: 0.7, wordBreak: 'break-all', fontFamily: 'monospace', fontSize: '0.7rem' }}>
+                                                {didcommInviteUrl}
+                                            </Typography>
+                                            <Button
+                                                size="small"
+                                                onClick={async () => {
+                                                    await navigator.clipboard.writeText(didcommInviteUrl);
+                                                    showSuccess('Invitation copied');
+                                                }}
+                                            >
+                                                Copy Link
+                                            </Button>
+                                        </Box>
+                                    }
+
+                                    <Typography variant="subtitle2">Accept an invitation</Typography>
+                                    <TextField
+                                        label="Invitation URL"
+                                        value={didcommInviteInput}
+                                        onChange={(e) => setDidcommInviteInput(e.target.value)}
+                                        disabled={didcommBusy}
+                                        placeholder="https://didcomm.org?_oob=..."
+                                        fullWidth
+                                    />
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
+                                        onClick={acceptDidCommInvitation}
+                                        disabled={didcommBusy}
+                                        sx={{ alignSelf: 'start' }}
+                                    >
+                                        Accept
+                                    </Button>
+
+                                    {didcommDecodedInvite &&
+                                        <Box>
+                                            <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
+                                                <strong>Invitation from:</strong> {didcommDecodedInvite.from}
+                                            </Typography>
+                                            {didcommDecodedInvite.goal &&
+                                                <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                                    Purpose: {didcommDecodedInvite.goal}
+                                                </Typography>
+                                            }
+                                            {/* The inviter is only a claim -- an invitation
+                                                is unsigned and anyone can mint one naming any
+                                                DID. This starts a message, it does not assert
+                                                a relationship. */}
+                                            <Button
+                                                variant="contained"
+                                                color="primary"
+                                                onClick={() => replyToDidComm(didcommDecodedInvite.from)}
+                                                disabled={didcommBusy}
+                                                sx={{ mt: 1 }}
+                                            >
+                                                Message Them
+                                            </Button>
+                                        </Box>
+                                    }
                                 </Box>
                             }
 

--- a/apps/gatekeeper-client/src/oobCodec.mjs
+++ b/apps/gatekeeper-client/src/oobCodec.mjs
@@ -1,0 +1,48 @@
+// Out-of-band invitation encoding for the demo wallets.
+//
+// This duplicates `encodeOutOfBandInvitation` / `decodeOutOfBandInvitation` from
+// @didcid/keymaster rather than importing them: KeymasterUI.jsx is shared with
+// the server-wallet demo, which depends only on the thin client package, and
+// pulling the keymaster package in for two helpers would drag it into that
+// bundle.
+//
+// Duplication drifts, and drift here would strand invitations between wallets
+// silently -- an invitation from one would simply fail to decode in the other.
+// So this lives in its own importable module and
+// tests/wallet/oob-codec.test.ts compares it against the library implementation.
+// Keep it importable; inlining it back into KeymasterUI.jsx would put it beyond
+// the reach of that test.
+
+export const OUT_OF_BAND_INVITATION_TYPE = 'https://didcomm.org/out-of-band/2.0/invitation';
+
+// btoa is byte-oriented, so UTF-8 has to be encoded by hand before it and
+// decoded after it; the library reaches Buffer for the same job.
+function toBase64Url(json) {
+    return btoa(unescape(encodeURIComponent(json)))
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+}
+
+function fromBase64Url(b64url) {
+    return decodeURIComponent(escape(atob(b64url.replace(/-/g, '+').replace(/_/g, '/'))));
+}
+
+export function outOfBandInvitation(from, body = {}) {
+    return {
+        type: OUT_OF_BAND_INVITATION_TYPE,
+        from,
+        body: { accept: ['didcomm/v2'], ...body },
+    };
+}
+
+export function encodeOutOfBandInvitation(invitation, base = 'https://didcomm.org') {
+    const sep = base.includes('?') ? '&' : '?';
+    return `${base}${sep}_oob=${toBase64Url(JSON.stringify(invitation))}`;
+}
+
+export function decodeOutOfBandInvitation(urlOrOob) {
+    const match = urlOrOob.match(/[?&]_oob=([^&]+)/);
+    const oob = match ? decodeURIComponent(match[1]) : urlOrOob;
+    return JSON.parse(fromBase64Url(oob));
+}

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -95,6 +95,11 @@ import { Buffer } from 'buffer';
 import { QRCodeSVG } from 'qrcode.react';
 import './App.css';
 import PollResultsModal from "./PollResultsModal";
+import {
+    decodeOutOfBandInvitation,
+    encodeOutOfBandInvitation,
+    outOfBandInvitation,
+} from './oobCodec.mjs';
 import TextInputModal from "./TextInputModal";
 import WarningModal from "./WarningModal";
 import packageJson from "../package.json";
@@ -409,7 +414,6 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const BASIC_MESSAGE_TYPE = 'https://didcomm.org/basicmessage/2.0/message';
     const TRUST_PING_TYPE = 'https://didcomm.org/trust-ping/2.0/ping';
     const TRUST_PING_RESPONSE_TYPE = 'https://didcomm.org/trust-ping/2.0/ping-response';
-    const OUT_OF_BAND_INVITATION_TYPE = 'https://didcomm.org/out-of-band/2.0/invitation';
 
     const [didcommTab, setDidcommTab] = useState('inbox');
     const [didcommComposeTo, setDidcommComposeTo] = useState('');
@@ -465,6 +469,16 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
         // eslint-disable-next-line
     }, [tab]);
+
+    useEffect(() => {
+        // An invitation names the identity that made it, so it must not survive a
+        // switch: leaving it on screen would offer a QR and a copyable link for
+        // the previous identity under the new one's name.
+        setDidcommInviteUrl('');
+        setDidcommInviteInput('');
+        setDidcommDecodedInvite(null);
+        // eslint-disable-next-line
+    }, [currentDID]);
 
     useEffect(() => {
         didcommActiveIdRef.current = currentId;
@@ -610,25 +624,6 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
     }
 
-    // Out-of-band invitation encoding, inlined for the same reason as the protocol
-    // URIs above: the server-wallet demo depends only on the thin client package.
-    // Mirrors encodeOutOfBandInvitation/decodeOutOfBandInvitation.
-    function encodeInvitation(invitation) {
-        const json = JSON.stringify(invitation);
-        const b64 = btoa(unescape(encodeURIComponent(json)))
-            .replace(/\+/g, '-')
-            .replace(/\//g, '_')
-            .replace(/=+$/, '');
-        return `https://didcomm.org?_oob=${b64}`;
-    }
-
-    function decodeInvitation(urlOrOob) {
-        const match = urlOrOob.match(/[?&]_oob=([^&]+)/);
-        const oob = match ? decodeURIComponent(match[1]) : urlOrOob;
-        const json = decodeURIComponent(escape(atob(oob.replace(/-/g, '+').replace(/_/g, '/'))));
-        return JSON.parse(json);
-    }
-
     function createDidCommInvitation() {
         if (!currentDID) {
             showError('Select an identity first');
@@ -637,15 +632,15 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
 
         // The invitation names the inviter; everything a recipient needs to reach
         // them is resolvable from that DID, so the URL carries no endpoint.
-        setDidcommInviteUrl(encodeInvitation({
-            type: OUT_OF_BAND_INVITATION_TYPE,
-            from: currentDID,
-            body: { accept: ['didcomm/v2'] },
-        }));
+        setDidcommInviteUrl(encodeOutOfBandInvitation(outOfBandInvitation(currentDID)));
     }
 
     function acceptDidCommInvitation() {
         const trimmed = didcommInviteInput.trim();
+
+        // Drop the previous result first: a failed decode must not leave the last
+        // inviter on screen with a live "Message Them" button.
+        setDidcommDecodedInvite(null);
 
         if (!trimmed) {
             showError('Paste an invitation URL first');
@@ -653,14 +648,22 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
 
         try {
-            const invitation = decodeInvitation(trimmed);
+            const invitation = decodeOutOfBandInvitation(trimmed);
 
-            if (!invitation?.from) {
+            // The payload is whatever the sender chose to encode, so nothing here
+            // is known to be a string. An object `from` would throw when React
+            // renders it, and would reach the compose field as a non-string.
+            const from = invitation?.from;
+            if (typeof from !== 'string' || !from.trim()) {
                 showError('That invitation names no inviter');
                 return;
             }
 
-            setDidcommDecodedInvite({ from: invitation.from, goal: invitation.body?.goal });
+            const goal = invitation?.body?.goal;
+            setDidcommDecodedInvite({
+                from: from.trim(),
+                goal: typeof goal === 'string' ? goal : undefined,
+            });
         } catch {
             showError('Could not read that invitation');
         }
@@ -8141,8 +8144,14 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                             <Button
                                                 size="small"
                                                 onClick={async () => {
-                                                    await navigator.clipboard.writeText(didcommInviteUrl);
-                                                    showSuccess('Invitation copied');
+                                                    try {
+                                                        await navigator.clipboard.writeText(didcommInviteUrl);
+                                                        showSuccess('Invitation copied');
+                                                    } catch {
+                                                        // Unavailable outside a secure context, and refusable;
+                                                        // the link is on screen to copy by hand either way.
+                                                        showError('Could not copy — select the link and copy it manually');
+                                                    }
                                                 }}
                                             >
                                                 Copy Link

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -409,12 +409,16 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const BASIC_MESSAGE_TYPE = 'https://didcomm.org/basicmessage/2.0/message';
     const TRUST_PING_TYPE = 'https://didcomm.org/trust-ping/2.0/ping';
     const TRUST_PING_RESPONSE_TYPE = 'https://didcomm.org/trust-ping/2.0/ping-response';
+    const OUT_OF_BAND_INVITATION_TYPE = 'https://didcomm.org/out-of-band/2.0/invitation';
 
     const [didcommTab, setDidcommTab] = useState('inbox');
     const [didcommComposeTo, setDidcommComposeTo] = useState('');
     const [didcommComposeKind, setDidcommComposeKind] = useState('message');
     const [didcommComposeContent, setDidcommComposeContent] = useState('');
     const [didcommComposeAnoncrypt, setDidcommComposeAnoncrypt] = useState(false);
+    const [didcommInviteUrl, setDidcommInviteUrl] = useState('');
+    const [didcommInviteInput, setDidcommInviteInput] = useState('');
+    const [didcommDecodedInvite, setDidcommDecodedInvite] = useState(null);
     const [didcommMessages, setDidcommMessages] = useState([]);
     const [didcommInboxLoading, setDidcommInboxLoading] = useState(false);
     // A ref, not the loading flag: the poll's interval callback closes over the
@@ -603,6 +607,62 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             showError(error);
         } finally {
             setDidcommBusy(false);
+        }
+    }
+
+    // Out-of-band invitation encoding, inlined for the same reason as the protocol
+    // URIs above: the server-wallet demo depends only on the thin client package.
+    // Mirrors encodeOutOfBandInvitation/decodeOutOfBandInvitation.
+    function encodeInvitation(invitation) {
+        const json = JSON.stringify(invitation);
+        const b64 = btoa(unescape(encodeURIComponent(json)))
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=+$/, '');
+        return `https://didcomm.org?_oob=${b64}`;
+    }
+
+    function decodeInvitation(urlOrOob) {
+        const match = urlOrOob.match(/[?&]_oob=([^&]+)/);
+        const oob = match ? decodeURIComponent(match[1]) : urlOrOob;
+        const json = decodeURIComponent(escape(atob(oob.replace(/-/g, '+').replace(/_/g, '/'))));
+        return JSON.parse(json);
+    }
+
+    function createDidCommInvitation() {
+        if (!currentDID) {
+            showError('Select an identity first');
+            return;
+        }
+
+        // The invitation names the inviter; everything a recipient needs to reach
+        // them is resolvable from that DID, so the URL carries no endpoint.
+        setDidcommInviteUrl(encodeInvitation({
+            type: OUT_OF_BAND_INVITATION_TYPE,
+            from: currentDID,
+            body: { accept: ['didcomm/v2'] },
+        }));
+    }
+
+    function acceptDidCommInvitation() {
+        const trimmed = didcommInviteInput.trim();
+
+        if (!trimmed) {
+            showError('Paste an invitation URL first');
+            return;
+        }
+
+        try {
+            const invitation = decodeInvitation(trimmed);
+
+            if (!invitation?.from) {
+                showError('That invitation names no inviter');
+                return;
+            }
+
+            setDidcommDecodedInvite({ from: invitation.from, goal: invitation.body?.goal });
+        } catch {
+            showError('Could not read that invitation');
         }
     }
 
@@ -7877,6 +7937,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                             >
                                 <Tab label="Inbox" value="inbox" />
                                 <Tab label="Compose" value="compose" />
+                                <Tab label="Invite" value="invite" />
                                 <Tab label="Endpoint" value="endpoint" />
                             </Tabs>
 
@@ -8046,6 +8107,93 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                     >
                                         Send
                                     </Button>
+                                </Box>
+                            }
+
+                            {didcommTab === 'invite' &&
+                                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                                    <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                        Share an out-of-band invitation so another agent can reach this identity without being handed a DID.
+                                    </Typography>
+
+                                    <Box sx={{ display: 'flex', gap: 1 }}>
+                                        <Button
+                                            variant="contained"
+                                            color="primary"
+                                            onClick={createDidCommInvitation}
+                                            disabled={didcommBusy}
+                                        >
+                                            {didcommInviteUrl ? 'Regenerate' : 'Create Invitation'}
+                                        </Button>
+                                    </Box>
+
+                                    {didcommInviteUrl &&
+                                        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
+                                            {/* White plate behind the code: a dark page
+                                                background breaks scanning, since readers
+                                                expect light quiet zones. */}
+                                            <Box sx={{ p: 2, backgroundColor: '#fff' }}>
+                                                <QRCodeSVG value={didcommInviteUrl} size={200} />
+                                            </Box>
+                                            <Typography variant="body2" sx={{ opacity: 0.7, wordBreak: 'break-all', fontFamily: 'monospace', fontSize: '0.7rem' }}>
+                                                {didcommInviteUrl}
+                                            </Typography>
+                                            <Button
+                                                size="small"
+                                                onClick={async () => {
+                                                    await navigator.clipboard.writeText(didcommInviteUrl);
+                                                    showSuccess('Invitation copied');
+                                                }}
+                                            >
+                                                Copy Link
+                                            </Button>
+                                        </Box>
+                                    }
+
+                                    <Typography variant="subtitle2">Accept an invitation</Typography>
+                                    <TextField
+                                        label="Invitation URL"
+                                        value={didcommInviteInput}
+                                        onChange={(e) => setDidcommInviteInput(e.target.value)}
+                                        disabled={didcommBusy}
+                                        placeholder="https://didcomm.org?_oob=..."
+                                        fullWidth
+                                    />
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
+                                        onClick={acceptDidCommInvitation}
+                                        disabled={didcommBusy}
+                                        sx={{ alignSelf: 'start' }}
+                                    >
+                                        Accept
+                                    </Button>
+
+                                    {didcommDecodedInvite &&
+                                        <Box>
+                                            <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
+                                                <strong>Invitation from:</strong> {didcommDecodedInvite.from}
+                                            </Typography>
+                                            {didcommDecodedInvite.goal &&
+                                                <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                                    Purpose: {didcommDecodedInvite.goal}
+                                                </Typography>
+                                            }
+                                            {/* The inviter is only a claim -- an invitation
+                                                is unsigned and anyone can mint one naming any
+                                                DID. This starts a message, it does not assert
+                                                a relationship. */}
+                                            <Button
+                                                variant="contained"
+                                                color="primary"
+                                                onClick={() => replyToDidComm(didcommDecodedInvite.from)}
+                                                disabled={didcommBusy}
+                                                sx={{ mt: 1 }}
+                                            >
+                                                Message Them
+                                            </Button>
+                                        </Box>
+                                    }
                                 </Box>
                             }
 

--- a/apps/keymaster-client/src/oobCodec.mjs
+++ b/apps/keymaster-client/src/oobCodec.mjs
@@ -1,0 +1,48 @@
+// Out-of-band invitation encoding for the demo wallets.
+//
+// This duplicates `encodeOutOfBandInvitation` / `decodeOutOfBandInvitation` from
+// @didcid/keymaster rather than importing them: KeymasterUI.jsx is shared with
+// the server-wallet demo, which depends only on the thin client package, and
+// pulling the keymaster package in for two helpers would drag it into that
+// bundle.
+//
+// Duplication drifts, and drift here would strand invitations between wallets
+// silently -- an invitation from one would simply fail to decode in the other.
+// So this lives in its own importable module and
+// tests/wallet/oob-codec.test.ts compares it against the library implementation.
+// Keep it importable; inlining it back into KeymasterUI.jsx would put it beyond
+// the reach of that test.
+
+export const OUT_OF_BAND_INVITATION_TYPE = 'https://didcomm.org/out-of-band/2.0/invitation';
+
+// btoa is byte-oriented, so UTF-8 has to be encoded by hand before it and
+// decoded after it; the library reaches Buffer for the same job.
+function toBase64Url(json) {
+    return btoa(unescape(encodeURIComponent(json)))
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+}
+
+function fromBase64Url(b64url) {
+    return decodeURIComponent(escape(atob(b64url.replace(/-/g, '+').replace(/_/g, '/'))));
+}
+
+export function outOfBandInvitation(from, body = {}) {
+    return {
+        type: OUT_OF_BAND_INVITATION_TYPE,
+        from,
+        body: { accept: ['didcomm/v2'], ...body },
+    };
+}
+
+export function encodeOutOfBandInvitation(invitation, base = 'https://didcomm.org') {
+    const sep = base.includes('?') ? '&' : '?';
+    return `${base}${sep}_oob=${toBase64Url(JSON.stringify(invitation))}`;
+}
+
+export function decodeOutOfBandInvitation(urlOrOob) {
+    const match = urlOrOob.match(/[?&]_oob=([^&]+)/);
+    const oob = match ? decodeURIComponent(match[1]) : urlOrOob;
+    return JSON.parse(fromBase64Url(oob));
+}

--- a/apps/react-wallet/src/components/DidCommTab.tsx
+++ b/apps/react-wallet/src/components/DidCommTab.tsx
@@ -13,7 +13,7 @@ import type { DidCommReceivedMessage } from "@didcid/keymaster/types";
 import { useWalletContext } from "../contexts/WalletProvider";
 import { useVariablesContext } from "../contexts/VariablesProvider";
 import { useSnackbar } from "../contexts/SnackbarProvider";
-import { scanQrCodeRaw } from "../utils/utils";
+import { scanQrText } from "../utils/utils";
 import { loadRefreshIntervalSeconds } from "../contexts/UIContext";
 import PageHeader from "./layout/PageHeader";
 import Section from "./layout/Section";
@@ -185,6 +185,15 @@ function DidCommTab() {
     }, [refreshStatus]);
 
     useEffect(() => {
+        // An invitation names the identity that made it, so it must not survive a
+        // switch: leaving it on screen would offer a QR and a copyable link for
+        // the previous identity under the new one's name.
+        setInviteUrl("");
+        setInviteInput("");
+        setDecodedInvite(null);
+    }, [currentDID]);
+
+    useEffect(() => {
         activeIdRef.current = currentId;
         // Drop the previous identity's mail immediately rather than leaving it on
         // screen under the new name until the fetch returns.
@@ -315,6 +324,10 @@ function DidCommTab() {
     function acceptInvitation(value: string) {
         const trimmed = value.trim();
 
+        // Drop the previous result first: a failed decode must not leave the last
+        // inviter on screen with a live "Message them" button.
+        setDecodedInvite(null);
+
         if (!trimmed) {
             setError("Paste an invitation URL first");
             return;
@@ -323,12 +336,20 @@ function DidCommTab() {
         try {
             const invitation = decodeOutOfBandInvitation(trimmed);
 
-            if (!invitation?.from) {
+            // The payload is whatever the sender chose to encode, so nothing here
+            // is known to be a string. An object `from` would throw when React
+            // renders it, and would reach Compose's trim() as a non-string.
+            const from = invitation?.from;
+            if (typeof from !== "string" || !from.trim()) {
                 setError("That invitation names no inviter");
                 return;
             }
 
-            setDecodedInvite({ from: invitation.from, goal: invitation.body?.goal });
+            const goal = invitation?.body?.goal;
+            setDecodedInvite({
+                from: from.trim(),
+                goal: typeof goal === "string" ? goal : undefined,
+            });
         } catch {
             // decode throws on anything that is not a well-formed _oob payload.
             setError("Could not read that invitation");
@@ -336,7 +357,9 @@ function DidCommTab() {
     }
 
     async function scanInvitation() {
-        const scanned = await scanQrCodeRaw();
+        // scanQrText, not scanQrCodeRaw: the latter only returns codes that carry
+        // a DID in the clear, and an invitation hides its DID inside the payload.
+        const scanned = await scanQrText();
 
         if (!scanned) {
             setError("Failed to scan QR code");
@@ -348,8 +371,14 @@ function DidCommTab() {
     }
 
     async function copyInvitation() {
-        await navigator.clipboard.writeText(inviteUrl);
-        setSuccess("Invitation copied");
+        try {
+            await navigator.clipboard.writeText(inviteUrl);
+            setSuccess("Invitation copied");
+        } catch {
+            // Clipboard access is unavailable outside a secure context and can be
+            // refused; the link is on screen to copy by hand either way.
+            setError("Could not copy — select the link and copy it manually");
+        }
     }
 
     function replyTo(sender: string) {

--- a/apps/react-wallet/src/components/DidCommTab.tsx
+++ b/apps/react-wallet/src/components/DidCommTab.tsx
@@ -3,14 +3,17 @@ import {
     Box, Button, Checkbox, Chip, CircularProgress, Divider, FormControlLabel, MenuItem,
     Tab, Tabs, TextField, Typography
 } from "@mui/material";
-import { Forum, Inbox } from "@mui/icons-material";
+import { ContentCopy, Forum, Inbox, QrCodeScanner } from "@mui/icons-material";
+import { QRCodeSVG } from "qrcode.react";
 import {
-    BASIC_MESSAGE_TYPE, TRUST_PING_TYPE, basicMessage, trustPing, trustPingResponse
+    BASIC_MESSAGE_TYPE, TRUST_PING_TYPE, basicMessage, decodeOutOfBandInvitation,
+    encodeOutOfBandInvitation, outOfBandInvitation, trustPing, trustPingResponse
 } from "@didcid/keymaster/didcomm-protocols";
 import type { DidCommReceivedMessage } from "@didcid/keymaster/types";
 import { useWalletContext } from "../contexts/WalletProvider";
 import { useVariablesContext } from "../contexts/VariablesProvider";
 import { useSnackbar } from "../contexts/SnackbarProvider";
+import { scanQrCodeRaw } from "../utils/utils";
 import { loadRefreshIntervalSeconds } from "../contexts/UIContext";
 import PageHeader from "./layout/PageHeader";
 import Section from "./layout/Section";
@@ -97,6 +100,9 @@ function DidCommTab() {
     const [composeKind, setComposeKind] = useState<string>("message");
     const [composeContent, setComposeContent] = useState<string>("");
     const [composeAnoncrypt, setComposeAnoncrypt] = useState<boolean>(false);
+    const [inviteUrl, setInviteUrl] = useState<string>("");
+    const [inviteInput, setInviteInput] = useState<string>("");
+    const [decodedInvite, setDecodedInvite] = useState<{ from?: string; goal?: string } | null>(null);
     // Keyed by identity, not a bare boolean: an in-flight read must not block a
     // read for a *different* identity, and must not commit its result after the
     // identity has changed.
@@ -294,6 +300,58 @@ function DidCommTab() {
         }
     }
 
+    function createInvitation() {
+        if (!currentDID) {
+            setError("Select an identity first");
+            return;
+        }
+
+        // The invitation names the inviter; everything a recipient needs to reach
+        // them is resolvable from that DID, so the URL carries no endpoint.
+        const invitation = outOfBandInvitation(currentDID);
+        setInviteUrl(encodeOutOfBandInvitation(invitation));
+    }
+
+    function acceptInvitation(value: string) {
+        const trimmed = value.trim();
+
+        if (!trimmed) {
+            setError("Paste an invitation URL first");
+            return;
+        }
+
+        try {
+            const invitation = decodeOutOfBandInvitation(trimmed);
+
+            if (!invitation?.from) {
+                setError("That invitation names no inviter");
+                return;
+            }
+
+            setDecodedInvite({ from: invitation.from, goal: invitation.body?.goal });
+        } catch {
+            // decode throws on anything that is not a well-formed _oob payload.
+            setError("Could not read that invitation");
+        }
+    }
+
+    async function scanInvitation() {
+        const scanned = await scanQrCodeRaw();
+
+        if (!scanned) {
+            setError("Failed to scan QR code");
+            return;
+        }
+
+        setInviteInput(scanned);
+        acceptInvitation(scanned);
+    }
+
+    async function copyInvitation() {
+        await navigator.clipboard.writeText(inviteUrl);
+        setSuccess("Invitation copied");
+    }
+
     function replyTo(sender: string) {
         setComposeTo(sender);
         setComposeKind("message");
@@ -432,6 +490,7 @@ function DidCommTab() {
             >
                 <Tab label="Inbox" value="inbox" />
                 <Tab label="Compose" value="compose" />
+                <Tab label="Invite" value="invite" />
                 <Tab label="Endpoint" value="endpoint" />
             </Tabs>
 
@@ -537,6 +596,97 @@ function DidCommTab() {
                             : "The recipient can verify this came from the current identity."}
                     </Typography>
                 </Section>
+            )}
+
+            {activeTab === "invite" && (
+                <>
+                    <Section
+                        title="Invite someone"
+                        description="Share an out-of-band invitation so another agent can reach this identity without being handed a DID."
+                        actions={
+                            <Button variant="contained" onClick={createInvitation} disabled={busy}>
+                                {inviteUrl ? "Regenerate" : "Create"}
+                            </Button>
+                        }
+                    >
+                        {inviteUrl ? (
+                            <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 2 }}>
+                                {/* White plate behind the code: a dark page background
+                                    breaks scanning, since readers expect light quiet zones. */}
+                                <Box sx={{ p: 2, bgcolor: "#fff", borderRadius: 1 }}>
+                                    <QRCodeSVG value={inviteUrl} size={200} />
+                                </Box>
+                                <Typography
+                                    variant="body2"
+                                    color="text.secondary"
+                                    sx={{ wordBreak: "break-all", fontFamily: "monospace", fontSize: "0.7rem" }}
+                                >
+                                    {inviteUrl}
+                                </Typography>
+                                <Button size="small" startIcon={<ContentCopy />} onClick={copyInvitation}>
+                                    Copy link
+                                </Button>
+                            </Box>
+                        ) : (
+                            <Typography variant="body2" color="text.secondary">
+                                Create an invitation to show a QR code and a link.
+                            </Typography>
+                        )}
+                    </Section>
+
+                    <Section
+                        title="Accept an invitation"
+                        description="Scan or paste an invitation to start a conversation with whoever issued it."
+                        actions={
+                            <>
+                                <Button variant="outlined" startIcon={<QrCodeScanner />} onClick={scanInvitation} disabled={busy}>
+                                    Scan
+                                </Button>
+                                <Button variant="contained" onClick={() => acceptInvitation(inviteInput)} disabled={busy}>
+                                    Accept
+                                </Button>
+                            </>
+                        }
+                    >
+                        <TextField
+                            fullWidth
+                            label="Invitation URL"
+                            value={inviteInput}
+                            onChange={event => setInviteInput(event.target.value)}
+                            disabled={busy}
+                            placeholder="https://didcomm.org?_oob=..."
+                            sx={{ mb: 2 }}
+                        />
+
+                        {decodedInvite && (
+                            <Box>
+                                <Typography variant="body2" color="text.secondary">
+                                    Invitation from
+                                </Typography>
+                                <Typography variant="body2" sx={{ wordBreak: "break-all" }}>
+                                    {decodedInvite.from}
+                                </Typography>
+                                {decodedInvite.goal && (
+                                    <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                                        Purpose: {decodedInvite.goal}
+                                    </Typography>
+                                )}
+                                {/* The inviter is only a claim -- an invitation is
+                                    unsigned and anyone can mint one naming any DID.
+                                    So this starts a message, it does not assert a
+                                    relationship. */}
+                                <Button
+                                    variant="contained"
+                                    sx={{ mt: 2 }}
+                                    onClick={() => decodedInvite.from && replyTo(decodedInvite.from)}
+                                    disabled={busy || !decodedInvite.from}
+                                >
+                                    Message them
+                                </Button>
+                            </Box>
+                        )}
+                    </Section>
+                </>
             )}
 
             {activeTab === "endpoint" && (

--- a/apps/react-wallet/src/utils/utils.ts
+++ b/apps/react-wallet/src/utils/utils.ts
@@ -125,6 +125,10 @@ export async function scanQrCode() {
     return null;
 }
 
+// "Raw" here means the whole payload rather than the extracted DID -- but only
+// for codes that carry a DID somewhere. Callers scanning something with no DID
+// in it (an out-of-band invitation hides its DID inside a base64url payload)
+// want scanQrText instead.
 export async function scanQrCodeRaw(): Promise<string | null> {
     try {
         const perm = await BarcodeScanner.requestPermissions();
@@ -144,6 +148,28 @@ export async function scanQrCodeRaw(): Promise<string | null> {
                 return b.rawValue;
             }
         }
+    } catch {}
+    return null;
+}
+
+// The scanned text, with no interpretation at all. Out-of-band invitations are
+// `https://didcomm.org?_oob=<base64url>`: the DID is inside the payload and the
+// base64url alphabet has no `:`, so every DID-shaped filter rejects them.
+// Validation belongs to the caller, which knows what it asked the user to scan.
+export async function scanQrText(): Promise<string | null> {
+    try {
+        const perm = await BarcodeScanner.requestPermissions();
+        if (perm.camera !== 'granted') {
+            return null;
+        }
+
+        const ready = await ensureGoogleModuleReady();
+        if (!ready) {
+            return null;
+        }
+
+        const { barcodes } = await BarcodeScanner.scan();
+        return barcodes[0]?.rawValue ?? null;
     } catch {}
     return null;
 }

--- a/tests/keymaster/didcomm-protocols.test.ts
+++ b/tests/keymaster/didcomm-protocols.test.ts
@@ -84,22 +84,6 @@ describe('DIDComm protocol builders', () => {
         const bare = url.split('_oob=')[1];
         expect(decodeOutOfBandInvitation(bare).type).toBe(OUT_OF_BAND_INVITATION_TYPE);
     });
-
-    // The wallets that cannot import this module (the demo KeymasterUI depends on
-    // the thin client package only) inline the same encoding with btoa. Pin the
-    // wire format against that construction so the two cannot drift apart
-    // silently: a changed encoding here would strand invitations between wallets.
-    it('encodes exactly as a btoa-based browser implementation would', () => {
-        const invitation = outOfBandInvitation('did:cid:alice', { goal: 'naïve — 主题 🎉' });
-        const json = JSON.stringify(invitation);
-        const browserStyle = btoa(unescape(encodeURIComponent(json)))
-            .replace(/\+/g, '-')
-            .replace(/\//g, '_')
-            .replace(/=+$/, '');
-
-        expect(encodeOutOfBandInvitation(invitation)).toBe(`https://didcomm.org?_oob=${browserStyle}`);
-        expect(decodeOutOfBandInvitation(`https://didcomm.org?_oob=${browserStyle}`)).toStrictEqual(invitation);
-    });
 });
 
 describe('credential-exchange builders (issue-credential / present-proof 3.0)', () => {

--- a/tests/keymaster/didcomm-protocols.test.ts
+++ b/tests/keymaster/didcomm-protocols.test.ts
@@ -84,6 +84,22 @@ describe('DIDComm protocol builders', () => {
         const bare = url.split('_oob=')[1];
         expect(decodeOutOfBandInvitation(bare).type).toBe(OUT_OF_BAND_INVITATION_TYPE);
     });
+
+    // The wallets that cannot import this module (the demo KeymasterUI depends on
+    // the thin client package only) inline the same encoding with btoa. Pin the
+    // wire format against that construction so the two cannot drift apart
+    // silently: a changed encoding here would strand invitations between wallets.
+    it('encodes exactly as a btoa-based browser implementation would', () => {
+        const invitation = outOfBandInvitation('did:cid:alice', { goal: 'naïve — 主题 🎉' });
+        const json = JSON.stringify(invitation);
+        const browserStyle = btoa(unescape(encodeURIComponent(json)))
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=+$/, '');
+
+        expect(encodeOutOfBandInvitation(invitation)).toBe(`https://didcomm.org?_oob=${browserStyle}`);
+        expect(decodeOutOfBandInvitation(`https://didcomm.org?_oob=${browserStyle}`)).toStrictEqual(invitation);
+    });
 });
 
 describe('credential-exchange builders (issue-credential / present-proof 3.0)', () => {

--- a/tests/wallet/oob-codec.test.ts
+++ b/tests/wallet/oob-codec.test.ts
@@ -1,0 +1,61 @@
+// The demo wallets cannot import @didcid/keymaster -- the server-wallet demo
+// depends only on the thin client package -- so apps/*/src/oobCodec.mjs carries
+// its own copy of the out-of-band invitation encoding.
+//
+// Duplicated wire formats drift, and this one would drift silently: an
+// invitation created in one wallet would simply fail to decode in the other,
+// with nothing failing until a user tried it. So compare the actual module the
+// demo UIs import against the actual library implementation.
+import {
+    decodeOutOfBandInvitation as libDecode,
+    encodeOutOfBandInvitation as libEncode,
+    outOfBandInvitation as libInvitation,
+} from '../../packages/keymaster/src/didcomm-protocols.ts';
+import {
+    decodeOutOfBandInvitation as uiDecode,
+    encodeOutOfBandInvitation as uiEncode,
+    outOfBandInvitation as uiInvitation,
+} from '../../apps/keymaster-client/src/oobCodec.mjs';
+import { readFileSync } from 'fs';
+
+// Non-ASCII is where a byte-oriented btoa and a Buffer-based encoder are most
+// likely to disagree, so every case carries some.
+const GOALS = [undefined, 'pay me', 'naïve — 主题 🎉'];
+
+describe('demo wallet out-of-band codec', () => {
+    it('builds the same invitation as the library', () => {
+        for (const goal of GOALS) {
+            const body = goal ? { goal } : {};
+            expect(uiInvitation('did:cid:alice', body)).toStrictEqual(libInvitation('did:cid:alice', body));
+        }
+    });
+
+    it('encodes byte-for-byte identically to the library', () => {
+        for (const goal of GOALS) {
+            const invitation = libInvitation('did:cid:alice', goal ? { goal } : {});
+            expect(uiEncode(invitation)).toBe(libEncode(invitation));
+        }
+    });
+
+    it('decodes what the library encoded, and the reverse', () => {
+        for (const goal of GOALS) {
+            const invitation = libInvitation('did:cid:alice', goal ? { goal } : {});
+            expect(uiDecode(libEncode(invitation))).toStrictEqual(invitation);
+            expect(libDecode(uiEncode(invitation))).toStrictEqual(invitation);
+        }
+    });
+
+    it('reads a bare _oob value as well as a full URL', () => {
+        const invitation = libInvitation('did:cid:alice');
+        const bare = uiEncode(invitation).split('_oob=')[1];
+        expect(uiDecode(bare)).toStrictEqual(invitation);
+    });
+
+    // gatekeeper-client and keymaster-client keep byte-identical sources
+    // (AGENTS.md), and only one of the two copies is exercised above.
+    it('is identical in both demo wallets', () => {
+        const keymasterClient = readFileSync('apps/keymaster-client/src/oobCodec.mjs', 'utf-8');
+        const gatekeeperClient = readFileSync('apps/gatekeeper-client/src/oobCodec.mjs', 'utf-8');
+        expect(gatekeeperClient).toBe(keymasterClient);
+    });
+});


### PR DESCRIPTION
Phase 4 of #905. Connecting to someone meant pasting a DID; an out-of-band invitation is how that works without one.

## What it does

A new **Invite** sub-tab on the DIDComm screen:

- **Create** — builds an OOB invitation for the current identity, renders it as a QR code, and offers the link to copy.
- **Accept** — takes a scanned or pasted invitation, names the inviter (and its `goal`, if it carries one), and hands off to Compose.

The protocol layer already existed — `outOfBandInvitation`, `encodeOutOfBandInvitation`, `decodeOutOfBandInvitation` in `didcomm-protocols.ts` — so this is UI only, with no new library surface.

## Two properties worth stating in the UI, not just the code

**The invitation carries no endpoint.** It names the inviter, and everything needed to reach them resolves from that DID. Nothing to keep in sync if the endpoint later changes.

**It is unsigned, so the inviter is a claim.** Anyone can mint an invitation naming any DID. Accepting therefore *starts a message* — it does not assert a relationship, and nothing about it is presented as verified. The button says "Message them" rather than "Connect", and the reasoning sits next to it in the source.

## First real divergence between the wallets

This is the first feature where the two wallets need genuinely different code rather than having merely drifted:

| | react-wallet | KeymasterUI (demo wallets) |
| --- | --- | --- |
| Display QR | `qrcode.react` | `qrcode.react` |
| Scan QR | `@capacitor-mlkit/barcode-scanning` | — no camera, paste only |

That asymmetry already exists in `LightningTab`, which scans in the wallet and only displays in the extension. Worth having as a concrete case before #894's extraction designs the platform-capability seam.

## The duplicated encoding, and the test that pins it

`KeymasterUI.jsx` inlines the invitation encoding for the same reason it already inlines the protocol URIs: the server-wallet demo depends only on `@didcid/clients`, and importing the keymaster package for two helpers would pull it into that bundle.

Duplication invites drift, and drift here would strand invitations between wallets rather than fail loudly. So a test pins the library's wire format against the `btoa` construction the copies use, with a non-ASCII payload — a changed encoding fails the test instead of the users. I also verified the two agree before writing it:

```
(no goal)       | encoders match: true
pay me          | encoders match: true
naïve — 主题 🎉 | encoders match: true
```

each with both directions of cross-decoding.

## Testing

`tests/keymaster/didcomm-protocols.test.ts` — 31 pass, including the new encoding pin. `didcomm.test.ts` — 41 pass. `npm run lint` clean; react-wallet, keymaster-client and gatekeeper-client all build; the two `KeymasterUI.jsx` copies verified byte-identical.

The UI itself has no automated coverage — the repo has no React component testing setup — so the QR paths want a manual pass: create on one identity, scan or paste on another.

Refs #905 (phase 5, credential exchange, is the remaining half)