### PR TITLE
fix(ci): Seed native prebuilds in the three jobs that were missed

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Prefetch native prebuilds
+        run: node scripts/prefetch-prebuilds.mjs
+
       - name: Setup env for Testing
         working-directory: ./tests/cli-tests
         run: ./generate_test_env.sh
@@ -109,6 +112,9 @@ jobs:
       # it reaches either gatekeeper.
       - name: Build workspace packages
         run: npm run build
+
+      - name: Prefetch native prebuilds
+        run: node scripts/prefetch-prebuilds.mjs
 
       - name: Start both gatekeepers
         env:

--- a/.github/workflows/python-sdk-tests.yml
+++ b/.github/workflows/python-sdk-tests.yml
@@ -24,6 +24,14 @@ jobs:
           ./generate_test_env.sh
           cat ../../.env
 
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "22.23.2"
+
+      - name: Prefetch native prebuilds
+        run: node scripts/prefetch-prebuilds.mjs
+
       - name: Build images from this PR
         run: |
           docker compose build mongodb redis ipfs gatekeeper keymaster

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,8 @@
         "supertest": "^7.2.2",
         "swagger-jsdoc": "^6.2.8",
         "ts-jest": "^29.2.6",
-        "typescript": "^5.8.2"
+        "typescript": "^5.8.2",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": "22.23.x",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "supertest": "^7.2.2",
     "swagger-jsdoc": "^6.2.8",
     "ts-jest": "^29.2.6",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "yaml": "^2.9.0"
   }
 }

--- a/tests/ci/prebuild-seeding.test.ts
+++ b/tests/ci/prebuild-seeding.test.ts
@@ -55,27 +55,50 @@ function workflowFiles(): string[] {
     return readdirSync(WORKFLOW_DIR).filter(name => /\.ya?ml$/.test(name));
 }
 
+// The env vars prebuild-install reads, derived from the script's own target
+// list so the two cannot drift: adding a third native module there makes this
+// require it in the Dockerfiles too. prebuild-install lowercases the package
+// name and replaces every non-alphanumeric character with an underscore, so
+// `@ipshipyard/node-datachannel` becomes ipshipyard_node_datachannel.
+function expectedPrebuildVars(): string[] {
+    const script = readFileSync(join('scripts', 'prefetch-prebuilds.mjs'), 'utf-8');
+    const targets = [...script.matchAll(/\bname:\s*'([^']+)'/g)].map(m => m[1]);
+
+    expect(targets.length).toBeGreaterThan(0);
+
+    return targets.map(name => `npm_config_${name.replace(/^@/, '').replace(/[^a-zA-Z0-9]/g, '_')}_local_prebuilds`);
+}
+
 describe('native prebuild seeding', () => {
     it('finds workflows to check', () => {
         // Guard the guard: an empty listing would make the check below vacuous.
         expect(workflowFiles().length).toBeGreaterThan(0);
     });
 
-    it('seeds ./prebuilds in every job that builds a Docker image', () => {
+    it('seeds ./prebuilds before the first image build in every job that builds one', () => {
+        // Position matters, not mere presence: a prefetch step sitting after
+        // the build has already let that build fall back to the network, and a
+        // guard that only asked "is it in this job somewhere" would call that
+        // fine.
         const unseeded: string[] = [];
 
         for (const file of workflowFiles()) {
             for (const { id, steps } of jobs(file)) {
-                const builds = steps.some(step =>
+                const firstBuild = steps.findIndex(step =>
                     BUILD_PATTERNS.some(pattern => pattern.test(stepText(step)))
                 );
 
-                if (!builds) {
+                if (firstBuild === -1) {
                     continue;
                 }
 
-                if (!steps.some(step => stepText(step).includes(PREFETCH))) {
-                    unseeded.push(`${file}:${id}`);
+                const prefetch = steps.findIndex(step => stepText(step).includes(PREFETCH));
+
+                if (prefetch === -1) {
+                    unseeded.push(`${file}:${id} (no prefetch step)`);
+                }
+                else if (prefetch > firstBuild) {
+                    unseeded.push(`${file}:${id} (prefetch at step ${prefetch}, after build at ${firstBuild})`);
                 }
             }
         }
@@ -89,23 +112,29 @@ describe('native prebuild seeding', () => {
         expect(readdirSync('scripts')).toContain('prefetch-prebuilds.mjs');
     });
 
-    it('points every seeded image at the directory it seeds', () => {
+    it('points every seeded image at the directory it seeds, for every module', () => {
         // Seeding is useless unless the Dockerfile copies ./prebuilds in and
-        // tells prebuild-install to look there. A Dockerfile that copies the
-        // directory without setting the env var silently falls back to the
-        // network -- the failure this all exists to prevent.
-        const mismatched: string[] = [];
+        // tells prebuild-install to look there. Each module is checked by name:
+        // matching any *_local_prebuilds assignment would stay green if
+        // sqlite3's were dropped while node-datachannel's remained -- and
+        // sqlite3 is the module #913 is actually about.
+        const expected = expectedPrebuildVars();
+        const problems: string[] = [];
 
         for (const name of readdirSync('docker').filter(f => f.startsWith('Dockerfile.'))) {
             const source = readFileSync(join('docker', name), 'utf-8');
             const copies = /COPY\s+prebuilds\//.test(source);
-            const points = /_local_prebuilds=/.test(source);
+            const missing = expected.filter(variable => !source.includes(`${variable}=/prebuilds`));
 
-            if (copies !== points) {
-                mismatched.push(`${name} (copies=${copies}, points=${points})`);
+            if (copies && missing.length) {
+                problems.push(`${name} copies prebuilds/ but does not set ${missing.join(', ')}`);
+            }
+
+            if (!copies && missing.length < expected.length) {
+                problems.push(`${name} points at /prebuilds but never copies it in`);
             }
         }
 
-        expect(mismatched).toStrictEqual([]);
+        expect(problems).toStrictEqual([]);
     });
 });

--- a/tests/ci/prebuild-seeding.test.ts
+++ b/tests/ci/prebuild-seeding.test.ts
@@ -1,0 +1,111 @@
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { parse as parseYaml } from 'yaml';
+
+// sqlite3's install script is `prebuild-install -r napi || node-gyp rebuild`,
+// and the node:*-slim images have no Python or C++ toolchain -- so any hiccup
+// fetching the prebuilt binary escalates into a source build that cannot
+// succeed, and `npm ci` fails. #879 removed the network from that path by
+// seeding ./prebuilds before the image build.
+//
+// It seeded three workflows and missed the other three jobs that also build
+// images, which is #913: a spurious red check on PRs that changed nothing near
+// Docker, reported as a Python error when the cause is a node native module.
+//
+// A job either builds images or it does not; if it does, it must seed first.
+// Checked per job rather than per file, because docker-build-test.yml has two
+// image-building jobs and covering only one would look correct from the outside.
+
+const WORKFLOW_DIR = '.github/workflows';
+const PREFETCH = 'scripts/prefetch-prebuilds.mjs';
+
+// Anything that can cause a Dockerfile in this repo to run `npm ci`. Includes
+// start-node-ci, which wraps `docker compose build`, since a wrapper script
+// hides the build from a naive grep -- that is the shape of the miss this file
+// exists to catch.
+const BUILD_PATTERNS = [
+    /docker\s+compose[^\n]*\bbuild\b/,
+    /docker\s+compose[^\n]*--build\b/,
+    /docker\s+build\b/,
+    /docker\/build-push-action/,
+    /start-node-ci/,
+];
+
+interface Step {
+    run?: string;
+    uses?: string;
+}
+
+function stepText(step: Step): string {
+    return `${step.run ?? ''}\n${step.uses ?? ''}`;
+}
+
+function jobs(file: string): Array<{ id: string; steps: Step[] }> {
+    const parsed = parseYaml(readFileSync(join(WORKFLOW_DIR, file), 'utf-8')) as {
+        jobs?: Record<string, { steps?: Step[] }>;
+    };
+
+    return Object.entries(parsed?.jobs ?? {}).map(([id, job]) => ({
+        id,
+        steps: job?.steps ?? [],
+    }));
+}
+
+function workflowFiles(): string[] {
+    return readdirSync(WORKFLOW_DIR).filter(name => /\.ya?ml$/.test(name));
+}
+
+describe('native prebuild seeding', () => {
+    it('finds workflows to check', () => {
+        // Guard the guard: an empty listing would make the check below vacuous.
+        expect(workflowFiles().length).toBeGreaterThan(0);
+    });
+
+    it('seeds ./prebuilds in every job that builds a Docker image', () => {
+        const unseeded: string[] = [];
+
+        for (const file of workflowFiles()) {
+            for (const { id, steps } of jobs(file)) {
+                const builds = steps.some(step =>
+                    BUILD_PATTERNS.some(pattern => pattern.test(stepText(step)))
+                );
+
+                if (!builds) {
+                    continue;
+                }
+
+                if (!steps.some(step => stepText(step).includes(PREFETCH))) {
+                    unseeded.push(`${file}:${id}`);
+                }
+            }
+        }
+
+        expect(unseeded).toStrictEqual([]);
+    });
+
+    it('has a prefetch script for those jobs to run', () => {
+        // The step above is a string match, so it would keep passing if the
+        // script were renamed or removed.
+        expect(readdirSync('scripts')).toContain('prefetch-prebuilds.mjs');
+    });
+
+    it('points every seeded image at the directory it seeds', () => {
+        // Seeding is useless unless the Dockerfile copies ./prebuilds in and
+        // tells prebuild-install to look there. A Dockerfile that copies the
+        // directory without setting the env var silently falls back to the
+        // network -- the failure this all exists to prevent.
+        const mismatched: string[] = [];
+
+        for (const name of readdirSync('docker').filter(f => f.startsWith('Dockerfile.'))) {
+            const source = readFileSync(join('docker', name), 'utf-8');
+            const copies = /COPY\s+prebuilds\//.test(source);
+            const points = /_local_prebuilds=/.test(source);
+
+            if (copies !== points) {
+                mismatched.push(`${name} (copies=${copies}, points=${points})`);
+            }
+        }
+
+        expect(mismatched).toStrictEqual([]);
+    });
+});


### PR DESCRIPTION
Closes #913.

**This isn't a new problem — it's an incomplete rollout.** #879 already removed the network from this path by seeding `./prebuilds` before the image build. Its own commit message says it covered *"the three workflows that now run the prefetch"* — but **six jobs build images**, and three were left out:

| Job | How it builds | Why it was missed |
| --- | --- | --- |
| `python-sdk-tests.yml` | `docker compose build` | never had a Node setup step at all — where #913's failure was observed |
| `docker-build-test.yml :: build_test_images` | `start-node-ci` | the wrapper hides `docker compose build` from a grep of the workflow |
| `docker-build-test.yml :: gatekeeper_parity` | `up -d --build` | — |

All three are PR-triggered, which is exactly why the symptom was *"every PR is exposed to a spurious red check"*.

## On option 3

The issue asked to check first whether the images use sqlite3 at all. They do — `services/keymaster/server/src/keymaster-api.ts:12` imports `WalletSQLite` statically and instantiates it at `:256`; the gatekeeper imports it dynamically at `gatekeeper-api.ts:384`. It's a supported backend, so removing it was never on the table.

## The guard

`tests/ci/prebuild-seeding.test.ts` checks **per job**, not per file — `docker-build-test.yml` has two image-building jobs, and covering only one would look correct from the outside, which is close to how the original miss happened. It parses the YAML rather than grepping, and its build-detection patterns include `start-node-ci` precisely because a wrapper script is what hid one of these.

It also checks the other half of the contract: a Dockerfile that copies `prebuilds/` must point `prebuild-install` at it, since one without the other silently falls back to the network — the exact failure being prevented.

Mutation-tested three ways:

| Mutation | Result |
| --- | --- |
| revert `python-sdk-tests.yml` to its broken state | ✕ seeds ./prebuilds in every job… |
| drop the prefetch from **only the second** job of `docker-build-test.yml` | ✕ seeds ./prebuilds in every job… |
| Dockerfile copies `prebuilds/` but drops the env var | ✕ points every seeded image at the directory it seeds |

And I ran the prefetch script rather than assuming it still works — all four tarballs fetched (sqlite3 and node-datachannel, x64 and arm64).

## Note

`tests/ci` uses `yaml` rather than `js-yaml` because it ships its own types, so this declares one dependency instead of two. Both were undeclared transitives — the same hazard #924's review caught with `@types/express`. Incidentally, the typecheck gate added in #924 caught this on its first real use: the original `js-yaml` import failed `npm run typecheck` while the suite passed green.

2252 tests pass, typecheck 0 errors, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)