### PR TITLE
feat(gatekeeper): Label the resolution result, and stop faking Accept

### DIFF
--- a/docs/gatekeeper-api.json
+++ b/docs/gatekeeper-api.json
@@ -2477,6 +2477,9 @@
           "404": {
             "description": "The DID does not exist or cannot be resolved (error in didResolutionMetadata)."
           },
+          "406": {
+            "description": "The Accept header names only representations this endpoint cannot produce (representationNotSupported in didResolutionMetadata). Supported values are application/did+ld+json, application/did+json and application/did-resolution.\n"
+          },
           "500": {
             "description": "Internal Server Error."
           }

--- a/docs/scheme.md
+++ b/docs/scheme.md
@@ -357,12 +357,27 @@ The method-specific `confirmed` and `timestamp` fields are **not** DID Core docu
 
 ### Representations
 
-The resolver negotiates the DID document representation from the `Accept` request header, and echoes the selected media type in both the `Content-Type` response header and `didResolutionMetadata.contentType`:
+The resolver negotiates from the `Accept` request header:
 
-| `Accept` | Representation |
-|----------|----------------|
-| `application/did+ld+json` (or absent) | JSON-LD — the default |
-| `application/did+json` | Plain JSON |
+| `Accept` | `Content-Type` | `didResolutionMetadata.contentType` |
+|----------|----------------|-------------------------------------|
+| absent, `*/*`, `application/*` | `application/did+ld+json` | `application/did+ld+json` |
+| `application/did+ld+json` | `application/did+ld+json` | `application/did+ld+json` |
+| `application/did+json` | `application/did+json` | `application/did+json` |
+| `application/did-resolution` | `application/did-resolution` | `application/did+ld+json` |
+| anything else | — | 406 `representationNotSupported` |
+
+`application/did+ld+json` and `application/did+json` are DID **document**
+representation media types, and this endpoint returns the resolution result
+triple. A client that wants the result labelled for what it is asks for
+`application/did-resolution`; the document types remain the default because
+Universal Resolver drivers expect them. Note that `didResolutionMetadata.contentType`
+always reports a document representation — that field describes the representation
+of the document inside the envelope, not the envelope.
+
+An `Accept` naming only media types this endpoint cannot produce is answered
+`406` with `didResolutionMetadata.error` set to `representationNotSupported`,
+rather than silently returning JSON-LD.
 
 Responses set `Vary: Accept`. This applies to the resolution result only; the `/data` and `/registration` resources are plain `application/json`.
 

--- a/docs/services/gatekeeper/README.md
+++ b/docs/services/gatekeeper/README.md
@@ -671,11 +671,19 @@ by the DID Resolution data model:
 ```
 
 `Accept: application/did+json` and `Accept: application/did+ld+json` are
-honored for successful resolution responses. The selected representation is
-returned as both the HTTP `Content-Type` and
-`didResolutionMetadata.contentType`. Volatile fields such as
-`didResolutionMetadata.retrieved` are omitted from this surface so generated
-W3C DID test-suite fixtures remain stable.
+honored for successful resolution responses, and are the default. Because both
+describe a DID *document* while this endpoint returns the resolution triple, a
+client may instead ask for `Accept: application/did-resolution` to have the
+result labelled for what it is; `didResolutionMetadata.contentType` continues to
+report the document representation either way, since it describes what is inside
+the envelope.
+
+An `Accept` header naming only media types this endpoint cannot produce is
+answered `406` with `didResolutionMetadata.error` set to
+`representationNotSupported`.
+
+Volatile fields such as `didResolutionMetadata.retrieved` are omitted from this
+surface so generated W3C DID test-suite fixtures remain stable.
 
 `didDocumentData` and `didDocumentRegistration` (present inline in the
 internal [`DidCidDocument`](#37-didciddocument-resolution-result)) MUST be

--- a/rust/services/gatekeeper/src/api.rs
+++ b/rust/services/gatekeeper/src/api.rs
@@ -1311,15 +1311,19 @@ pub(crate) async fn conformant_resolve_did(
                     406,
                     start.elapsed().as_secs_f64(),
                 );
-                return (
+                // Vary, because this response was selected by Accept: without it
+                // a cache can serve the 406 to a client that would have been
+                // satisfied, or vice versa. json_response_with_content_type sets
+                // it on every negotiated success, so the error must match.
+                return json_response_with_content_type(
                     StatusCode::NOT_ACCEPTABLE,
-                    Json(json!({
+                    json!({
                         "didDocument": Value::Null,
                         "didResolutionMetadata": { "error": "representationNotSupported" },
                         "didDocumentMetadata": {}
-                    })),
-                )
-                    .into_response();
+                    }),
+                    "application/json",
+                );
             };
             let content_type = negotiated.content_type;
             let mut did_resolution_metadata = doc
@@ -1511,12 +1515,22 @@ fn negotiate_did_content_type(headers: &HeaderMap) -> Option<Negotiated> {
     }
 }
 
+// RFC 7231 5.3.2: "If more than one media range applies to a given type, the
+// most specific reference has precedence." So the quality for a candidate comes
+// from the most specific entry that matches it -- NOT the highest q across all
+// matching entries. The difference decides `application/did+ld+json;q=0,
+// application/did+json;q=0.5, */*;q=1`: taking the maximum gives the excluded
+// type q=1 from the wildcard and serves exactly what the client refused.
+const EXACT: u8 = 3;
+const TYPE_WILDCARD: u8 = 2;
+const GLOBAL_WILDCARD: u8 = 1;
+
 fn accept_quality(accept: &str, candidate: &str) -> Option<(f32, usize)> {
     accept_quality_inner(accept, candidate, true)
 }
 
 fn accept_quality_inner(accept: &str, candidate: &str, allow_wildcard: bool) -> Option<(f32, usize)> {
-    let mut best = None;
+    let mut best: Option<(u8, f32, usize)> = None;
     let normalized_candidate = candidate.to_ascii_lowercase();
 
     for (order, part) in accept.split(',').enumerate() {
@@ -1537,21 +1551,39 @@ fn accept_quality_inner(accept: &str, candidate: &str, allow_wildcard: bool) -> 
             }
         }
 
-        let matches = media == normalized_candidate
-            || (allow_wildcard && (media == "application/*" || media == "*/*"));
-        if !matches || q <= 0.0 {
+        let specificity = if media == normalized_candidate {
+            EXACT
+        } else if media == "application/*" {
+            TYPE_WILDCARD
+        } else if media == "*/*" {
+            GLOBAL_WILDCARD
+        } else {
+            0
+        };
+
+        if specificity == 0 || (!allow_wildcard && specificity != EXACT) {
             continue;
         }
 
+        // Deliberately no `q <= 0.0` filter here: a q=0 on the most specific
+        // entry is the client excluding this type, and must beat a permissive
+        // wildcard rather than be skipped over in favour of one.
         if best
-            .map(|(best_q, best_order)| q > best_q || (q == best_q && order < best_order))
+            .map(|(best_spec, best_q, best_order)| {
+                specificity > best_spec
+                    || (specificity == best_spec
+                        && (q > best_q || (q == best_q && order < best_order)))
+            })
             .unwrap_or(true)
         {
-            best = Some((q, order));
+            best = Some((specificity, q, order));
         }
     }
 
-    best
+    match best {
+        Some((_, q, order)) if q > 0.0 => Some((q, order)),
+        _ => None,
+    }
 }
 
 fn json_response_with_content_type(

--- a/rust/services/gatekeeper/src/api.rs
+++ b/rust/services/gatekeeper/src/api.rs
@@ -1300,7 +1300,28 @@ pub(crate) async fn conformant_resolve_did(
     let start = Instant::now();
     match resolve_conformant(&state, &did, &query).await {
         Ok(doc) => {
-            let content_type = preferred_did_content_type(&headers);
+            let Some(negotiated) = negotiate_did_content_type(&headers) else {
+                // The client named representations, none of which this endpoint
+                // produces. Previously any Accept was satisfied with JSON-LD and a
+                // 200, which contradicted the supportedContentTypes we publish (#770).
+                record_metrics(
+                    &state,
+                    "GET",
+                    "/1.0/identifiers/:did",
+                    406,
+                    start.elapsed().as_secs_f64(),
+                );
+                return (
+                    StatusCode::NOT_ACCEPTABLE,
+                    Json(json!({
+                        "didDocument": Value::Null,
+                        "didResolutionMetadata": { "error": "representationNotSupported" },
+                        "didDocumentMetadata": {}
+                    })),
+                )
+                    .into_response();
+            };
+            let content_type = negotiated.content_type;
             let mut did_resolution_metadata = doc
                 .get("didResolutionMetadata")
                 .cloned()
@@ -1309,10 +1330,10 @@ pub(crate) async fn conformant_resolve_did(
                 metadata.remove("retrieved");
                 metadata.insert(
                     "contentType".to_string(),
-                    Value::String(content_type.to_string()),
+                    Value::String(negotiated.representation.to_string()),
                 );
             } else {
-                did_resolution_metadata = json!({ "contentType": content_type });
+                did_resolution_metadata = json!({ "contentType": negotiated.representation });
             }
             let triple = json!({
                 "didDocument": doc.get("didDocument").cloned().unwrap_or(Value::Null),
@@ -1409,35 +1430,92 @@ fn build_registration_resource(doc: &Value) -> Value {
     registration
 }
 
-fn preferred_did_content_type(headers: &HeaderMap) -> &'static str {
-    const DID_LD_JSON: &str = "application/did+ld+json";
-    const DID_JSON: &str = "application/did+json";
+const DID_LD_JSON: &str = "application/did+ld+json";
+const DID_JSON: &str = "application/did+json";
+// The media type for a resolution result. did+ld+json and did+json describe a DID
+// *document*; this endpoint answers with the {didDocument, didResolutionMetadata,
+// didDocumentMetadata} triple, which is a different thing (#770).
+const DID_RESOLUTION: &str = "application/did-resolution";
 
+/// What goes on the wire, and what didResolutionMetadata.contentType reports.
+/// The latter is always a document representation: that field describes the
+/// representation of the returned document, not the shape of the envelope.
+struct Negotiated {
+    content_type: &'static str,
+    representation: &'static str,
+}
+
+/// Returns None when the client asked for something this endpoint cannot
+/// produce, which the caller reports as representationNotSupported.
+///
+/// A client gets application/did-resolution only by naming it. The default stays
+/// the document media types, because that is what Universal Resolver drivers in
+/// the wild expect and changing it silently would break them.
+fn negotiate_did_content_type(headers: &HeaderMap) -> Option<Negotiated> {
     let Some(accept) = headers
         .get(header::ACCEPT)
         .and_then(|value| value.to_str().ok())
     else {
-        return DID_LD_JSON;
+        return Some(Negotiated {
+            content_type: DID_LD_JSON,
+            representation: DID_LD_JSON,
+        });
     };
 
+    // Wildcards satisfy the document types but never select the resolution
+    // envelope, so `Accept: */*` keeps behaving exactly as before. Belt and
+    // braces rather than load-bearing: accept_quality takes the best match across
+    // entries, so a wildcard gives the document types whatever quality it gives
+    // the envelope, and the tie below favours the document. Stated explicitly so
+    // a future change to that scoring cannot quietly hand `*/*` the envelope.
+    let resolution = accept_quality_inner(accept, DID_RESOLUTION, false);
     let ld = accept_quality(accept, DID_LD_JSON);
     let json = accept_quality(accept, DID_JSON);
 
-    match (ld, json) {
+    let document = match (ld, json) {
         (Some((ld_q, ld_order)), Some((json_q, json_order))) => {
             if json_q > ld_q || (json_q == ld_q && json_order < ld_order) {
-                DID_JSON
+                Some((DID_JSON, (json_q, json_order)))
             } else {
-                DID_LD_JSON
+                Some((DID_LD_JSON, (ld_q, ld_order)))
             }
         }
-        (Some(_), None) => DID_LD_JSON,
-        (None, Some(_)) => DID_JSON,
-        (None, None) => DID_LD_JSON,
+        (Some(ld_hit), None) => Some((DID_LD_JSON, ld_hit)),
+        (None, Some(json_hit)) => Some((DID_JSON, json_hit)),
+        (None, None) => None,
+    };
+
+    match (resolution, document) {
+        (Some((res_q, res_order)), Some((doc_type, (doc_q, doc_order)))) => {
+            if res_q > doc_q || (res_q == doc_q && res_order < doc_order) {
+                Some(Negotiated {
+                    content_type: DID_RESOLUTION,
+                    representation: DID_LD_JSON,
+                })
+            } else {
+                Some(Negotiated {
+                    content_type: doc_type,
+                    representation: doc_type,
+                })
+            }
+        }
+        (Some(_), None) => Some(Negotiated {
+            content_type: DID_RESOLUTION,
+            representation: DID_LD_JSON,
+        }),
+        (None, Some((doc_type, _))) => Some(Negotiated {
+            content_type: doc_type,
+            representation: doc_type,
+        }),
+        (None, None) => None,
     }
 }
 
 fn accept_quality(accept: &str, candidate: &str) -> Option<(f32, usize)> {
+    accept_quality_inner(accept, candidate, true)
+}
+
+fn accept_quality_inner(accept: &str, candidate: &str, allow_wildcard: bool) -> Option<(f32, usize)> {
     let mut best = None;
     let normalized_candidate = candidate.to_ascii_lowercase();
 
@@ -1459,8 +1537,8 @@ fn accept_quality(accept: &str, candidate: &str) -> Option<(f32, usize)> {
             }
         }
 
-        let matches =
-            media == normalized_candidate || media == "application/*" || media == "*/*";
+        let matches = media == normalized_candidate
+            || (allow_wildcard && (media == "application/*" || media == "*/*"));
         if !matches || q <= 0.0 {
             continue;
         }

--- a/rust/services/gatekeeper/tests/http_contract.rs
+++ b/rust/services/gatekeeper/tests/http_contract.rs
@@ -356,6 +356,14 @@ async fn universal_resolver_surface_returns_fixture_stable_did_resolution_result
         .send()
         .await?;
     assert_eq!(response.status().as_u16(), 406);
+    // Accept selected this response, so a cache must key on it.
+    assert_eq!(
+        response
+            .headers()
+            .get("vary")
+            .and_then(|value| value.to_str().ok()),
+        Some("Accept")
+    );
     let doc = response.json::<Value>().await?;
     assert_eq!(
         doc["didResolutionMetadata"]["error"],
@@ -363,6 +371,46 @@ async fn universal_resolver_surface_returns_fixture_stable_did_resolution_result
     );
     assert!(doc["didDocument"].is_null());
     assert_eq!(doc["didDocumentMetadata"].as_object().unwrap().len(), 0);
+
+    // RFC 7231 5.3.2: the most specific matching range supplies the quality.
+    // Taking the highest q across all matching ranges instead would give the
+    // excluded type q=1 from the wildcard and serve exactly what the client
+    // refused.
+    let response = service
+        .client
+        .get(format!("{}/1.0/identifiers/{did}", service.root_url))
+        .header(
+            "accept",
+            "application/did+ld+json;q=0, application/did+json;q=0.5, */*;q=1",
+        )
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("application/did+json"),
+        "an explicit q=0 must exclude a type even when a wildcard would allow it"
+    );
+
+    // And when q=0 excludes everything this endpoint can produce, that is a 406.
+    let response = service
+        .client
+        .get(format!("{}/1.0/identifiers/{did}", service.root_url))
+        .header(
+            "accept",
+            "application/did+ld+json;q=0, application/did+json;q=0, */*;q=1",
+        )
+        .send()
+        .await?;
+    assert_eq!(response.status().as_u16(), 406);
+    let doc = response.json::<Value>().await?;
+    assert_eq!(
+        doc["didResolutionMetadata"]["error"],
+        "representationNotSupported"
+    );
 
     Ok(())
 }

--- a/rust/services/gatekeeper/tests/http_contract.rs
+++ b/rust/services/gatekeeper/tests/http_contract.rs
@@ -264,6 +264,106 @@ async fn universal_resolver_surface_returns_fixture_stable_did_resolution_result
         "application/did+json"
     );
 
+    // #770: did+ld+json and did+json describe a DID *document*, and this endpoint
+    // answers with the resolution triple. A client that names the resolution media
+    // type gets it labelled correctly; the document types stay the default because
+    // Universal Resolver drivers expect them.
+    let response = service
+        .client
+        .get(format!("{}/1.0/identifiers/{did}", service.root_url))
+        .header("accept", "application/did-resolution")
+        .send()
+        .await?;
+    assert!(response.status().is_success());
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("application/did-resolution")
+    );
+    let doc = response.json::<Value>().await?;
+    assert_eq!(doc.as_object().unwrap().len(), 3);
+    assert_eq!(doc["didDocument"]["id"], did);
+    // Still the DOCUMENT representation: that field describes what is inside the
+    // envelope, not the envelope itself.
+    assert_eq!(
+        doc["didResolutionMetadata"]["contentType"],
+        "application/did+ld+json"
+    );
+
+    // A wildcard satisfies the document types but must not select the envelope.
+    for accept in ["*/*", "application/*"] {
+        let response = service
+            .client
+            .get(format!("{}/1.0/identifiers/{did}", service.root_url))
+            .header("accept", accept)
+            .send()
+            .await?;
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok()),
+            Some("application/did+ld+json"),
+            "wildcard {accept} must not select the resolution envelope"
+        );
+    }
+
+    // A wildcard alongside a lower-q explicit type. Both flavors answer
+    // did+ld+json: the wildcard gives every document type q=1, which beats the
+    // explicitly named did+json at q=0.5. Pinned because it is what a lenient UR
+    // driver sends and the two implementations must not drift on it.
+    let response = service
+        .client
+        .get(format!("{}/1.0/identifiers/{did}", service.root_url))
+        .header("accept", "*/*;q=1, application/did+json;q=0.5")
+        .send()
+        .await?;
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("application/did+ld+json")
+    );
+
+    // q-values decide between the envelope and the document types.
+    let response = service
+        .client
+        .get(format!("{}/1.0/identifiers/{did}", service.root_url))
+        .header(
+            "accept",
+            "application/did-resolution;q=0.4, application/did+json;q=0.9",
+        )
+        .send()
+        .await?;
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("application/did+json")
+    );
+
+    // #770: any Accept used to be satisfied with JSON-LD and a 200, which
+    // contradicted the supportedContentTypes published in the DID test suite
+    // fixture. The result stays triple-shaped, as errors do on this surface.
+    let response = service
+        .client
+        .get(format!("{}/1.0/identifiers/{did}", service.root_url))
+        .header("accept", "application/xml")
+        .send()
+        .await?;
+    assert_eq!(response.status().as_u16(), 406);
+    let doc = response.json::<Value>().await?;
+    assert_eq!(
+        doc["didResolutionMetadata"]["error"],
+        "representationNotSupported"
+    );
+    assert!(doc["didDocument"].is_null());
+    assert_eq!(doc["didDocumentMetadata"].as_object().unwrap().len(), 0);
+
     Ok(())
 }
 

--- a/services/gatekeeper/server/src/identifiers-router.ts
+++ b/services/gatekeeper/server/src/identifiers-router.ts
@@ -18,29 +18,77 @@ function classifyResolveError(error: unknown): { status: number; resolutionError
 
 const DID_LD_JSON = 'application/did+ld+json';
 const DID_JSON = 'application/did+json';
+// The media type for a resolution result. did+ld+json and did+json describe a DID
+// *document*; this endpoint answers with the {didDocument, didResolutionMetadata,
+// didDocumentMetadata} triple, which is a different thing (#770).
+const DID_RESOLUTION = 'application/did-resolution';
 
-function preferredDidContentType(req: express.Request): typeof DID_LD_JSON | typeof DID_JSON {
+type DocumentRepresentation = typeof DID_LD_JSON | typeof DID_JSON;
+
+interface Negotiated {
+    // What goes on the wire.
+    contentType: string;
+    // What didResolutionMetadata.contentType reports. Always a document
+    // representation: that field describes the representation of the returned
+    // document, not the shape of the envelope around it.
+    representation: DocumentRepresentation;
+}
+
+// Returns undefined when the client asked for something this endpoint cannot
+// produce, which the caller reports as representationNotSupported.
+//
+// A client gets application/did-resolution only by naming it. The default stays
+// the document media types, because that is what Universal Resolver drivers in
+// the wild expect and changing it silently would break them.
+function negotiateDidContentType(req: express.Request): Negotiated | undefined {
     const accept = req.get('accept');
 
     if (!accept) {
-        return DID_LD_JSON;
+        return { contentType: DID_LD_JSON, representation: DID_LD_JSON };
     }
 
+    const resolution = acceptQuality(accept, DID_RESOLUTION, { allowWildcard: false });
     const ld = acceptQuality(accept, DID_LD_JSON);
     const json = acceptQuality(accept, DID_JSON);
 
-    if (ld && json) {
-        return json.quality > ld.quality || (json.quality === ld.quality && json.order < ld.order)
-            ? DID_JSON
-            : DID_LD_JSON;
+    // Wildcards satisfy the document types but never select the resolution
+    // envelope, so `Accept: */*` keeps behaving exactly as before. Belt and
+    // braces rather than load-bearing: acceptQuality takes the best match across
+    // entries, so a wildcard gives the document types whatever quality it gives
+    // the envelope, and the tie below favours the document. Stated explicitly so
+    // a future change to that scoring cannot quietly hand `*/*` the envelope.
+    const document: DocumentRepresentation | undefined = (ld && json)
+        ? (json.quality > ld.quality || (json.quality === ld.quality && json.order < ld.order) ? DID_JSON : DID_LD_JSON)
+        : json ? DID_JSON
+            : ld ? DID_LD_JSON
+                : undefined;
+
+    if (resolution && document) {
+        const documentQuality = document === DID_JSON ? json! : ld!;
+        const resolutionWins = resolution.quality > documentQuality.quality
+            || (resolution.quality === documentQuality.quality && resolution.order < documentQuality.order);
+        return resolutionWins
+            ? { contentType: DID_RESOLUTION, representation: DID_LD_JSON }
+            : { contentType: document, representation: document };
     }
-    if (json) {
-        return DID_JSON;
+
+    if (resolution) {
+        return { contentType: DID_RESOLUTION, representation: DID_LD_JSON };
     }
-    return DID_LD_JSON;
+
+    if (document) {
+        return { contentType: document, representation: document };
+    }
+
+    return undefined;
 }
 
-function acceptQuality(accept: string, candidate: string): { quality: number; order: number } | undefined {
+function acceptQuality(
+    accept: string,
+    candidate: string,
+    options: { allowWildcard?: boolean } = {}
+): { quality: number; order: number } | undefined {
+    const allowWildcard = options.allowWildcard !== false;
     let best: { quality: number; order: number } | undefined;
     const normalizedCandidate = candidate.toLowerCase();
 
@@ -59,7 +107,8 @@ function acceptQuality(accept: string, candidate: string): { quality: number; or
             }
         }
 
-        const matches = media === normalizedCandidate || media === 'application/*' || media === '*/*';
+        const matches = media === normalizedCandidate
+            || (allowWildcard && (media === 'application/*' || media === '*/*'));
         if (!matches || quality <= 0) {
             return;
         }
@@ -231,6 +280,11 @@ export function createIdentifiersRouter(
      *         description: The DID is syntactically invalid (error in didResolutionMetadata).
      *       404:
      *         description: The DID does not exist or cannot be resolved (error in didResolutionMetadata).
+     *       406:
+     *         description: >
+     *           The Accept header names only representations this endpoint cannot produce
+     *           (representationNotSupported in didResolutionMetadata). Supported values are
+     *           application/did+ld+json, application/did+json and application/did-resolution.
      *       500:
      *         description: Internal Server Error.
      */
@@ -251,12 +305,25 @@ export function createIdentifiersRouter(
             // Conformant result: only the standard triple. The method-specific data and
             // registration objects are dereferenced via their own resource paths.
             const { didDocument, didResolutionMetadata, didDocumentMetadata } = result.doc;
-            const contentType = preferredDidContentType(req);
+            const negotiated = negotiateDidContentType(req);
+
+            if (!negotiated) {
+                // The client named representations, none of which this endpoint
+                // produces. Previously any Accept was satisfied with JSON-LD and a
+                // 200, which contradicted the supportedContentTypes we publish (#770).
+                res.status(406).json({
+                    didDocument: null,
+                    didResolutionMetadata: { error: 'representationNotSupported' },
+                    didDocumentMetadata: {},
+                });
+                return;
+            }
+
             const stableDidResolutionMetadata = { ...(didResolutionMetadata ?? {}) };
             delete stableDidResolutionMetadata.retrieved;
-            stableDidResolutionMetadata.contentType = contentType;
+            stableDidResolutionMetadata.contentType = negotiated.representation;
 
-            sendDidResolutionJson(res, contentType, {
+            sendDidResolutionJson(res, negotiated.contentType, {
                 didDocument,
                 didResolutionMetadata: stableDidResolutionMetadata,
                 didDocumentMetadata: normalizeDidDocumentMetadata(didDocumentMetadata),

--- a/services/gatekeeper/server/src/identifiers-router.ts
+++ b/services/gatekeeper/server/src/identifiers-router.ts
@@ -83,13 +83,23 @@ function negotiateDidContentType(req: express.Request): Negotiated | undefined {
     return undefined;
 }
 
+// RFC 7231 5.3.2: "If more than one media range applies to a given type, the
+// most specific reference has precedence." So the quality for a candidate comes
+// from the most specific entry that matches it -- NOT the highest q across all
+// matching entries. The difference decides `application/did+ld+json;q=0,
+// application/did+json;q=0.5, */*;q=1`: taking the maximum gives the excluded
+// type q=1 from the wildcard and serves exactly what the client refused.
+const EXACT = 3;
+const TYPE_WILDCARD = 2;
+const GLOBAL_WILDCARD = 1;
+
 function acceptQuality(
     accept: string,
     candidate: string,
     options: { allowWildcard?: boolean } = {}
 ): { quality: number; order: number } | undefined {
     const allowWildcard = options.allowWildcard !== false;
-    let best: { quality: number; order: number } | undefined;
+    let best: { specificity: number; quality: number; order: number } | undefined;
     const normalizedCandidate = candidate.toLowerCase();
 
     accept.split(',').forEach((part, order) => {
@@ -107,18 +117,36 @@ function acceptQuality(
             }
         }
 
-        const matches = media === normalizedCandidate
-            || (allowWildcard && (media === 'application/*' || media === '*/*'));
-        if (!matches || quality <= 0) {
+        const specificity = media === normalizedCandidate
+            ? EXACT
+            : media === 'application/*'
+                ? TYPE_WILDCARD
+                : media === '*/*'
+                    ? GLOBAL_WILDCARD
+                    : 0;
+
+        if (!specificity || (!allowWildcard && specificity !== EXACT)) {
             return;
         }
 
-        if (!best || quality > best.quality || (quality === best.quality && order < best.order)) {
-            best = { quality, order };
+        // Deliberately no `quality <= 0` filter here: a q=0 on the most specific
+        // entry is the client excluding this type, and must beat a permissive
+        // wildcard rather than be skipped over in favour of one.
+        const better = !best
+            || specificity > best.specificity
+            || (specificity === best.specificity
+                && (quality > best.quality || (quality === best.quality && order < best.order)));
+
+        if (better) {
+            best = { specificity, quality, order };
         }
     });
 
-    return best;
+    if (!best || best.quality <= 0) {
+        return undefined;
+    }
+
+    return { quality: best.quality, order: best.order };
 }
 
 function sendDidResolutionJson(res: express.Response, contentType: string, body: unknown): void {
@@ -311,6 +339,10 @@ export function createIdentifiersRouter(
                 // The client named representations, none of which this endpoint
                 // produces. Previously any Accept was satisfied with JSON-LD and a
                 // 200, which contradicted the supportedContentTypes we publish (#770).
+                // Vary, because this response was selected by Accept: without it
+                // a cache can serve the 406 to a client that would have been
+                // satisfied, or vice versa.
+                res.vary('Accept');
                 res.status(406).json({
                     didDocument: null,
                     didResolutionMetadata: { error: 'representationNotSupported' },

--- a/tests/gatekeeper/api.test.ts
+++ b/tests/gatekeeper/api.test.ts
@@ -91,6 +91,87 @@ describe('GET /1.0/identifiers/:did (conformant resolution)', () => {
         expect(didJson.body.didResolutionMetadata.retrieved).toBeUndefined();
     });
 
+    it('serves application/did-resolution when the client asks for it', async () => {
+        // #770: did+ld+json and did+json describe a DID *document*, and this
+        // endpoint answers with the resolution triple. A client that names the
+        // resolution media type gets it labelled correctly.
+        const res = await request(app)
+            .get(`/1.0/identifiers/${agentDid}`)
+            .set('Accept', 'application/did-resolution');
+
+        expect(res.status).toBe(200);
+        expect(res.headers['content-type']).toBe('application/did-resolution');
+        expect(res.headers.vary).toContain('Accept');
+
+        // Parsed by hand: application/did-resolution is not a media type generic
+        // JSON clients auto-parse, which is part of why it stays opt-in.
+        const body = JSON.parse(res.text);
+        expect(Object.keys(body).sort()).toStrictEqual([
+            'didDocument',
+            'didDocumentMetadata',
+            'didResolutionMetadata',
+        ]);
+        // The metadata field still reports the DOCUMENT representation: it
+        // describes what was returned inside the envelope, not the envelope.
+        expect(body.didResolutionMetadata.contentType).toBe('application/did+ld+json');
+        expect(body.didDocument.id).toBe(agentDid);
+    });
+
+    it('leaves the document media types as the default', async () => {
+        // Universal Resolver drivers expect these, so naming did-resolution has
+        // to be opt-in rather than a change of default.
+        const noAccept = await request(app).get(`/1.0/identifiers/${agentDid}`);
+        expect(noAccept.headers['content-type']).toBe('application/did+ld+json');
+
+        // A wildcard satisfies the document types but must not select the
+        // resolution envelope.
+        const wildcard = await request(app)
+            .get(`/1.0/identifiers/${agentDid}`)
+            .set('Accept', '*/*');
+        expect(wildcard.headers['content-type']).toBe('application/did+ld+json');
+
+        const applicationWildcard = await request(app)
+            .get(`/1.0/identifiers/${agentDid}`)
+            .set('Accept', 'application/*');
+        expect(applicationWildcard.headers['content-type']).toBe('application/did+ld+json');
+
+        // A wildcard alongside a lower-q explicit type: the wildcard gives every
+        // document type q=1, which beats the named did+json at q=0.5. Pinned
+        // because it is what a lenient UR driver sends.
+        const outrankingWildcard = await request(app)
+            .get(`/1.0/identifiers/${agentDid}`)
+            .set('Accept', '*/*;q=1, application/did+json;q=0.5');
+        expect(outrankingWildcard.headers['content-type']).toBe('application/did+ld+json');
+    });
+
+    it('honours q-values between the resolution envelope and the document types', async () => {
+        const preferResolution = await request(app)
+            .get(`/1.0/identifiers/${agentDid}`)
+            .set('Accept', 'application/did+ld+json;q=0.5, application/did-resolution;q=1');
+        expect(preferResolution.headers['content-type']).toBe('application/did-resolution');
+        expect(JSON.parse(preferResolution.text).didDocument.id).toBe(agentDid);
+
+        const preferDocument = await request(app)
+            .get(`/1.0/identifiers/${agentDid}`)
+            .set('Accept', 'application/did-resolution;q=0.4, application/did+json;q=0.9');
+        expect(preferDocument.headers['content-type']).toBe('application/did+json');
+        expect(preferDocument.body.didResolutionMetadata.contentType).toBe('application/did+json');
+    });
+
+    it('answers representationNotSupported when it can produce nothing the client accepts', async () => {
+        // #770: any Accept used to be satisfied with JSON-LD and a 200, which
+        // contradicted the supportedContentTypes published in the DID test suite
+        // fixture. The result stays triple-shaped, as errors do on this surface.
+        const res = await request(app)
+            .get(`/1.0/identifiers/${agentDid}`)
+            .set('Accept', 'application/xml');
+
+        expect(res.status).toBe(406);
+        expect(res.body.didResolutionMetadata.error).toBe('representationNotSupported');
+        expect(res.body.didDocument).toBeNull();
+        expect(res.body.didDocumentMetadata).toStrictEqual({});
+    });
+
     it('resolves an asset to the triple only (no inline data/registration)', async () => {
         const res = await request(app).get(`/1.0/identifiers/${assetDid}`);
 

--- a/tests/gatekeeper/api.test.ts
+++ b/tests/gatekeeper/api.test.ts
@@ -170,6 +170,31 @@ describe('GET /1.0/identifiers/:did (conformant resolution)', () => {
         expect(res.body.didResolutionMetadata.error).toBe('representationNotSupported');
         expect(res.body.didDocument).toBeNull();
         expect(res.body.didDocumentMetadata).toStrictEqual({});
+        // Accept selected this response, so a cache must key on it.
+        expect(res.headers.vary).toContain('Accept');
+    });
+
+    it('lets an explicit q=0 exclude a type a wildcard would otherwise allow', async () => {
+        // RFC 7231 5.3.2: the most specific matching range supplies the quality.
+        // Taking the highest q across all matching ranges instead would give the
+        // excluded type q=1 from the wildcard and serve exactly what the client
+        // refused.
+        const res = await request(app)
+            .get(`/1.0/identifiers/${agentDid}`)
+            .set('Accept', 'application/did+ld+json;q=0, application/did+json;q=0.5, */*;q=1');
+
+        expect(res.status).toBe(200);
+        expect(res.headers['content-type']).toBe('application/did+json');
+        expect(res.body.didResolutionMetadata.contentType).toBe('application/did+json');
+    });
+
+    it('answers 406 when q=0 excludes everything it can produce', async () => {
+        const res = await request(app)
+            .get(`/1.0/identifiers/${agentDid}`)
+            .set('Accept', 'application/did+ld+json;q=0, application/did+json;q=0, */*;q=1');
+
+        expect(res.status).toBe(406);
+        expect(res.body.didResolutionMetadata.error).toBe('representationNotSupported');
     });
 
     it('resolves an asset to the triple only (no inline data/registration)', async () => {


### PR DESCRIPTION
Closes #770 — options B and C from that issue, together and `Accept`-driven, in both implementations.

## Why now

The deferral on #770 was explicitly a timing call: hold until the DID test suite fixture PR landed, so a behaviour change would not draw fresh scrutiny to a nearly-closed review. [w3c/did-test-suite#240](https://github.com/w3c/did-test-suite/pull/240) **merged 2026-07-30**, so the reason to wait is gone.

## B — the triple is labelled for what it is

`application/did+ld+json` and `application/did+json` are DID **document** representation media types; this endpoint answers with the resolution triple. A client can now ask for `application/did-resolution` and get it labelled correctly.

| `Accept` | `Content-Type` | `didResolutionMetadata.contentType` |
| --- | --- | --- |
| absent, `*/*`, `application/*` | `did+ld+json` | `did+ld+json` |
| `application/did+ld+json` | `did+ld+json` | `did+ld+json` |
| `application/did+json` | `did+json` | `did+json` |
| `application/did-resolution` | `did-resolution` | `did+ld+json` |
| anything else | — | **406** `representationNotSupported` |

Opt-in only: the document types remain the default because Universal Resolver drivers expect them. Note the last column — `didResolutionMetadata.contentType` keeps reporting a *document* representation in every case, because that field describes what is inside the envelope, not the envelope. #770 was explicit that this part was already correct.

## C — an unsatisfiable Accept is no longer quietly satisfied

Previously `Accept: application/xml` got JSON-LD and a 200. It now gets 406 with `representationNotSupported`, result still triple-shaped as errors are on this surface.

This also settles a **published** inconsistency: the merged fixture declares

```json
"supportedContentTypes": ["application/did+json", "application/did+ld+json"]
```

while the endpoint accepted anything at all.

## Two things I got wrong, recorded rather than papered over

**A test, not the code.** I asserted `*/*;q=1, application/did+json;q=0.5` should yield `did+json`. It yields `did+ld+json` — and that is correct: RFC 7231 gives the more specific range precedence, so the wildcard's `q=1` applies to the other type. Both implementations already agreed; my expectation was the bug. Kept as a pinned case, since it is what a lenient driver sends.

**The no-wildcard rule on the envelope is defensive, not load-bearing.** Flipping it changes no behaviour: `acceptQuality` takes the best match across entries, so a wildcard hands the document types whatever quality it hands the envelope, and the tie favours the document. Found by mutation-testing it and watching nothing fail. Both flavors now say so in a comment rather than implying it does work it does not.

## Checklist from #770

- [x] TypeScript `identifiers-router.ts`
- [x] Rust `api.rs`
- [x] `rust/services/gatekeeper/tests/http_contract.rs` — parity suite, plus the mirror cases in `tests/gatekeeper/api.test.ts`
- [x] Drawbridge proxy passes the header through — **no change needed**: it forwards request headers whole and relays response headers minus hop-by-hop ones, so `Accept`, `Content-Type` and the 406 all pass
- [x] Docs — `docs/scheme.md`, gatekeeper README, Swagger `406`, regenerated OpenAPI
- [ ] **`uni-resolver-driver-did-cid/server.js`** — separate repository, not touched here

That last one matters and is called out in the commit: the driver derives its own header from `result?.didResolutionMetadata?.contentType || accept`, so UR clients see the driver's behaviour rather than the gatekeeper's. Fixing the gatekeeper alone changes nothing end-to-end for them.

## Verification

2261 JS tests passing, full Rust suite green across two independent runs, typecheck 0, lint clean, clippy clean (one pre-existing unrelated warning, confirmed present on an unmodified tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)