### PR TITLE
fix: Send SOCKS-dispatched requests through undici's fetch, not Node's

### DIFF
--- a/services/didcomm/server/package-lock.json
+++ b/services/didcomm/server/package-lock.json
@@ -13,7 +13,8 @@
         "dotenv": "^16.4.5",
         "express": "^4.22.1",
         "fetch-socks": "^1.3.3",
-        "ioredis": "^5.10.1"
+        "ioredis": "^5.10.1",
+        "undici": "^7.28.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
@@ -1108,12 +1109,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.19.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/services/didcomm/server/package.json
+++ b/services/didcomm/server/package.json
@@ -16,7 +16,8 @@
     "dotenv": "^16.4.5",
     "express": "^4.22.1",
     "fetch-socks": "^1.3.3",
-    "ioredis": "^5.10.1"
+    "ioredis": "^5.10.1",
+    "undici": "^7.28.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/services/didcomm/server/src/didcomm-api.ts
+++ b/services/didcomm/server/src/didcomm-api.ts
@@ -6,6 +6,13 @@ import crypto from 'crypto';
 import express, { type Express } from 'express';
 import cors from 'cors';
 import { socksDispatcher } from 'fetch-socks';
+// Aliased rather than shadowing the global fetch, which the rest of this
+// service (and its tests) still use. socksDispatcher is built on fetch-socks's
+// undici (>=7), and Node's built-in fetch hands it a v6-era request handler that
+// it rejects with "invalid onRequestStart method" -- surfacing as a bare
+// `TypeError: fetch failed` in about 10ms, which reads like an unreachable Tor
+// destination rather than a wiring bug. See #916.
+import { fetch as socksFetch } from 'undici';
 import type { Cipher } from '@didcid/cipher/types';
 import { MailboxFullError, MailboxStore } from './store.js';
 import { recipientDidsFromEnvelope, verifyChallengeSignature, type Resolver } from './mailbox.js';
@@ -222,7 +229,10 @@ export function createApp(deps: AppDeps): Express {
             }
 
             const target = `${endpoint.replace(/\/+$/, '')}/api/v1/messages`;
-            const response = await fetch(target, fetchOptions);
+            // Only the SOCKS-dispatched path needs undici's fetch; clearnet stays
+            // on the built-in one, which the rest of the service uses.
+            const doFetch = fetchOptions.dispatcher ? socksFetch : fetch;
+            const response = await doFetch(target, fetchOptions);
             if (response.status >= 300 && response.status < 400) {
                 // Say what happened: a bare "failed: 307" reads like the recipient
                 // is broken rather than like a rule we enforce.

--- a/services/didcomm/server/src/didcomm-api.ts
+++ b/services/didcomm/server/src/didcomm-api.ts
@@ -17,6 +17,13 @@ import type { Cipher } from '@didcid/cipher/types';
 import { MailboxFullError, MailboxStore } from './store.js';
 import { recipientDidsFromEnvelope, verifyChallengeSignature, type Resolver } from './mailbox.js';
 
+// An object, so tests can substitute it. SOCKS-dispatched requests deliberately
+// bypass globalThis.fetch, so a test cannot observe them by stubbing that -- and
+// mocking the 'undici' module does not work either, since this file resolves it
+// from the service's own node_modules while a test resolves it from the repo
+// root. Two different modules, one mock.
+export const socksEgress = { fetch: socksFetch };
+
 export interface AppDeps {
     store: MailboxStore;
     resolver: Resolver;
@@ -231,7 +238,7 @@ export function createApp(deps: AppDeps): Express {
             const target = `${endpoint.replace(/\/+$/, '')}/api/v1/messages`;
             // Only the SOCKS-dispatched path needs undici's fetch; clearnet stays
             // on the built-in one, which the rest of the service uses.
-            const doFetch = fetchOptions.dispatcher ? socksFetch : fetch;
+            const doFetch = fetchOptions.dispatcher ? socksEgress.fetch : fetch;
             const response = await doFetch(target, fetchOptions);
             if (response.status >= 300 && response.status < 400) {
                 // Say what happened: a bare "failed: 307" reads like the recipient

--- a/services/herald/server/package-lock.json
+++ b/services/herald/server/package-lock.json
@@ -20,7 +20,8 @@
         "ioredis": "^5.10.1",
         "jose": "^6.2.8",
         "morgan": "^1.11.0",
-        "multer": "^2.2.0"
+        "multer": "^2.2.0",
+        "undici": "^7.28.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.18",
@@ -2057,12 +2058,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.19.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/services/herald/server/package.json
+++ b/services/herald/server/package.json
@@ -23,7 +23,8 @@
     "ioredis": "^5.10.1",
     "jose": "^6.2.8",
     "morgan": "^1.11.0",
-    "multer": "^2.2.0"
+    "multer": "^2.2.0",
+    "undici": "^7.28.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.18",

--- a/services/herald/server/src/routes.ts
+++ b/services/herald/server/src/routes.ts
@@ -1,6 +1,12 @@
 import express, { NextFunction, Request, Response } from 'express';
 import cors from 'cors';
 import { socksDispatcher } from 'fetch-socks';
+// Aliased rather than shadowing the global fetch, which the rest of this file
+// uses with DOM-typed bodies. socksDispatcher is built on fetch-socks's undici
+// (>=7), and Node's built-in fetch hands it a v6-era request handler that it
+// rejects with "invalid onRequestStart method" -- a bare `TypeError: fetch
+// failed` in milliseconds, long before any Tor round trip. See #916.
+import { fetch as socksFetch } from 'undici';
 import multer from 'multer';
 
 import type Keymaster from '@didcid/keymaster';
@@ -1072,7 +1078,8 @@ export function createHeraldRoutes(ctx: HeraldContext): {
                 });
             }
 
-            const response = await fetch(invoiceUrl, fetchOptions);
+            // socksFetch: this request may carry a SOCKS dispatcher (#916).
+            const response = await socksFetch(invoiceUrl, fetchOptions);
             if (!response.ok) {
                 res.json({ status: 'ERROR', reason: 'Lightning service returned an error' });
                 return;

--- a/services/herald/server/src/routes.ts
+++ b/services/herald/server/src/routes.ts
@@ -30,6 +30,13 @@ import {
     WEBHOOK_SECRET,
 } from './config.js';
 
+// An object, so tests can substitute it. SOCKS-dispatched requests deliberately
+// bypass globalThis.fetch, so a test cannot observe them by stubbing that --
+// and mocking the 'undici' module does not work either, because this file
+// resolves it from the service's own node_modules while a test resolves it from
+// the repo root. Two different modules, one mock.
+export const socksEgress = { fetch: socksFetch };
+
 // Mutable state owned by the bootstrap in index.ts. Routes read it through this
 // object because it is populated after the routes are registered.
 export interface HeraldContext {
@@ -1078,8 +1085,10 @@ export function createHeraldRoutes(ctx: HeraldContext): {
                 });
             }
 
-            // socksFetch: this request may carry a SOCKS dispatcher (#916).
-            const response = await socksFetch(invoiceUrl, fetchOptions);
+            // Only the SOCKS-dispatched path needs undici's fetch; clearnet stays
+            // on the built-in one, which the rest of this service uses (#916).
+            const doFetch = fetchOptions.dispatcher ? socksEgress.fetch : fetch;
+            const response = await doFetch(invoiceUrl, fetchOptions);
             if (!response.ok) {
                 res.json({ status: 'ERROR', reason: 'Lightning service returned an error' });
                 return;

--- a/services/mediators/lightning/package-lock.json
+++ b/services/mediators/lightning/package-lock.json
@@ -12,11 +12,12 @@
         "axios": "^1.18.0",
         "dotenv": "^16.4.5",
         "express": "^4.22.2",
-        "fetch-socks": "^1.3.2",
+        "fetch-socks": "^1.3.3",
         "ioredis": "^5.5.0",
         "morgan": "^1.11.0",
         "pino": "^9.14.0",
-        "prom-client": "^15.1.3"
+        "prom-client": "^15.1.3",
+        "undici": "^7.28.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -592,13 +593,13 @@
       }
     },
     "node_modules/fetch-socks": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fetch-socks/-/fetch-socks-1.3.2.tgz",
-      "integrity": "sha512-vkH5+Zgj2yEbU57Cei0iyLgTZ4OkEKJj56Xu3ViB5dpsl599JgEooQ3x6NVagIFRHWnWJ+7K0MO0aIV1TMgvnw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/fetch-socks/-/fetch-socks-1.3.3.tgz",
+      "integrity": "sha512-jI22jzTf7x3GAcUoZARwuxKBPotb3PFkemVWqxlF2qV55FhRytRJrn95HeLoUMq2vkIbY3aQqNYytvZKqUoMaQ==",
       "license": "MIT",
       "dependencies": {
-        "socks": "^2.8.2",
-        "undici": ">=6"
+        "socks": "^2.8.7",
+        "undici": ">=7"
       }
     },
     "node_modules/finalhandler": {
@@ -1516,12 +1517,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.19.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/services/mediators/lightning/package.json
+++ b/services/mediators/lightning/package.json
@@ -12,14 +12,15 @@
   "author": "Archetech",
   "license": "MIT",
   "dependencies": {
-    "fetch-socks": "^1.3.2",
     "axios": "^1.18.0",
     "dotenv": "^16.4.5",
     "express": "^4.22.2",
+    "fetch-socks": "^1.3.3",
     "ioredis": "^5.5.0",
     "morgan": "^1.11.0",
     "pino": "^9.14.0",
-    "prom-client": "^15.1.3"
+    "prom-client": "^15.1.3",
+    "undici": "^7.28.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/services/mediators/lightning/src/lightning-mediator.ts
+++ b/services/mediators/lightning/src/lightning-mediator.ts
@@ -6,6 +6,14 @@ import { timingSafeEqual } from 'crypto';
 import { Counter, Gauge, collectDefaultMetrics, register } from 'prom-client';
 import GatekeeperClient from '@didcid/clients/gatekeeper';
 import { socksDispatcher } from 'fetch-socks';
+// Aliased rather than shadowing the global fetch, which the rest of this file
+// uses with DOM-typed bodies. socksDispatcher is built on fetch-socks's undici
+// (>=7), and Node's built-in fetch hands it a v6-era request handler that it
+// rejects with "invalid onRequestStart method" -- surfacing as a bare
+// `TypeError: fetch failed` in milliseconds, long before any Tor round trip.
+// Anything dispatched through SOCKS must therefore use this fetch. See #916.
+import { fetch as socksFetch } from 'undici';
+
 import { Redis } from 'ioredis';
 
 import config from './config.js';
@@ -579,7 +587,8 @@ async function main(): Promise<void> {
                     });
                 }
 
-                const invoiceResponse = await fetch(invoiceUrl.toString(), fetchOptions);
+                // socksFetch: this request may carry a SOCKS dispatcher (#916).
+                const invoiceResponse = await socksFetch(invoiceUrl.toString(), fetchOptions);
                 if (invoiceResponse.status >= 300 && invoiceResponse.status < 400) {
                     res.status(502).json({
                         error: `Invoice request failed: endpoint redirected (${invoiceResponse.status}); redirects are not followed`,
@@ -587,7 +596,8 @@ async function main(): Promise<void> {
                     return;
                 }
                 if (!invoiceResponse.ok) {
-                    const error = await invoiceResponse.json().catch(() => ({ error: invoiceResponse.statusText }));
+                    // undici's json() is typed unknown, unlike the DOM's any.
+                    const error = await invoiceResponse.json().catch(() => ({ error: invoiceResponse.statusText })) as { error?: string };
                     res.status(502).json({ error: `Invoice request failed: ${error.error || invoiceResponse.statusText}` });
                     return;
                 }

--- a/services/mediators/lightning/src/lightning-mediator.ts
+++ b/services/mediators/lightning/src/lightning-mediator.ts
@@ -587,8 +587,10 @@ async function main(): Promise<void> {
                     });
                 }
 
-                // socksFetch: this request may carry a SOCKS dispatcher (#916).
-                const invoiceResponse = await socksFetch(invoiceUrl.toString(), fetchOptions);
+                // Only the SOCKS-dispatched path needs undici's fetch; clearnet and
+                // the internal loopback shortcut stay on the built-in one (#916).
+                const doFetch = fetchOptions.dispatcher ? socksFetch : fetch;
+                const invoiceResponse = await doFetch(invoiceUrl.toString(), fetchOptions);
                 if (invoiceResponse.status >= 300 && invoiceResponse.status < 400) {
                     res.status(502).json({
                         error: `Invoice request failed: endpoint redirected (${invoiceResponse.status}); redirects are not followed`,

--- a/tests/didcomm/mailbox.test.ts
+++ b/tests/didcomm/mailbox.test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import Gatekeeper from '@didcid/gatekeeper';
 import Keymaster from '@didcid/keymaster';
 import CipherNode from '@didcid/cipher/node';
@@ -7,7 +8,7 @@ import HeliaClient from '@didcid/ipfs/helia';
 import { packEncrypted } from '@didcid/cipher/didcomm';
 import { MailboxFullError, MemoryMailboxStore, RedisMailboxStore } from '../../services/didcomm/server/src/store.ts';
 import { recipientDidsFromEnvelope, verifyChallengeSignature } from '../../services/didcomm/server/src/mailbox.ts';
-import { createApp } from '../../services/didcomm/server/src/didcomm-api.ts';
+import { createApp, socksEgress } from '../../services/didcomm/server/src/didcomm-api.ts';
 import express from 'express';
 import request from 'supertest';
 
@@ -201,7 +202,7 @@ describe('deposit route capacity', () => {
 
     // Egress checks sit behind challenge auth, so these need a relay that accepts
     // the signature -- otherwise every request 401s before reaching them.
-    function appWithEgress(options: { allowInsecureEgress?: boolean } = {}) {
+    function appWithEgress(options: { allowInsecureEgress?: boolean; torProxy?: string } = {}) {
         const store = new MemoryMailboxStore(1000, 1000, () => 1_000_000);
         const resolver = {
             resolveDID: async () => ({
@@ -278,6 +279,38 @@ describe('deposit route capacity', () => {
             expect(response.body.error).toMatch(/redirect/);
         }
         finally {
+            globalThis.fetch = realFetch;
+        }
+    });
+
+    // #916: a SOCKS dispatcher built on fetch-socks's undici is rejected by
+    // Node's built-in fetch ("invalid onRequestStart method"), which surfaced as
+    // an unreachable-looking `TypeError: fetch failed` and broke every onion
+    // delivery. The onion path must therefore go through undici's fetch.
+    it('sends onion deliveries through undici, never the global fetch', async () => {
+        const socksFetchMock = jest.fn<any>().mockResolvedValue(
+            new Response(JSON.stringify({ ids: ['onion-1'] }), { status: 200 }),
+        );
+        const realSocksFetch = socksEgress.fetch;
+        socksEgress.fetch = socksFetchMock;
+
+        // A trap, not a stub: the global fetch reaching this request is exactly
+        // what the regression looks like.
+        const realFetch = globalThis.fetch;
+        const globalTrap = jest.fn<any>();
+        globalThis.fetch = globalTrap as any;
+
+        try {
+            const { app } = appWithEgress({ torProxy: '127.0.0.1:1' });
+            const response = await deliver(app, 'http://abcdefghijklmnop.onion:4222/didcomm');
+
+            expect(response.status).toBe(200);
+            expect(globalTrap).not.toHaveBeenCalled();
+            expect(socksFetchMock).toHaveBeenCalledTimes(1);
+            expect(socksFetchMock.mock.calls[0][1].dispatcher).toBeDefined();
+        }
+        finally {
+            socksEgress.fetch = realSocksFetch;
             globalThis.fetch = realFetch;
         }
     });

--- a/tests/didcomm/socks-egress.test.ts
+++ b/tests/didcomm/socks-egress.test.ts
@@ -17,13 +17,20 @@ const SOCKS_USERS = [
 ];
 
 describe('SOCKS egress (#916)', () => {
-    it.each(SOCKS_USERS)('%s imports fetch from undici', path => {
+    it.each(SOCKS_USERS)('%s routes the dispatcher-bearing request through undici', path => {
         const source = readFileSync(path, 'utf-8');
 
         // Guard the guard: if a file stops dispatching over SOCKS this test
         // should be removed rather than passing vacuously.
         expect(source).toContain('socksDispatcher');
-        expect(source).toMatch(/import \{ fetch(?: as \w+)? \} from 'undici';/);
+        expect(source).toMatch(/import \{ fetch as \w+ \} from 'undici';/);
+
+        // The import alone proves nothing -- reverting the call site to the global
+        // fetch while leaving an unused import would keep it green. Assert the
+        // selection itself: when a dispatcher is attached, undici's fetch is used.
+        expect(source).toMatch(
+            /dispatcher\s*\?\s*(socksFetch|socksEgress\.fetch)\s*:\s*fetch/,
+        );
     });
 
     it.each(SOCKS_USERS)('%s declares undici so it shares one copy with fetch-socks', path => {

--- a/tests/didcomm/socks-egress.test.ts
+++ b/tests/didcomm/socks-egress.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'fs';
+
+// #916: onion delivery broke silently when the base image moved to Node 22.
+// socksDispatcher comes from fetch-socks, which builds it on its own undici
+// (>=7). Node's *built-in* fetch constructs a v6-era request handler, and the
+// newer dispatcher rejects it -- "invalid onRequestStart method" -- surfacing as
+// a bare `TypeError: fetch failed` in about 10ms, which reads like an
+// unreachable Tor destination rather than a wiring bug.
+//
+// A real end-to-end test would need a live SOCKS proxy and an onion, so this
+// guards the invariant that makes it work: any file that builds a SOCKS
+// dispatcher must send it through undici's fetch, not the global one.
+const SOCKS_USERS = [
+    'services/didcomm/server/src/didcomm-api.ts',
+    'services/mediators/lightning/src/lightning-mediator.ts',
+    'services/herald/server/src/routes.ts',
+];
+
+describe('SOCKS egress (#916)', () => {
+    it.each(SOCKS_USERS)('%s imports fetch from undici', path => {
+        const source = readFileSync(path, 'utf-8');
+
+        // Guard the guard: if a file stops dispatching over SOCKS this test
+        // should be removed rather than passing vacuously.
+        expect(source).toContain('socksDispatcher');
+        expect(source).toMatch(/import \{ fetch(?: as \w+)? \} from 'undici';/);
+    });
+
+    it.each(SOCKS_USERS)('%s declares undici so it shares one copy with fetch-socks', path => {
+        // Sharing matters as much as importing: two undici copies with different
+        // handler interfaces is the whole bug. Declaring it lets npm dedupe
+        // fetch-socks onto the same version instead of nesting its own.
+        const pkgPath = `${path.split('/src/')[0]}/package.json`;
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+
+        expect(pkg.dependencies?.['fetch-socks']).toBeDefined();
+        expect(pkg.dependencies?.undici).toBeDefined();
+    });
+});

--- a/tests/herald/routes-env.test.ts
+++ b/tests/herald/routes-env.test.ts
@@ -155,14 +155,32 @@ describe('LNURLp callback over Tor', () => {
 
     it('routes an .onion endpoint through the configured SOCKS proxy', async () => {
         const { app } = withEndpoint('http://abcd.onion/invoice');
-        const fetchMock = jest.fn<any>().mockResolvedValue({ ok: true, json: async () => ({ pr: 'lnbc1' }) });
-        global.fetch = fetchMock as any;
+        // The onion request must use undici's fetch, not the global one: a
+        // dispatcher built on fetch-socks's undici is rejected by Node's built-in
+        // fetch with "invalid onRequestStart method" (#916). Failing that way here
+        // is what a regression would look like, so the global fetch is left as a
+        // trap -- if the onion path ever goes back through it, this test sees no
+        // call on socksFetchMock and fails.
+        const socksFetchMock = jest.fn<any>().mockResolvedValue({ ok: true, json: async () => ({ pr: 'lnbc1' }) });
+        const { socksEgress } = await import('../../services/herald/server/src/routes');
+        const realSocksFetch = socksEgress.fetch;
+        socksEgress.fetch = socksFetchMock as any;
+        const globalTrap = jest.fn<any>();
+        global.fetch = globalTrap as any;
 
-        const response = await request(app).get('/api/lnurlp/alice/callback?amount=100000');
+        try {
+            const response = await request(app).get('/api/lnurlp/alice/callback?amount=100000');
 
-        expect(response.body).toMatchObject({ pr: 'lnbc1' });
-        // A dispatcher is attached only for .onion destinations.
-        expect(fetchMock.mock.calls[0][1].dispatcher).toBeDefined();
+            expect(response.body).toMatchObject({ pr: 'lnbc1' });
+            // The global fetch is left as a trap: if the onion path ever goes back
+            // through it, the dispatcher is rejected at runtime (#916), so seeing a
+            // call here is the regression.
+            expect(globalTrap).not.toHaveBeenCalled();
+            // A dispatcher is attached only for .onion destinations.
+            expect(socksFetchMock.mock.calls[0][1].dispatcher).toBeDefined();
+        } finally {
+            socksEgress.fetch = realSocksFetch;
+        }
     });
 
     it('does not attach a proxy dispatcher for a clearnet endpoint', async () => {


### PR DESCRIPTION
Fixes #916.

## Confirmed, then measured

`socksDispatcher` comes from `fetch-socks`, which builds it on its own undici (`>=7`). Node's **built-in** fetch constructs a v6-era request handler, and the newer dispatcher rejects it. Against a live onion, before and after:

```
built-in fetch + socksDispatcher: THREW in 10ms  -> invalid onRequestStart method
undici's fetch + socksDispatcher: HTTP 400 in 1218ms
```

The **10ms** is the diagnostic tell — far too fast to be the Tor round trip it presents as. The surfaced error is a bare `TypeError: fetch failed`, which reads as an unreachable recipient; this cost a long diagnosis across two nodes, including eliminating the receiving node with an independent Tor client, before #916 identified it.

(The 400 is the receiving relay correctly rejecting a `{}` test envelope — a real round trip with a real answer.)

## Three services, not one

#916 describes the DIDComm relay. The same pattern is in two more:

| Service | Call site | Impact |
| --- | --- | --- |
| didcomm | `didcomm-api.ts` | DIDComm delivery to onion recipients |
| lightning-mediator | `lightning-mediator.ts` | **Zaps to onion recipients** |
| herald | `routes.ts` | Herald's LUD16 onion path |

So onion Lightning payments have been failing for the same reason since #892.

## The fix

Each service declares `undici` directly, so npm dedupes `fetch-socks` onto that copy rather than nesting its own, and each SOCKS call site uses that fetch.

Two constraints, both found by **testing rather than reasoning** — I had committed the opposite of each before the evidence corrected me:

**`undici@^7`, not `^8`.** My first attempt pinned `^8.10.0` (what fetch-socks resolves). It throws `removeAbortListener is not a function` on Node 22.15 — older than the images' 22.23.2, but current for developers and easily hit in local runs. `^7` satisfies fetch-socks's `>=7`, dedupes the same way, and I verified it against a live onion: `HTTP 200 in 1602ms`.

**Aliased as `socksFetch`, not shadowing `fetch`.** Importing undici's fetch as `fetch` broke the other call sites in these files, which pass DOM-typed bodies (`FormData`, `Blob`), and — worse — silently bypassed the suites' `globalThis.fetch` mocks. One mailbox test stopped being intercepted, hit the network, and timed out. Only the dispatched request switches; clearnet stays on the built-in fetch.

`undici`'s `.json()` is typed `unknown` where the DOM's is `any`, so one existing destructure needed a cast.

## Regression guard

`tests/didcomm/socks-egress.test.ts` asserts the invariant that makes this work: any file building a SOCKS dispatcher imports fetch from undici, **and** its package declares undici so the two share one copy — sharing matters as much as importing, since two undici copies with different handler interfaces is the whole bug. It also asserts `socksDispatcher` is still present, so it can't pass vacuously if a file stops doing SOCKS.

Verified by reverting the import and watching it fail.

A true end-to-end test would need a live SOCKS proxy and a reachable onion in CI, which is why this guards the wiring instead.

## Testing

`tests/didcomm` — 51 pass. `test:didcomm-e2e` — 9/9. All three services `tsc --noEmit` clean. `npm run lint` clean.

Manually verified against a live onion at each step: the reproduction, the undici-8 fix, the undici-7 fix, and the final narrowed version.

Fixes #916