### PR TITLE
feat(clients): Add DIDComm credential exchange to KeymasterUI

### DIFF
--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -2838,14 +2838,29 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     // carrying the credential's DID, which only a did:cid holder can resolve and
     // decrypt; this carries the signed credential itself, which is the only way
     // to reach a subject whose DID is not a did:cid.
-    async function sendCredentialOverDidComm(recipient) {
-        const to = recipient.trim();
+    async function sendCredentialOverDidComm(recipientInput) {
+        const recipient = recipientInput.trim();
 
-        if (!to) {
+        // This modal's confirm button is always enabled, so an empty submit
+        // reaches here. Returning quietly would leave the dialog open with no
+        // indication of why nothing happened.
+        if (!recipient) {
+            showError("Enter a recipient DID or alias");
             return;
         }
 
         try {
+            // Resolve first so an unknown alias fails before any crypto, and so
+            // a DID travels in the envelope rather than a local name. Matches
+            // the shared wallet UI (packages/wallet-ui IssuedTab).
+            const docs = await keymaster.resolveDID(recipient);
+            const to = docs.didDocument?.id;
+
+            if (!to) {
+                showError(`Could not resolve ${recipient}`);
+                return;
+            }
+
             await keymaster.sendCredentialDidComm(sendCredentialDidCommDID, to);
             showSuccess("Credential sent over DIDComm");
             setSendCredentialDidCommOpen(false);

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -413,6 +413,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     // package. These are stable DIDComm protocol URIs.
     const BASIC_MESSAGE_TYPE = 'https://didcomm.org/basicmessage/2.0/message';
     const TRUST_PING_TYPE = 'https://didcomm.org/trust-ping/2.0/ping';
+    const ISSUE_CREDENTIAL_TYPE = 'https://didcomm.org/issue-credential/3.0/issue-credential';
     const TRUST_PING_RESPONSE_TYPE = 'https://didcomm.org/trust-ping/2.0/ping-response';
 
     const [didcommTab, setDidcommTab] = useState('inbox');
@@ -424,6 +425,8 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [didcommInviteInput, setDidcommInviteInput] = useState('');
     const [didcommDecodedInvite, setDidcommDecodedInvite] = useState(null);
     const [didcommMessages, setDidcommMessages] = useState([]);
+    const [sendCredentialDidCommOpen, setSendCredentialDidCommOpen] = useState(false);
+    const [sendCredentialDidCommDID, setSendCredentialDidCommDID] = useState('');
     const [didcommInboxLoading, setDidcommInboxLoading] = useState(false);
     // A ref, not the loading flag: the poll's interval callback closes over the
     // render that created it, so a state read there would always be stale. Keyed
@@ -736,6 +739,9 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
         if (type === TRUST_PING_TYPE) {
             return 'Trust ping';
+        }
+        if (type === ISSUE_CREDENTIAL_TYPE) {
+            return 'Credential';
         }
         return type || 'Unknown';
     }
@@ -2828,6 +2834,52 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
     }
 
+    // The DIDComm counterpart of sendIssued. sendCredential posts a Notice
+    // carrying the credential's DID, which only a did:cid holder can resolve and
+    // decrypt; this carries the signed credential itself, which is the only way
+    // to reach a subject whose DID is not a did:cid.
+    async function sendCredentialOverDidComm(recipient) {
+        const to = recipient.trim();
+
+        if (!to) {
+            return;
+        }
+
+        try {
+            await keymaster.sendCredentialDidComm(sendCredentialDidCommDID, to);
+            showSuccess("Credential sent over DIDComm");
+            setSendCredentialDidCommOpen(false);
+            setSendCredentialDidCommDID('');
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    async function acceptCredentialFromDidComm(received) {
+        setDidcommBusy(true);
+
+        try {
+            const accepted = await keymaster.acceptCredentialDidComm(received.message);
+
+            if (accepted) {
+                showSuccess("Credential added to your wallet");
+                await refreshHeld();
+                await dismissDidComm([received.id]);
+                return;
+            }
+
+            // A credential from a foreign issuer has no did:cid for this wallet
+            // to resolve, so there is nothing to hold. Say so rather than report
+            // a success that stored nothing; the message stays in the inbox
+            // where its contents can still be read.
+            showError("This credential has no DID this wallet can resolve, so it cannot be held");
+        } catch (error) {
+            showError(error);
+        } finally {
+            setDidcommBusy(false);
+        }
+    }
+
     useEffect(() => {
         if (selectedDmailDID && dmailList[selectedDmailDID]) {
             setSelectedDmail(dmailList[selectedDmailDID]);
@@ -4811,6 +4863,16 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                     <Button variant="contained" onClick={handlePromptOk}>OK</Button>
                 </DialogActions>
             </Dialog>
+
+            <TextInputModal
+                isOpen={sendCredentialDidCommOpen}
+                title="Send credential over DIDComm"
+                description="Enter the recipient's DID or alias. The credential itself is sent, so a subject outside this network can read it."
+                label="Recipient"
+                confirmText="Send"
+                onSubmit={sendCredentialOverDidComm}
+                onClose={() => setSendCredentialDidCommOpen(false)}
+            />
 
             <TextInputModal
                 isOpen={importNostrOpen}
@@ -6950,6 +7012,18 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                                         Send
                                                                     </Button>
                                                                 </Grid>
+                                                                <Grid item>
+                                                                    <Button
+                                                                        variant="contained"
+                                                                        color="primary"
+                                                                        onClick={() => {
+                                                                            setSendCredentialDidCommDID(did);
+                                                                            setSendCredentialDidCommOpen(true);
+                                                                        }}
+                                                                    >
+                                                                        Send over DIDComm
+                                                                    </Button>
+                                                                </Grid>
                                                             </Grid>
                                                         </TableCell>
                                                     </TableRow>
@@ -8011,6 +8085,15 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                                     disabled={didcommBusy}
                                                                 >
                                                                     Reply
+                                                                </Button>
+                                                            }
+                                                            {message.type === ISSUE_CREDENTIAL_TYPE &&
+                                                                <Button
+                                                                    size="small"
+                                                                    onClick={() => acceptCredentialFromDidComm(received)}
+                                                                    disabled={didcommBusy}
+                                                                >
+                                                                    Accept
                                                                 </Button>
                                                             }
                                                             <Button

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -2838,14 +2838,29 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     // carrying the credential's DID, which only a did:cid holder can resolve and
     // decrypt; this carries the signed credential itself, which is the only way
     // to reach a subject whose DID is not a did:cid.
-    async function sendCredentialOverDidComm(recipient) {
-        const to = recipient.trim();
+    async function sendCredentialOverDidComm(recipientInput) {
+        const recipient = recipientInput.trim();
 
-        if (!to) {
+        // This modal's confirm button is always enabled, so an empty submit
+        // reaches here. Returning quietly would leave the dialog open with no
+        // indication of why nothing happened.
+        if (!recipient) {
+            showError("Enter a recipient DID or alias");
             return;
         }
 
         try {
+            // Resolve first so an unknown alias fails before any crypto, and so
+            // a DID travels in the envelope rather than a local name. Matches
+            // the shared wallet UI (packages/wallet-ui IssuedTab).
+            const docs = await keymaster.resolveDID(recipient);
+            const to = docs.didDocument?.id;
+
+            if (!to) {
+                showError(`Could not resolve ${recipient}`);
+                return;
+            }
+
             await keymaster.sendCredentialDidComm(sendCredentialDidCommDID, to);
             showSuccess("Credential sent over DIDComm");
             setSendCredentialDidCommOpen(false);

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -413,6 +413,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     // package. These are stable DIDComm protocol URIs.
     const BASIC_MESSAGE_TYPE = 'https://didcomm.org/basicmessage/2.0/message';
     const TRUST_PING_TYPE = 'https://didcomm.org/trust-ping/2.0/ping';
+    const ISSUE_CREDENTIAL_TYPE = 'https://didcomm.org/issue-credential/3.0/issue-credential';
     const TRUST_PING_RESPONSE_TYPE = 'https://didcomm.org/trust-ping/2.0/ping-response';
 
     const [didcommTab, setDidcommTab] = useState('inbox');
@@ -424,6 +425,8 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
     const [didcommInviteInput, setDidcommInviteInput] = useState('');
     const [didcommDecodedInvite, setDidcommDecodedInvite] = useState(null);
     const [didcommMessages, setDidcommMessages] = useState([]);
+    const [sendCredentialDidCommOpen, setSendCredentialDidCommOpen] = useState(false);
+    const [sendCredentialDidCommDID, setSendCredentialDidCommDID] = useState('');
     const [didcommInboxLoading, setDidcommInboxLoading] = useState(false);
     // A ref, not the loading flag: the poll's interval callback closes over the
     // render that created it, so a state read there would always be stale. Keyed
@@ -736,6 +739,9 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
         if (type === TRUST_PING_TYPE) {
             return 'Trust ping';
+        }
+        if (type === ISSUE_CREDENTIAL_TYPE) {
+            return 'Credential';
         }
         return type || 'Unknown';
     }
@@ -2828,6 +2834,52 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         }
     }
 
+    // The DIDComm counterpart of sendIssued. sendCredential posts a Notice
+    // carrying the credential's DID, which only a did:cid holder can resolve and
+    // decrypt; this carries the signed credential itself, which is the only way
+    // to reach a subject whose DID is not a did:cid.
+    async function sendCredentialOverDidComm(recipient) {
+        const to = recipient.trim();
+
+        if (!to) {
+            return;
+        }
+
+        try {
+            await keymaster.sendCredentialDidComm(sendCredentialDidCommDID, to);
+            showSuccess("Credential sent over DIDComm");
+            setSendCredentialDidCommOpen(false);
+            setSendCredentialDidCommDID('');
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    async function acceptCredentialFromDidComm(received) {
+        setDidcommBusy(true);
+
+        try {
+            const accepted = await keymaster.acceptCredentialDidComm(received.message);
+
+            if (accepted) {
+                showSuccess("Credential added to your wallet");
+                await refreshHeld();
+                await dismissDidComm([received.id]);
+                return;
+            }
+
+            // A credential from a foreign issuer has no did:cid for this wallet
+            // to resolve, so there is nothing to hold. Say so rather than report
+            // a success that stored nothing; the message stays in the inbox
+            // where its contents can still be read.
+            showError("This credential has no DID this wallet can resolve, so it cannot be held");
+        } catch (error) {
+            showError(error);
+        } finally {
+            setDidcommBusy(false);
+        }
+    }
+
     useEffect(() => {
         if (selectedDmailDID && dmailList[selectedDmailDID]) {
             setSelectedDmail(dmailList[selectedDmailDID]);
@@ -4811,6 +4863,16 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                     <Button variant="contained" onClick={handlePromptOk}>OK</Button>
                 </DialogActions>
             </Dialog>
+
+            <TextInputModal
+                isOpen={sendCredentialDidCommOpen}
+                title="Send credential over DIDComm"
+                description="Enter the recipient's DID or alias. The credential itself is sent, so a subject outside this network can read it."
+                label="Recipient"
+                confirmText="Send"
+                onSubmit={sendCredentialOverDidComm}
+                onClose={() => setSendCredentialDidCommOpen(false)}
+            />
 
             <TextInputModal
                 isOpen={importNostrOpen}
@@ -6950,6 +7012,18 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                                         Send
                                                                     </Button>
                                                                 </Grid>
+                                                                <Grid item>
+                                                                    <Button
+                                                                        variant="contained"
+                                                                        color="primary"
+                                                                        onClick={() => {
+                                                                            setSendCredentialDidCommDID(did);
+                                                                            setSendCredentialDidCommOpen(true);
+                                                                        }}
+                                                                    >
+                                                                        Send over DIDComm
+                                                                    </Button>
+                                                                </Grid>
                                                             </Grid>
                                                         </TableCell>
                                                     </TableRow>
@@ -8011,6 +8085,15 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                                     disabled={didcommBusy}
                                                                 >
                                                                     Reply
+                                                                </Button>
+                                                            }
+                                                            {message.type === ISSUE_CREDENTIAL_TYPE &&
+                                                                <Button
+                                                                    size="small"
+                                                                    onClick={() => acceptCredentialFromDidComm(received)}
+                                                                    disabled={didcommBusy}
+                                                                >
+                                                                    Accept
                                                                 </Button>
                                                             }
                                                             <Button


### PR DESCRIPTION
#919 added DIDComm credential exchange to `packages/wallet-ui`, which both wallets consume, and left the two standalone clients behind. It went unnoticed for weeks.

## Why nobody caught it

No automated check in this repo covers `KeymasterUI.jsx`:

- **eslint** — `eslint .` lints 457 files and **zero** `.jsx`; the eslintrc setup does not pick up that extension, which is why the file carries 136 pre-existing `indent` errors that have never gated anything
- **typecheck** (#923) — `.jsx`, so outside `tsc`
- **render tests** (#914) — the two wallets' provider trees only

So a whole feature could go missing silently. Filed as **#935**, with the guard that would have failed the moment #919 landed.

## What this adds

Both copies, alongside the existing Notice-based **Send**:

- **"Send over DIDComm"** on each issued credential — opens a recipient modal, calls `sendCredentialDidComm`. Worth keeping both: `sendCredential` posts a Notice carrying the credential's *DID*, which only a `did:cid` holder can resolve and decrypt, while this carries the signed credential itself and is the only way to reach a subject outside the network.
- **"Accept"** on `issue-credential/3.0` messages in the inbox. A `false` return means a foreign issuer's credential with no `did:cid` to resolve, so it says so rather than reporting a success that stored nothing — the message stays in the inbox where its contents can still be read.
- **"Credential"** as the inbox label for that type, instead of the raw type URI.

## Verification

The two files are byte-identical copies, so the change was applied from a single script to both and confirmed still identical afterwards.

Both apps build, and rather than trust the source diff I checked the calls reach the built bundles:

```
keymaster-client     sendCredentialDidComm=2 acceptCredentialDidComm=2 'Send over DIDComm'=1
gatekeeper-client    sendCredentialDidComm=2 acceptCredentialDidComm=2 'Send over DIDComm'=1
```

2266 tests, typecheck 0, lint clean.

## Note

This is the fourth and fifth copy of this feature. **#99** is the actual fix — consolidating `KeymasterUI.jsx` so there are two implementations rather than four. **#935** is the guard that makes the next omission loud while that is outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)