### PR TITLE
fix(deps): Declare @noble/curves at the root, where a test depends on it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@commitlint/cli": "^20.2.0",
         "@commitlint/config-conventional": "^20.2.0",
+        "@noble/curves": "^2.3.0",
         "@types/chrome": "^0.2.5",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
@@ -5739,12 +5740,12 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
-      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.3.0.tgz",
+      "integrity": "sha512-v7cY+4oWYPQszRj6ZFGzTVL7uP2TaLo1xMhWHzYC5wj0ZhOXQ5x+sBre8rF3hi8cAoi0bh1qXoovoOkdFtvqEg==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.0.1"
+        "@noble/hashes": "2.3.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -5754,9 +5755,9 @@
       }
     },
     "node_modules/@noble/curves/node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@commitlint/cli": "^20.2.0",
     "@commitlint/config-conventional": "^20.2.0",
+    "@noble/curves": "^2.3.0",
     "@types/chrome": "^0.2.5",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",

--- a/tests/keymaster/nostr.test.ts
+++ b/tests/keymaster/nostr.test.ts
@@ -6,9 +6,20 @@ import WalletJsonMemory from '@didcid/keymaster/wallet/json-memory';
 import { UnknownIDError } from '@didcid/common/errors';
 import HeliaClient from '@didcid/ipfs/helia';
 import { bech32 } from 'bech32';
-// The root has @noble/curves 2.x, which exports './secp256k1.js' only, while
-// packages/cipher pins 1.9.7 where the extensionless specifier still resolves.
-// jest finds the file either way; the type resolver does not.
+// Deliberately a DIFFERENT copy of @noble/curves than the one that signed:
+// packages/cipher pins 1.9.7, and this resolves the root's 2.x. Nostr
+// signatures have to be verifiable by other people's software, so checking
+// them with an independent implementation is the point rather than an
+// accident -- it is what makes this an interop test instead of a round trip
+// through one library.
+//
+// The root dependency is declared for that reason (#925). It used to arrive
+// only because @libp2p/crypto happened to hoist it, so a dependency change
+// could have quietly collapsed both sides onto one copy and this would have
+// kept passing while proving nothing.
+//
+// The explicit '.js' is required: 2.x exports './secp256k1.js' only, where
+// 1.x still resolved the extensionless specifier.
 import { schnorr } from '@noble/curves/secp256k1.js';
 
 let ipfs: HeliaClient;


### PR DESCRIPTION
Item 1 of #925. Deliberately narrow: this declares an existing dependency and leaves the version split in place.

## Why it matters

`tests/keymaster/nostr.test.ts` verifies schnorr signatures with a copy of `@noble/curves` that is **not** the one that signed them — `packages/cipher` pins 1.9.7, the test resolves the root's 2.x.

On reflection that asymmetry is the right test design, not the bug I first took it for. Nostr signatures have to be verifiable by other people's software, so checking them with an independent implementation is what makes this an interop test rather than a round trip through one library.

The actual defect was that the root copy was **undeclared** — present only because `@libp2p/crypto` happens to hoist it:

```
archon@0.12.0
├─┬ @didcid/cipher@0.4.2 -> ./packages/cipher
│ └── @noble/curves@1.9.7
└─┬ @didcid/ipfs@0.3.2 -> ./packages/ipfs
  └─┬ kubo-rpc-client@5.4.1
    └─┬ @libp2p/crypto@5.1.13
      └── @noble/curves@2.0.1
```

A dependency change could legally have collapsed both sides onto one copy, and the test would have kept passing while silently proving nothing. Same undeclared-but-relied-upon hazard #924's review caught with `@types/express`.

## One thing to know

Declaring it moved the resolved version **2.0.1 → 2.3.0**, because 2.0.1 was never chosen — it was whatever `@libp2p/crypto`'s range happened to land on. That copy is also used at runtime by helia and kubo, so I verified rather than assumed: the interop test, the 63 `tests/cipher` tests, and the full 2252-test suite all pass on 2.3.0.

## What this does not do

`packages/cipher` stays on 1.9.7 on purpose. Moving it to 2.x means two breaking renames in the key-agreement path every DIDComm envelope depends on:

| 1.9.7 | 2.x |
| --- | --- |
| `x25519.utils.randomPrivateKey()` | `randomSecretKey()` |
| `edwardsToMontgomeryPub()` | `utils.toMontgomery()` — no longer a top-level export |

Small and mechanical, but it buys nothing today. #925 stays open for that, and records the gate if it is ever done: the committed JS→Python envelope vectors in `python/keymaster/tests/test_didcomm.py` decrypt TypeScript-produced envelopes in Python, so an x25519 behaviour change fails loudly.

typecheck 0, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)