### PR TITLE
fix(keymaster-service): Serve the DIDComm API from the Python flavor too

### DIFF
--- a/python/keymaster_service/src/keymaster_service/app.py
+++ b/python/keymaster_service/src/keymaster_service/app.py
@@ -160,6 +160,11 @@ async def registries() -> dict[str, list[str]]:
     return {"registries": await service.list_registries()}
 
 
+@protected_api.get("/capabilities")
+async def capabilities() -> dict[str, Any]:
+    return {"capabilities": await service.get_node_capabilities()}
+
+
 @protected_api.get("/wallet")
 async def wallet() -> dict[str, Any]:
     return {"wallet": await service.load_wallet()}
@@ -298,6 +303,20 @@ async def import_address(body: dict[str, Any]) -> dict[str, Any]:
 @protected_api.get("/addresses/check/{address}")
 async def check_address(address: str) -> dict[str, Any]:
     return await service.check_address(address)
+
+
+# Declared ahead of the `/addresses/{address}` templates below: FastAPI matches
+# in declaration order, so a later literal loses to an earlier parameter and
+# `DELETE /addresses/publish` would arrive as a removal of an address literally
+# named "publish".
+@protected_api.post("/addresses/publish")
+async def publish_address(body: dict[str, Any]) -> dict[str, bool]:
+    return {"ok": await service.publish_address(body.get("address"), body.get("name"))}
+
+
+@protected_api.delete("/addresses/publish")
+async def unpublish_address(body: dict[str, Any] | None = None) -> dict[str, bool]:
+    return {"ok": await service.unpublish_address((body or {}).get("name"))}
 
 
 @protected_api.post("/addresses")
@@ -810,6 +829,14 @@ async def view_poll(poll: str) -> dict[str, Any]:
     return {"poll": await service.view_poll(poll)}
 
 
+# Ahead of `/polls/{poll}/send`: FastAPI matches in declaration order, so this
+# was previously unreachable -- a ballot send arrived as send_poll(poll="ballot").
+# The JS router has always declared it in this order.
+@protected_api.post("/polls/ballot/send")
+async def send_ballot(body: dict[str, Any]) -> dict[str, str]:
+    return {"did": await service.send_ballot(body["ballot"], body["poll"])}
+
+
 @protected_api.post("/polls/{poll}/send")
 async def send_poll(poll: str) -> dict[str, str]:
     return {"did": await service.send_poll(poll)}
@@ -833,11 +860,6 @@ async def publish_poll(poll: str, body: dict[str, Any] | None = None) -> dict[st
 @protected_api.post("/polls/{poll}/unpublish")
 async def unpublish_poll(poll: str) -> dict[str, bool]:
     return {"ok": await service.unpublish_poll(poll)}
-
-
-@protected_api.post("/polls/ballot/send")
-async def send_ballot(body: dict[str, Any]) -> dict[str, str]:
-    return {"did": await service.send_ballot(body["ballot"], body["poll"])}
 
 
 @protected_api.get("/polls/ballot/{did}")
@@ -908,6 +930,62 @@ async def response_verify(body: dict[str, Any]) -> dict[str, Any]:
 @app.get("/metrics")
 async def metrics() -> Response:
     return PlainTextResponse(generate_latest().decode("utf-8"), media_type=CONTENT_TYPE_LATEST)
+
+
+# The DIDComm surface, mirroring services/keymaster/server/src/keymaster-didcomm-router.ts.
+# The `keymaster` library has implemented all of this since #633; only this
+# routing layer was missing, which made every SDK didcomm call 404 against the
+# Python flavor while working against the JS one (#920).
+
+
+@protected_api.post("/didcomm/publish")
+async def publish_didcomm(body: dict[str, Any]) -> dict[str, bool]:
+    return {"ok": await service.publish_didcomm(body.get("endpoint"), body.get("name"), body.get("routingKeys"))}
+
+
+@protected_api.delete("/didcomm/publish")
+async def unpublish_didcomm(body: dict[str, Any] | None = None) -> dict[str, bool]:
+    return {"ok": await service.unpublish_didcomm((body or {}).get("name"))}
+
+
+@protected_api.post("/didcomm/pack")
+async def pack_didcomm(body: dict[str, Any]) -> dict[str, str]:
+    return {"packed": await service.pack_didcomm(body.get("message"), body.get("to"), body.get("options"))}
+
+
+@protected_api.post("/didcomm/unpack")
+async def unpack_didcomm(body: dict[str, Any]) -> dict[str, Any]:
+    return {"result": await service.unpack_didcomm(body.get("packed"), body.get("options"))}
+
+
+@protected_api.post("/didcomm/send")
+async def send_didcomm(body: dict[str, Any]) -> dict[str, Any]:
+    return {"ids": await service.send_didcomm(body.get("message"), body.get("to"), body.get("options"))}
+
+
+@protected_api.post("/didcomm/receive")
+async def receive_didcomm(body: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {"results": await service.receive_didcomm((body or {}).get("options"))}
+
+
+@protected_api.post("/didcomm/ack")
+async def ack_didcomm(body: dict[str, Any]) -> dict[str, Any]:
+    return {"acknowledged": await service.ack_didcomm(body.get("ids"), body.get("options"))}
+
+
+@protected_api.post("/didcomm/mediate")
+async def mediate_didcomm(body: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {"result": await service.mediate_didcomm((body or {}).get("options"))}
+
+
+@protected_api.post("/didcomm/credential/send")
+async def send_credential_didcomm(body: dict[str, Any]) -> dict[str, Any]:
+    return {"ids": await service.send_credential_didcomm(body.get("did"), body.get("to"), body.get("options"))}
+
+
+@protected_api.post("/didcomm/credential/accept")
+async def accept_credential_didcomm(body: dict[str, Any]) -> dict[str, bool]:
+    return {"ok": await service.accept_credential_didcomm(body.get("message"))}
 
 
 app.include_router(public_api)

--- a/python/keymaster_service/tests/test_app_partial_parity.py
+++ b/python/keymaster_service/tests/test_app_partial_parity.py
@@ -797,6 +797,58 @@ class StubService:
         self.calls.append(("revoke_credential", identifier))
         return True
 
+    async def get_node_capabilities(self):
+        self.calls.append(("get_node_capabilities",))
+        return {"didcomm": True, "lightning": False}
+
+    async def publish_address(self, address=None, name=None) -> bool:
+        self.calls.append(("publish_address", address, name))
+        return True
+
+    async def unpublish_address(self, name=None) -> bool:
+        self.calls.append(("unpublish_address", name))
+        return True
+
+    async def publish_didcomm(self, endpoint=None, name=None, routing_keys=None) -> bool:
+        self.calls.append(("publish_didcomm", endpoint, name, routing_keys))
+        return True
+
+    async def unpublish_didcomm(self, name=None) -> bool:
+        self.calls.append(("unpublish_didcomm", name))
+        return True
+
+    async def pack_didcomm(self, message, to, options=None) -> str:
+        self.calls.append(("pack_didcomm", message, to, options))
+        return "packed-envelope"
+
+    async def unpack_didcomm(self, packed, options=None):
+        self.calls.append(("unpack_didcomm", packed, options))
+        return {"message": {"body": {"content": "hello"}}, "metadata": {"sender": "did:test:alice"}}
+
+    async def send_didcomm(self, message, to, options=None):
+        self.calls.append(("send_didcomm", message, to, options))
+        return ["msg-1"]
+
+    async def receive_didcomm(self, options=None):
+        self.calls.append(("receive_didcomm", options))
+        return [{"id": "msg-1", "message": {"body": {"content": "hello"}}}]
+
+    async def ack_didcomm(self, ids, options=None) -> int:
+        self.calls.append(("ack_didcomm", ids, options))
+        return 1
+
+    async def mediate_didcomm(self, options=None):
+        self.calls.append(("mediate_didcomm", options))
+        return {"forwarded": 2}
+
+    async def send_credential_didcomm(self, did, to, options=None):
+        self.calls.append(("send_credential_didcomm", did, to, options))
+        return ["msg-2"]
+
+    async def accept_credential_didcomm(self, message) -> bool:
+        self.calls.append(("accept_credential_didcomm", message))
+        return True
+
 
 @pytest.fixture
 def stub_service(monkeypatch: pytest.MonkeyPatch) -> StubService:
@@ -1469,4 +1521,84 @@ def test_poll_handlers(stub_service: StubService):
         ("add_poll_voter", "did:test:poll", "did:test:alice"),
         ("list_poll_voters", "did:test:poll"),
         ("remove_poll_voter", "did:test:poll", "did:test:alice"),
+    ]
+
+
+def test_capabilities_handler(stub_service: StubService):
+    assert run(app_module.capabilities()) == {"capabilities": {"didcomm": True, "lightning": False}}
+    assert stub_service.calls == [("get_node_capabilities",)]
+
+
+def test_address_publish_handlers(stub_service: StubService):
+    published = run(app_module.publish_address({"address": "bc1qtest", "name": "Alice"}))
+    unpublished = run(app_module.unpublish_address({"name": "Alice"}))
+    # The JS client sends no body at all for the bare case, so an absent body
+    # must not be a 422.
+    default = run(app_module.unpublish_address())
+
+    assert published == {"ok": True}
+    assert unpublished == {"ok": True}
+    assert default == {"ok": True}
+    assert stub_service.calls == [
+        ("publish_address", "bc1qtest", "Alice"),
+        ("unpublish_address", "Alice"),
+        ("unpublish_address", None),
+    ]
+
+
+def test_didcomm_handlers(stub_service: StubService):
+    # #920: none of these routes existed, so every SDK didcomm call 404'd against
+    # the Python flavor while working against the JS one.
+    message = {"type": "https://didcomm.org/basicmessage/2.0/message", "body": {"content": "hello"}}
+
+    published = run(app_module.publish_didcomm({"endpoint": "https://node.test/didcomm", "name": "Alice", "routingKeys": ["did:test:mediator"]}))
+    unpublished = run(app_module.unpublish_didcomm({"name": "Alice"}))
+    packed = run(app_module.pack_didcomm({"message": message, "to": "did:test:bob", "options": {"name": "Alice"}}))
+    unpacked = run(app_module.unpack_didcomm({"packed": "packed-envelope", "options": {"name": "Bob"}}))
+    sent = run(app_module.send_didcomm({"message": message, "to": ["did:test:bob"], "options": {"name": "Alice"}}))
+    received = run(app_module.receive_didcomm({"options": {"name": "Bob"}}))
+    acked = run(app_module.ack_didcomm({"ids": ["msg-1"], "options": {"name": "Bob"}}))
+    mediated = run(app_module.mediate_didcomm({"options": {"name": "Alice"}}))
+    credential_sent = run(app_module.send_credential_didcomm({"did": "did:test:credential", "to": "did:web:example.com", "options": {"name": "Alice"}}))
+    credential_accepted = run(app_module.accept_credential_didcomm({"message": message}))
+
+    # The response envelopes are the contract the SDK reads by key, so they are
+    # asserted whole rather than by presence.
+    assert published == {"ok": True}
+    assert unpublished == {"ok": True}
+    assert packed == {"packed": "packed-envelope"}
+    assert unpacked == {"result": {"message": {"body": {"content": "hello"}}, "metadata": {"sender": "did:test:alice"}}}
+    assert sent == {"ids": ["msg-1"]}
+    assert received == {"results": [{"id": "msg-1", "message": {"body": {"content": "hello"}}}]}
+    assert acked == {"acknowledged": 1}
+    assert mediated == {"result": {"forwarded": 2}}
+    assert credential_sent == {"ids": ["msg-2"]}
+    assert credential_accepted == {"ok": True}
+
+    assert stub_service.calls == [
+        # routingKeys is camelCase on the wire and snake_case in the library.
+        ("publish_didcomm", "https://node.test/didcomm", "Alice", ["did:test:mediator"]),
+        ("unpublish_didcomm", "Alice"),
+        ("pack_didcomm", message, "did:test:bob", {"name": "Alice"}),
+        ("unpack_didcomm", "packed-envelope", {"name": "Bob"}),
+        ("send_didcomm", message, ["did:test:bob"], {"name": "Alice"}),
+        ("receive_didcomm", {"name": "Bob"}),
+        ("ack_didcomm", ["msg-1"], {"name": "Bob"}),
+        ("mediate_didcomm", {"name": "Alice"}),
+        ("send_credential_didcomm", "did:test:credential", "did:web:example.com", {"name": "Alice"}),
+        ("accept_credential_didcomm", message),
+    ]
+
+
+def test_didcomm_handlers_tolerate_an_absent_body(stub_service: StubService):
+    # receive/mediate/unpublish take no required argument, and the JS clients
+    # send no body for them. FastAPI would 422 a required body parameter.
+    run(app_module.unpublish_didcomm())
+    run(app_module.receive_didcomm())
+    run(app_module.mediate_didcomm())
+
+    assert stub_service.calls == [
+        ("unpublish_didcomm", None),
+        ("receive_didcomm", None),
+        ("mediate_didcomm", None),
     ]

--- a/tests/keymaster/python-service-parity.test.ts
+++ b/tests/keymaster/python-service-parity.test.ts
@@ -1,0 +1,131 @@
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+// The Python keymaster service is meant to be a drop-in replacement for the JS
+// one -- same paths, same auth. Nothing checked that, and the result was #920:
+// the Python flavor served NONE of the DIDComm surface. Eleven SDK methods
+// worked against one flavor and 404'd against the other, silently, from the day
+// DIDComm landed (#633) until a review of #919 happened to notice.
+//
+// This compares the two route surfaces directly. It cannot tell whether the
+// handlers behave alike -- python/keymaster_service/tests/test_app_partial_parity.py
+// does that -- but a whole protocol going missing is exactly what it catches.
+
+const TS_DIR = 'services/keymaster/server/src';
+const TS_API = join(TS_DIR, 'keymaster-api.ts');
+const PY_APP = 'python/keymaster_service/src/keymaster_service/app.py';
+
+type Route = string; // "PROTECTED POST /didcomm/send"
+
+// Express `:name` and FastAPI `{name}` mean the same thing; the name itself is
+// local to each flavor and carries no contract.
+function normalize(path: string): string {
+    return path.replace(/:[A-Za-z_][A-Za-z0-9_]*/g, ':param').replace(/\{[A-Za-z_][A-Za-z0-9_]*\}/g, ':param');
+}
+
+// Which file defines each `createXRouter` mount. Found by looking for the
+// export rather than by transforming the name into a filename: createDidCommRouter
+// lives in keymaster-didcomm-router.ts, not keymaster-did-comm-router.ts, and a
+// name-mangling guess that misses drops that router from the comparison
+// entirely -- silently, which is the exact failure this file exists to catch.
+function routerFile(factory: string): string | undefined {
+    return readdirSync(TS_DIR)
+        .filter(name => name.endsWith('.ts'))
+        .find(name => new RegExp(`export function ${factory}\\b`).test(readFileSync(join(TS_DIR, name), 'utf-8')));
+}
+
+function tsRoutes(): Route[] {
+    const api = readFileSync(TS_API, 'utf-8');
+
+    // Everything mounted after createRequireAdminKey sits behind the admin key.
+    // Reading the mount order rather than hardcoding a list means a router moved
+    // across that line shows up here as the auth change it is.
+    const mounts = [...api.matchAll(/v1router\.use\((create[A-Za-z]+)\(/g)].map(m => m[1]);
+    const guard = mounts.indexOf('createRequireAdminKey');
+    expect(guard).toBeGreaterThan(-1);
+
+    const routes: Route[] = [];
+
+    for (const [index, factory] of mounts.entries()) {
+        if (factory === 'createRequireAdminKey') {
+            continue;
+        }
+
+        const file = routerFile(factory);
+        // Loudly, not by skipping: an unresolved router would quietly shrink the
+        // JS side of the comparison and make the parity assertions pass.
+        expect(file).toBeDefined();
+
+        const scope = index < guard ? 'PUBLIC' : 'PROTECTED';
+        const source = readFileSync(join(TS_DIR, file as string), 'utf-8');
+
+        for (const match of source.matchAll(/router\.(get|post|put|delete)\('([^']+)'/g)) {
+            routes.push(`${scope} ${match[1].toUpperCase()} ${normalize(match[2])}`);
+        }
+    }
+
+    return routes;
+}
+
+function pyRoutes(): Route[] {
+    const source = readFileSync(PY_APP, 'utf-8');
+
+    return [...source.matchAll(/@(public|protected)_api\.(get|post|put|delete)\("([^"]+)"/g)].map(
+        m => `${m[1].toUpperCase()} ${m[2].toUpperCase()} ${normalize(m[3])}`
+    );
+}
+
+describe('python keymaster service route parity', () => {
+    it('finds routes on both sides', () => {
+        // Guard the guard: a regex that silently stopped matching would make
+        // every comparison below vacuously true.
+        expect(tsRoutes().length).toBeGreaterThan(100);
+        expect(pyRoutes().length).toBeGreaterThan(100);
+    });
+
+    it('serves every route the JS service serves, with the same auth', () => {
+        const python = new Set(pyRoutes());
+        const missing = [...new Set(tsRoutes())].filter(route => !python.has(route)).sort();
+
+        expect(missing).toStrictEqual([]);
+    });
+
+    it('serves no route the JS service does not', () => {
+        // The other direction matters too: a Python-only endpoint is a surface
+        // no OpenAPI document describes and no JS client can reach.
+        const typescript = new Set(tsRoutes());
+        const extra = [...new Set(pyRoutes())].filter(route => !typescript.has(route)).sort();
+
+        expect(extra).toStrictEqual([]);
+    });
+
+    it('declares literal paths before the parameter templates that would swallow them', () => {
+        // FastAPI matches in declaration order, so `DELETE /addresses/{address}`
+        // declared first would take `DELETE /addresses/publish` and try to
+        // remove an address literally named "publish".
+        const source = readFileSync(PY_APP, 'utf-8');
+        const declared = [...source.matchAll(/@(?:public|protected)_api\.(get|post|put|delete)\("([^"]+)"/g)].map(
+            m => ({ method: m[1], path: m[2] })
+        );
+
+        const shadowed: string[] = [];
+
+        for (const [index, route] of declared.entries()) {
+            if (route.path.includes('{')) {
+                continue;
+            }
+
+            const earlier = declared.slice(0, index).find(other =>
+                other.method === route.method &&
+                other.path.includes('{') &&
+                new RegExp(`^${other.path.replace(/\{[^}]+\}/g, '[^/]+')}$`).test(route.path)
+            );
+
+            if (earlier) {
+                shadowed.push(`${route.method.toUpperCase()} ${route.path} is shadowed by ${earlier.path}`);
+            }
+        }
+
+        expect(shadowed).toStrictEqual([]);
+    });
+});


### PR DESCRIPTION
Closes #920.

`python/keymaster_service` registered **none** of the DIDComm routes. All eleven SDK didcomm methods fell through to the catch-all 404 against the Python flavor while working against the JS one — silently, since DIDComm landed in #633. The `keymaster` library has implemented every operation the whole time; only the FastAPI routing layer was missing, and nothing checked.

## Scope: 13 routes, not 10

The same gap covered two neighbours — `GET /capabilities` and `POST|DELETE /addresses/publish` — each a one-liner with the core method already present. Closing them too brings the two surfaces to **exact parity in both directions**, which is what lets the new guard assert zero divergence instead of carrying an allowlist that would rot.

## The guard

`tests/keymaster/python-service-parity.test.ts` compares the JS routers against `app.py`: paths, methods, and public-vs-protected. The auth scope is read from the mount order around `createRequireAdminKey` rather than a hardcoded list, so a router moved across that line shows up as the auth change it is.

It resolves each `createXRouter` to its file by looking for the `export function`, not by mangling the name into a filename. That matters — my first draft guessed `keymaster-did-comm-router.ts`, found nothing, `continue`d, and **passed**, having silently dropped the very router it was written to check. It now fails loudly on an unresolved router. Mutation-tested by renaming a route:

```
✕ serves every route the JS service serves, with the same auth
✕ serves no route the JS service does not
    +   "PROTECTED POST /didcomm/sendx",
```

## A live bug it found

`POST /polls/ballot/send` was declared *after* `POST /polls/{poll}/send`. FastAPI matches in declaration order, so the literal never won. Resolved through the real app on unmodified `main`:

```
POST   /api/v1/polls/ballot/send      -> send_poll        ← wrong
DELETE /api/v1/addresses/publish      -> remove_address   ← would have been, once added
```

and after:

```
POST   /api/v1/polls/ballot/send      -> send_ballot
POST   /api/v1/polls/abc/send         -> send_poll
DELETE /api/v1/addresses/publish      -> unpublish_address
DELETE /api/v1/addresses/bc1qxyz      -> remove_address
```

So sending a ballot on the Python service has been landing in `send_poll(poll="ballot")`. The JS router has always declared it in the correct order. There's now a test for that whole class of shadowing.

## Tests

Handler tests for all 13 in `test_app_partial_parity.py`, asserting the response envelopes whole (the SDK reads them by key) and the `routingKeys` → `routing_keys` casing hop. Plus a test that `receive`/`mediate`/`unpublish` tolerate an absent body, since the JS clients send none and FastAPI would 422 a required body parameter.

Verified against real FastAPI, not just the test stubs: all 13 register on the actual app and dispatch to the right handlers.

1079 JS, 26 Python service, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)