### PR TITLE
fix(lint): Bring .jsx into scope, and clear what that surfaced

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,5 +24,18 @@
         ],
         "sonarjs/no-duplicate-string": "off",
         "sonarjs/prefer-single-boolean-return": "off"
-    }
+    },
+    // `eslint .` only expands directories to extensions it knows about: .js by
+    // default, plus any named in an `overrides.files` pattern. eslint-config-react-app
+    // contributes `**/*.ts?(x)`, which is why .ts and .tsx were linted and .jsx
+    // silently was not -- 15 files, including two 8400-line KeymasterUI copies,
+    // invisible to every check in the repo. This override adds no rules; naming
+    // the extension is the whole point. See #935.
+    "overrides": [
+        {
+            "files": [
+                "**/*.jsx"
+            ]
+        }
+    ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,7 +34,8 @@
     "overrides": [
         {
             "files": [
-                "**/*.jsx"
+                "**/*.jsx",
+                "**/*.mjs"
             ]
         }
     ]

--- a/apps/gatekeeper-client/src/App.jsx
+++ b/apps/gatekeeper-client/src/App.jsx
@@ -107,19 +107,19 @@ function App() {
         const walletWeb = new WalletWeb();
         const walletMemory = new WalletJsonMemory();
 
-        if (uploadAction && pendingWallet) {
-            if (modalAction === 'decrypt') {
-                await walletMemory.saveWallet(pendingWallet, true);
+        // One condition rather than two nested ifs: the outer had no else and
+        // nothing else in its body, so the nesting carried no information.
+        if (uploadAction && pendingWallet && modalAction === 'decrypt') {
+            await walletMemory.saveWallet(pendingWallet, true);
 
-                try {
-                    const km = new Keymaster({ gatekeeper, wallet: walletMemory, cipher, passphrase });
-                    // check pass
-                    await km.loadWallet();
-                    await walletWeb.saveWallet(pendingWallet, true);
-                } catch {
-                    setPassphraseErrorText('Incorrect passphrase');
-                    return;
-                }
+            try {
+                const km = new Keymaster({ gatekeeper, wallet: walletMemory, cipher, passphrase });
+                // check pass
+                await km.loadWallet();
+                await walletWeb.saveWallet(pendingWallet, true);
+            } catch {
+                setPassphraseErrorText('Incorrect passphrase');
+                return;
             }
         }
 

--- a/apps/gatekeeper-client/src/App.jsx
+++ b/apps/gatekeeper-client/src/App.jsx
@@ -107,8 +107,6 @@ function App() {
         const walletWeb = new WalletWeb();
         const walletMemory = new WalletJsonMemory();
 
-        // One condition rather than two nested ifs: the outer had no else and
-        // nothing else in its body, so the nesting carried no information.
         if (uploadAction && pendingWallet && modalAction === 'decrypt') {
             await walletMemory.saveWallet(pendingWallet, true);
 

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -4676,9 +4676,6 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             // three live tabs share this; archive and trash each define their own.
             const live = () => not(DmailTags.DELETED) && not(DmailTags.ARCHIVED);
 
-            // A dispatch table rather than an if/else chain whose every branch
-            // assigned the same thing -- which is what it always was, and what
-            // sonarjs/no-duplicated-branches was pointing at.
             const matchesTab = {
                 inbox: () => has(DmailTags.INBOX) && live(),
                 outbox: () => has(DmailTags.SENT) && live(),

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -1,8 +1,5 @@
 import { useEffect, useRef, useState, useMemo, useCallback } from 'react';
 import {
-    Accordion,
-    AccordionDetails,
-    AccordionSummary,
     Alert,
     Autocomplete,
     Box,
@@ -59,7 +56,6 @@ import {
     Drafts,
     Edit,
     Email,
-    ExpandMore,
     Forward,
     HowToVote,
     Image,

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -4672,16 +4672,22 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         for (const [did, item] of Object.entries(dmailList)) {
             const has = (tag) => item.tags.includes(tag);
             const not = (tag) => !has(tag);
+            // Neither deleted nor archived, i.e. still in the working set. The
+            // three live tabs share this; archive and trash each define their own.
+            const live = () => not(DmailTags.DELETED) && not(DmailTags.ARCHIVED);
 
-            if (dmailTab === 'inbox' && has(DmailTags.INBOX) && not(DmailTags.DELETED) && not(DmailTags.ARCHIVED)) {
-                filtered[did] = item;
-            } else if (dmailTab === 'outbox' && has(DmailTags.SENT) && not(DmailTags.DELETED) && not(DmailTags.ARCHIVED)) {
-                filtered[did] = item;
-            } else if (dmailTab === 'drafts' && has(DmailTags.DRAFT) && not(DmailTags.DELETED) && not(DmailTags.ARCHIVED)) {
-                filtered[did] = item;
-            } else if (dmailTab === 'archive' && has(DmailTags.ARCHIVED) && not(DmailTags.DELETED)) {
-                filtered[did] = item;
-            } else if (dmailTab === 'trash' && has(DmailTags.DELETED)) {
+            // A dispatch table rather than an if/else chain whose every branch
+            // assigned the same thing -- which is what it always was, and what
+            // sonarjs/no-duplicated-branches was pointing at.
+            const matchesTab = {
+                inbox: () => has(DmailTags.INBOX) && live(),
+                outbox: () => has(DmailTags.SENT) && live(),
+                drafts: () => has(DmailTags.DRAFT) && live(),
+                archive: () => has(DmailTags.ARCHIVED) && not(DmailTags.DELETED),
+                trash: () => has(DmailTags.DELETED),
+            };
+
+            if (matchesTab[dmailTab]?.()) {
                 filtered[did] = item;
             }
         }
@@ -5139,7 +5145,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                         </Grid>
                                     </Grid>
                                     <TableContainer component={Paper} style={{ maxHeight: '260px', overflow: 'auto', marginBottom: '8px' }}>
-                                            <Table stickyHeader style={{ width: '100%', tableLayout: 'fixed' }}>
+                                        <Table stickyHeader style={{ width: '100%', tableLayout: 'fixed' }}>
                                             <colgroup>
                                                 <col />
                                                 <col style={{ width: '220px' }} />
@@ -5900,49 +5906,49 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                         selectVersion={selectImageVersion}
                                                     />
                                                     <div className="container">
-                                                    <div className="left-pane">
-                                                        <img src={selectedImageURL} alt={selectedImageName} style={{ width: '100%', height: 'auto' }} />
-                                                    </div>
-                                                    <div className="right-pane">
-                                                        <TableContainer>
-                                                            <Table>
-                                                                <TableBody>
-                                                                    <TableRow>
-                                                                        <TableCell>DID</TableCell>
-                                                                        <TableCell>{selectedImageDocs.didDocument.id}</TableCell>
-                                                                    </TableRow>
-                                                                    <TableRow>
-                                                                        <TableCell>CID</TableCell>
-                                                                        <TableCell>{selectedImage.file.cid}</TableCell>
-                                                                    </TableRow>
-                                                                    <TableRow>
-                                                                        <TableCell>Created</TableCell>
-                                                                        <TableCell>{selectedImageDocs.didDocumentMetadata.created}</TableCell>
-                                                                    </TableRow>
-                                                                    <TableRow>
-                                                                        <TableCell>Updated</TableCell>
-                                                                        <TableCell>{selectedImageDocs.didDocumentMetadata.updated || selectedImageDocs.didDocumentMetadata.created}</TableCell>
-                                                                    </TableRow>
-                                                                    <TableRow>
-                                                                        <TableCell>Version</TableCell>
-                                                                        <TableCell>{selectedImageDocs.didDocumentMetadata.version} of {imageVersionMax}</TableCell>
-                                                                    </TableRow>
-                                                                    <TableRow>
-                                                                        <TableCell>File size</TableCell>
-                                                                        <TableCell>{selectedImage.file.bytes} bytes</TableCell>
-                                                                    </TableRow>
-                                                                    <TableRow>
-                                                                        <TableCell>Image size</TableCell>
-                                                                        <TableCell>{selectedImage.image.width} x {selectedImage.image.height} pixels</TableCell>
-                                                                    </TableRow>
-                                                                    <TableRow>
-                                                                        <TableCell>Image type</TableCell>
-                                                                        <TableCell>{selectedImage.file.type}</TableCell>
-                                                                    </TableRow>
-                                                                </TableBody>
-                                                            </Table>
-                                                        </TableContainer>
-                                                    </div>
+                                                        <div className="left-pane">
+                                                            <img src={selectedImageURL} alt={selectedImageName} style={{ width: '100%', height: 'auto' }} />
+                                                        </div>
+                                                        <div className="right-pane">
+                                                            <TableContainer>
+                                                                <Table>
+                                                                    <TableBody>
+                                                                        <TableRow>
+                                                                            <TableCell>DID</TableCell>
+                                                                            <TableCell>{selectedImageDocs.didDocument.id}</TableCell>
+                                                                        </TableRow>
+                                                                        <TableRow>
+                                                                            <TableCell>CID</TableCell>
+                                                                            <TableCell>{selectedImage.file.cid}</TableCell>
+                                                                        </TableRow>
+                                                                        <TableRow>
+                                                                            <TableCell>Created</TableCell>
+                                                                            <TableCell>{selectedImageDocs.didDocumentMetadata.created}</TableCell>
+                                                                        </TableRow>
+                                                                        <TableRow>
+                                                                            <TableCell>Updated</TableCell>
+                                                                            <TableCell>{selectedImageDocs.didDocumentMetadata.updated || selectedImageDocs.didDocumentMetadata.created}</TableCell>
+                                                                        </TableRow>
+                                                                        <TableRow>
+                                                                            <TableCell>Version</TableCell>
+                                                                            <TableCell>{selectedImageDocs.didDocumentMetadata.version} of {imageVersionMax}</TableCell>
+                                                                        </TableRow>
+                                                                        <TableRow>
+                                                                            <TableCell>File size</TableCell>
+                                                                            <TableCell>{selectedImage.file.bytes} bytes</TableCell>
+                                                                        </TableRow>
+                                                                        <TableRow>
+                                                                            <TableCell>Image size</TableCell>
+                                                                            <TableCell>{selectedImage.image.width} x {selectedImage.image.height} pixels</TableCell>
+                                                                        </TableRow>
+                                                                        <TableRow>
+                                                                            <TableCell>Image type</TableCell>
+                                                                            <TableCell>{selectedImage.file.type}</TableCell>
+                                                                        </TableRow>
+                                                                    </TableBody>
+                                                                </Table>
+                                                            </TableContainer>
+                                                        </div>
                                                     </div>
                                                 </>
                                             }
@@ -6380,26 +6386,26 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
 
                                     <Box sx={{ mt: 2 }}>
                                         {!createdPollDid && (
-                                        <>
-                                        <Select
-                                            value={registry}
-                                            onChange={(e) => setRegistry(e.target.value)}
-                                            sx={{ minWidth: 200, mb: 2 }}
-                                        >
-                                            {registries.map((r) => (
-                                                <MenuItem key={r} value={r}>
-                                                    {r}
-                                                </MenuItem>
-                                            ))}
-                                        </Select>
-                                        <Button
-                                            variant="contained"
-                                            onClick={handleCreatePoll}
-                                            sx={{ mr: 1 }}
-                                        >
+                                            <>
+                                                <Select
+                                                    value={registry}
+                                                    onChange={(e) => setRegistry(e.target.value)}
+                                                    sx={{ minWidth: 200, mb: 2 }}
+                                                >
+                                                    {registries.map((r) => (
+                                                        <MenuItem key={r} value={r}>
+                                                            {r}
+                                                        </MenuItem>
+                                                    ))}
+                                                </Select>
+                                                <Button
+                                                    variant="contained"
+                                                    onClick={handleCreatePoll}
+                                                    sx={{ mr: 1 }}
+                                                >
                                             Create
-                                        </Button>
-                                        </>
+                                                </Button>
+                                            </>
                                         )}
                                         <Button
                                             variant="outlined"
@@ -7766,7 +7772,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                         <Box>
                                             {lightningWalletError ?
                                                 <Typography color="error">{lightningWalletError}</Typography>
-                                            :
+                                                :
                                                 <Typography variant="h6">
                                                     Balance: {(lightningBalance ?? 0).toLocaleString()} sats
                                                 </Typography>
@@ -7836,20 +7842,20 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                         const date = d ? `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, '0')}/${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}` : '—';
                                                         const displayStatus = p.status === 'success' ? 'settled'
                                                             : p.status === 'failed' ? 'failed'
-                                                            : (p.expiry && new Date(p.expiry) < new Date()) ? 'expired'
-                                                            : 'pending';
+                                                                : (p.expiry && new Date(p.expiry) < new Date()) ? 'expired'
+                                                                    : 'pending';
                                                         if (!lightningStatusFilter[displayStatus]) return null;
                                                         const statusColor = displayStatus === 'settled' ? 'inherit'
                                                             : displayStatus === 'failed' ? 'error.main'
-                                                            : 'text.secondary';
+                                                                : 'text.secondary';
                                                         return (
-                                                        <TableRow key={i}>
-                                                            <TableCell>{date}</TableCell>
-                                                            <TableCell align="right">{p.amount}</TableCell>
-                                                            <TableCell align="right">{p.fee > 0 ? p.fee : ''}</TableCell>
-                                                            <TableCell><Box component="span" sx={{ color: statusColor }}>{displayStatus}</Box></TableCell>
-                                                            <TableCell>{p.memo || '—'}</TableCell>
-                                                        </TableRow>
+                                                            <TableRow key={i}>
+                                                                <TableCell>{date}</TableCell>
+                                                                <TableCell align="right">{p.amount}</TableCell>
+                                                                <TableCell align="right">{p.fee > 0 ? p.fee : ''}</TableCell>
+                                                                <TableCell><Box component="span" sx={{ color: statusColor }}>{displayStatus}</Box></TableCell>
+                                                                <TableCell>{p.memo || '—'}</TableCell>
+                                                            </TableRow>
                                                         );
                                                     })}
                                                 </TableBody>
@@ -8006,14 +8012,14 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                             {loadingZap ? 'Zapping...' : 'Zap'}
                                         </Button>
                                     </Box>
-                                        {zapResult &&
+                                    {zapResult &&
                                             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 1 }}>
                                                 <Typography variant="body2"><strong>Status:</strong> {zapResult.paid ? 'Settled' : zapResult.status === 'failed' ? 'Failed' : 'Pending'}</Typography>
                                                 <Typography variant="body2"><strong>Payment Hash:</strong> {zapResult.paymentHash}</Typography>
                                                 {zapResult.preimage &&
                                                     <Typography variant="body2"><strong>Preimage (Proof):</strong> {zapResult.preimage}</Typography>
-                                            }
-                                        </Box>
+                                                }
+                                            </Box>
                                     }
                                 </Box>
                             }
@@ -8306,75 +8312,75 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
 
                             {didcommTab === 'endpoint' &&
                             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                            <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                <Typography variant="body2" sx={{ opacity: 0.7 }}>
                                 Publish a messaging endpoint so other agents can send encrypted DIDComm messages to this identity.
-                            </Typography>
+                                </Typography>
 
-                            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                                <Typography variant="subtitle2">Published</Typography>
-                                {didcommStatus
-                                    ? <>
-                                        {didcommStatus.endpoint
-                                            ? <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
-                                                <strong>Endpoint:</strong> {didcommStatus.endpoint}
-                                            </Typography>
-                                            : <Typography variant="body2">
-                                                <strong>Endpoint:</strong> key only (others can encrypt to this identity but have nowhere to deliver)
-                                            </Typography>
-                                        }
-                                        {didcommStatus.routingKeys.length > 0 &&
+                                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                                    <Typography variant="subtitle2">Published</Typography>
+                                    {didcommStatus
+                                        ? <>
+                                            {didcommStatus.endpoint
+                                                ? <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
+                                                    <strong>Endpoint:</strong> {didcommStatus.endpoint}
+                                                </Typography>
+                                                : <Typography variant="body2">
+                                                    <strong>Endpoint:</strong> key only (others can encrypt to this identity but have nowhere to deliver)
+                                                </Typography>
+                                            }
+                                            {didcommStatus.routingKeys.length > 0 &&
                                             <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
                                                 <strong>Routing keys:</strong> {didcommStatus.routingKeys.join(', ')}
                                             </Typography>
-                                        }
-                                        <Typography variant="body2">
-                                            <strong>Key agreement:</strong> {didcommStatus.keyAgreement ? 'published' : 'missing'}
-                                        </Typography>
-                                    </>
-                                    : <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                            }
+                                            <Typography variant="body2">
+                                                <strong>Key agreement:</strong> {didcommStatus.keyAgreement ? 'published' : 'missing'}
+                                            </Typography>
+                                        </>
+                                        : <Typography variant="body2" sx={{ opacity: 0.7 }}>
                                         Nothing published for this identity yet.
-                                    </Typography>
-                                }
-                            </Box>
+                                        </Typography>
+                                    }
+                                </Box>
 
-                            <TextField
-                                label="Endpoint URL (optional)"
-                                value={didcommEndpoint}
-                                onChange={(e) => setDidcommEndpoint(e.target.value)}
-                                disabled={didcommBusy}
-                                placeholder="https://relay.example/didcomm"
-                                helperText="Leave blank to use this node's own relay."
-                                fullWidth
-                            />
-
-                            <TextField
-                                label="Routing keys (optional, comma separated)"
-                                value={didcommRoutingKeys}
-                                onChange={(e) => setDidcommRoutingKeys(e.target.value)}
-                                disabled={didcommBusy}
-                                placeholder="did:cid:mediator#key-agreement-1"
-                                helperText="Set these when delivery goes through a mediator; senders then wrap messages in a Forward."
-                                fullWidth
-                            />
-
-                            <Box sx={{ display: 'flex', gap: 1 }}>
-                                <Button
-                                    variant="contained"
-                                    color="primary"
-                                    onClick={publishDidComm}
+                                <TextField
+                                    label="Endpoint URL (optional)"
+                                    value={didcommEndpoint}
+                                    onChange={(e) => setDidcommEndpoint(e.target.value)}
                                     disabled={didcommBusy}
-                                >
-                                    {didcommStatus ? 'Update' : 'Publish'}
-                                </Button>
-                                <Button
-                                    variant="outlined"
-                                    color="primary"
-                                    onClick={unpublishDidComm}
-                                    disabled={didcommBusy || !didcommStatus}
-                                >
+                                    placeholder="https://relay.example/didcomm"
+                                    helperText="Leave blank to use this node's own relay."
+                                    fullWidth
+                                />
+
+                                <TextField
+                                    label="Routing keys (optional, comma separated)"
+                                    value={didcommRoutingKeys}
+                                    onChange={(e) => setDidcommRoutingKeys(e.target.value)}
+                                    disabled={didcommBusy}
+                                    placeholder="did:cid:mediator#key-agreement-1"
+                                    helperText="Set these when delivery goes through a mediator; senders then wrap messages in a Forward."
+                                    fullWidth
+                                />
+
+                                <Box sx={{ display: 'flex', gap: 1 }}>
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
+                                        onClick={publishDidComm}
+                                        disabled={didcommBusy}
+                                    >
+                                        {didcommStatus ? 'Update' : 'Publish'}
+                                    </Button>
+                                    <Button
+                                        variant="outlined"
+                                        color="primary"
+                                        onClick={unpublishDidComm}
+                                        disabled={didcommBusy || !didcommStatus}
+                                    >
                                     Unpublish
-                                </Button>
-                            </Box>
+                                    </Button>
+                                </Box>
                             </Box>
                             }
                         </Box>

--- a/apps/gatekeeper-client/src/KeymasterUI.jsx
+++ b/apps/gatekeeper-client/src/KeymasterUI.jsx
@@ -4674,12 +4674,12 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             const not = (tag) => !has(tag);
             // Neither deleted nor archived, i.e. still in the working set. The
             // three live tabs share this; archive and trash each define their own.
-            const live = () => not(DmailTags.DELETED) && not(DmailTags.ARCHIVED);
+            const live = not(DmailTags.DELETED) && not(DmailTags.ARCHIVED);
 
             const matchesTab = {
-                inbox: () => has(DmailTags.INBOX) && live(),
-                outbox: () => has(DmailTags.SENT) && live(),
-                drafts: () => has(DmailTags.DRAFT) && live(),
+                inbox: () => has(DmailTags.INBOX) && live,
+                outbox: () => has(DmailTags.SENT) && live,
+                drafts: () => has(DmailTags.DRAFT) && live,
                 archive: () => has(DmailTags.ARCHIVED) && not(DmailTags.DELETED),
                 trash: () => has(DmailTags.DELETED),
             };

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -4676,9 +4676,6 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             // three live tabs share this; archive and trash each define their own.
             const live = () => not(DmailTags.DELETED) && not(DmailTags.ARCHIVED);
 
-            // A dispatch table rather than an if/else chain whose every branch
-            // assigned the same thing -- which is what it always was, and what
-            // sonarjs/no-duplicated-branches was pointing at.
             const matchesTab = {
                 inbox: () => has(DmailTags.INBOX) && live(),
                 outbox: () => has(DmailTags.SENT) && live(),

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -1,8 +1,5 @@
 import { useEffect, useRef, useState, useMemo, useCallback } from 'react';
 import {
-    Accordion,
-    AccordionDetails,
-    AccordionSummary,
     Alert,
     Autocomplete,
     Box,
@@ -59,7 +56,6 @@ import {
     Drafts,
     Edit,
     Email,
-    ExpandMore,
     Forward,
     HowToVote,
     Image,

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -4672,16 +4672,22 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
         for (const [did, item] of Object.entries(dmailList)) {
             const has = (tag) => item.tags.includes(tag);
             const not = (tag) => !has(tag);
+            // Neither deleted nor archived, i.e. still in the working set. The
+            // three live tabs share this; archive and trash each define their own.
+            const live = () => not(DmailTags.DELETED) && not(DmailTags.ARCHIVED);
 
-            if (dmailTab === 'inbox' && has(DmailTags.INBOX) && not(DmailTags.DELETED) && not(DmailTags.ARCHIVED)) {
-                filtered[did] = item;
-            } else if (dmailTab === 'outbox' && has(DmailTags.SENT) && not(DmailTags.DELETED) && not(DmailTags.ARCHIVED)) {
-                filtered[did] = item;
-            } else if (dmailTab === 'drafts' && has(DmailTags.DRAFT) && not(DmailTags.DELETED) && not(DmailTags.ARCHIVED)) {
-                filtered[did] = item;
-            } else if (dmailTab === 'archive' && has(DmailTags.ARCHIVED) && not(DmailTags.DELETED)) {
-                filtered[did] = item;
-            } else if (dmailTab === 'trash' && has(DmailTags.DELETED)) {
+            // A dispatch table rather than an if/else chain whose every branch
+            // assigned the same thing -- which is what it always was, and what
+            // sonarjs/no-duplicated-branches was pointing at.
+            const matchesTab = {
+                inbox: () => has(DmailTags.INBOX) && live(),
+                outbox: () => has(DmailTags.SENT) && live(),
+                drafts: () => has(DmailTags.DRAFT) && live(),
+                archive: () => has(DmailTags.ARCHIVED) && not(DmailTags.DELETED),
+                trash: () => has(DmailTags.DELETED),
+            };
+
+            if (matchesTab[dmailTab]?.()) {
                 filtered[did] = item;
             }
         }
@@ -5139,7 +5145,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                         </Grid>
                                     </Grid>
                                     <TableContainer component={Paper} style={{ maxHeight: '260px', overflow: 'auto', marginBottom: '8px' }}>
-                                            <Table stickyHeader style={{ width: '100%', tableLayout: 'fixed' }}>
+                                        <Table stickyHeader style={{ width: '100%', tableLayout: 'fixed' }}>
                                             <colgroup>
                                                 <col />
                                                 <col style={{ width: '220px' }} />
@@ -5900,49 +5906,49 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                         selectVersion={selectImageVersion}
                                                     />
                                                     <div className="container">
-                                                    <div className="left-pane">
-                                                        <img src={selectedImageURL} alt={selectedImageName} style={{ width: '100%', height: 'auto' }} />
-                                                    </div>
-                                                    <div className="right-pane">
-                                                        <TableContainer>
-                                                            <Table>
-                                                                <TableBody>
-                                                                    <TableRow>
-                                                                        <TableCell>DID</TableCell>
-                                                                        <TableCell>{selectedImageDocs.didDocument.id}</TableCell>
-                                                                    </TableRow>
-                                                                    <TableRow>
-                                                                        <TableCell>CID</TableCell>
-                                                                        <TableCell>{selectedImage.file.cid}</TableCell>
-                                                                    </TableRow>
-                                                                    <TableRow>
-                                                                        <TableCell>Created</TableCell>
-                                                                        <TableCell>{selectedImageDocs.didDocumentMetadata.created}</TableCell>
-                                                                    </TableRow>
-                                                                    <TableRow>
-                                                                        <TableCell>Updated</TableCell>
-                                                                        <TableCell>{selectedImageDocs.didDocumentMetadata.updated || selectedImageDocs.didDocumentMetadata.created}</TableCell>
-                                                                    </TableRow>
-                                                                    <TableRow>
-                                                                        <TableCell>Version</TableCell>
-                                                                        <TableCell>{selectedImageDocs.didDocumentMetadata.version} of {imageVersionMax}</TableCell>
-                                                                    </TableRow>
-                                                                    <TableRow>
-                                                                        <TableCell>File size</TableCell>
-                                                                        <TableCell>{selectedImage.file.bytes} bytes</TableCell>
-                                                                    </TableRow>
-                                                                    <TableRow>
-                                                                        <TableCell>Image size</TableCell>
-                                                                        <TableCell>{selectedImage.image.width} x {selectedImage.image.height} pixels</TableCell>
-                                                                    </TableRow>
-                                                                    <TableRow>
-                                                                        <TableCell>Image type</TableCell>
-                                                                        <TableCell>{selectedImage.file.type}</TableCell>
-                                                                    </TableRow>
-                                                                </TableBody>
-                                                            </Table>
-                                                        </TableContainer>
-                                                    </div>
+                                                        <div className="left-pane">
+                                                            <img src={selectedImageURL} alt={selectedImageName} style={{ width: '100%', height: 'auto' }} />
+                                                        </div>
+                                                        <div className="right-pane">
+                                                            <TableContainer>
+                                                                <Table>
+                                                                    <TableBody>
+                                                                        <TableRow>
+                                                                            <TableCell>DID</TableCell>
+                                                                            <TableCell>{selectedImageDocs.didDocument.id}</TableCell>
+                                                                        </TableRow>
+                                                                        <TableRow>
+                                                                            <TableCell>CID</TableCell>
+                                                                            <TableCell>{selectedImage.file.cid}</TableCell>
+                                                                        </TableRow>
+                                                                        <TableRow>
+                                                                            <TableCell>Created</TableCell>
+                                                                            <TableCell>{selectedImageDocs.didDocumentMetadata.created}</TableCell>
+                                                                        </TableRow>
+                                                                        <TableRow>
+                                                                            <TableCell>Updated</TableCell>
+                                                                            <TableCell>{selectedImageDocs.didDocumentMetadata.updated || selectedImageDocs.didDocumentMetadata.created}</TableCell>
+                                                                        </TableRow>
+                                                                        <TableRow>
+                                                                            <TableCell>Version</TableCell>
+                                                                            <TableCell>{selectedImageDocs.didDocumentMetadata.version} of {imageVersionMax}</TableCell>
+                                                                        </TableRow>
+                                                                        <TableRow>
+                                                                            <TableCell>File size</TableCell>
+                                                                            <TableCell>{selectedImage.file.bytes} bytes</TableCell>
+                                                                        </TableRow>
+                                                                        <TableRow>
+                                                                            <TableCell>Image size</TableCell>
+                                                                            <TableCell>{selectedImage.image.width} x {selectedImage.image.height} pixels</TableCell>
+                                                                        </TableRow>
+                                                                        <TableRow>
+                                                                            <TableCell>Image type</TableCell>
+                                                                            <TableCell>{selectedImage.file.type}</TableCell>
+                                                                        </TableRow>
+                                                                    </TableBody>
+                                                                </Table>
+                                                            </TableContainer>
+                                                        </div>
                                                     </div>
                                                 </>
                                             }
@@ -6380,26 +6386,26 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
 
                                     <Box sx={{ mt: 2 }}>
                                         {!createdPollDid && (
-                                        <>
-                                        <Select
-                                            value={registry}
-                                            onChange={(e) => setRegistry(e.target.value)}
-                                            sx={{ minWidth: 200, mb: 2 }}
-                                        >
-                                            {registries.map((r) => (
-                                                <MenuItem key={r} value={r}>
-                                                    {r}
-                                                </MenuItem>
-                                            ))}
-                                        </Select>
-                                        <Button
-                                            variant="contained"
-                                            onClick={handleCreatePoll}
-                                            sx={{ mr: 1 }}
-                                        >
+                                            <>
+                                                <Select
+                                                    value={registry}
+                                                    onChange={(e) => setRegistry(e.target.value)}
+                                                    sx={{ minWidth: 200, mb: 2 }}
+                                                >
+                                                    {registries.map((r) => (
+                                                        <MenuItem key={r} value={r}>
+                                                            {r}
+                                                        </MenuItem>
+                                                    ))}
+                                                </Select>
+                                                <Button
+                                                    variant="contained"
+                                                    onClick={handleCreatePoll}
+                                                    sx={{ mr: 1 }}
+                                                >
                                             Create
-                                        </Button>
-                                        </>
+                                                </Button>
+                                            </>
                                         )}
                                         <Button
                                             variant="outlined"
@@ -7766,7 +7772,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                         <Box>
                                             {lightningWalletError ?
                                                 <Typography color="error">{lightningWalletError}</Typography>
-                                            :
+                                                :
                                                 <Typography variant="h6">
                                                     Balance: {(lightningBalance ?? 0).toLocaleString()} sats
                                                 </Typography>
@@ -7836,20 +7842,20 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                                         const date = d ? `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, '0')}/${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}` : '—';
                                                         const displayStatus = p.status === 'success' ? 'settled'
                                                             : p.status === 'failed' ? 'failed'
-                                                            : (p.expiry && new Date(p.expiry) < new Date()) ? 'expired'
-                                                            : 'pending';
+                                                                : (p.expiry && new Date(p.expiry) < new Date()) ? 'expired'
+                                                                    : 'pending';
                                                         if (!lightningStatusFilter[displayStatus]) return null;
                                                         const statusColor = displayStatus === 'settled' ? 'inherit'
                                                             : displayStatus === 'failed' ? 'error.main'
-                                                            : 'text.secondary';
+                                                                : 'text.secondary';
                                                         return (
-                                                        <TableRow key={i}>
-                                                            <TableCell>{date}</TableCell>
-                                                            <TableCell align="right">{p.amount}</TableCell>
-                                                            <TableCell align="right">{p.fee > 0 ? p.fee : ''}</TableCell>
-                                                            <TableCell><Box component="span" sx={{ color: statusColor }}>{displayStatus}</Box></TableCell>
-                                                            <TableCell>{p.memo || '—'}</TableCell>
-                                                        </TableRow>
+                                                            <TableRow key={i}>
+                                                                <TableCell>{date}</TableCell>
+                                                                <TableCell align="right">{p.amount}</TableCell>
+                                                                <TableCell align="right">{p.fee > 0 ? p.fee : ''}</TableCell>
+                                                                <TableCell><Box component="span" sx={{ color: statusColor }}>{displayStatus}</Box></TableCell>
+                                                                <TableCell>{p.memo || '—'}</TableCell>
+                                                            </TableRow>
                                                         );
                                                     })}
                                                 </TableBody>
@@ -8006,14 +8012,14 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
                                             {loadingZap ? 'Zapping...' : 'Zap'}
                                         </Button>
                                     </Box>
-                                        {zapResult &&
+                                    {zapResult &&
                                             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 1 }}>
                                                 <Typography variant="body2"><strong>Status:</strong> {zapResult.paid ? 'Settled' : zapResult.status === 'failed' ? 'Failed' : 'Pending'}</Typography>
                                                 <Typography variant="body2"><strong>Payment Hash:</strong> {zapResult.paymentHash}</Typography>
                                                 {zapResult.preimage &&
                                                     <Typography variant="body2"><strong>Preimage (Proof):</strong> {zapResult.preimage}</Typography>
-                                            }
-                                        </Box>
+                                                }
+                                            </Box>
                                     }
                                 </Box>
                             }
@@ -8306,75 +8312,75 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
 
                             {didcommTab === 'endpoint' &&
                             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                            <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                <Typography variant="body2" sx={{ opacity: 0.7 }}>
                                 Publish a messaging endpoint so other agents can send encrypted DIDComm messages to this identity.
-                            </Typography>
+                                </Typography>
 
-                            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                                <Typography variant="subtitle2">Published</Typography>
-                                {didcommStatus
-                                    ? <>
-                                        {didcommStatus.endpoint
-                                            ? <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
-                                                <strong>Endpoint:</strong> {didcommStatus.endpoint}
-                                            </Typography>
-                                            : <Typography variant="body2">
-                                                <strong>Endpoint:</strong> key only (others can encrypt to this identity but have nowhere to deliver)
-                                            </Typography>
-                                        }
-                                        {didcommStatus.routingKeys.length > 0 &&
+                                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                                    <Typography variant="subtitle2">Published</Typography>
+                                    {didcommStatus
+                                        ? <>
+                                            {didcommStatus.endpoint
+                                                ? <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
+                                                    <strong>Endpoint:</strong> {didcommStatus.endpoint}
+                                                </Typography>
+                                                : <Typography variant="body2">
+                                                    <strong>Endpoint:</strong> key only (others can encrypt to this identity but have nowhere to deliver)
+                                                </Typography>
+                                            }
+                                            {didcommStatus.routingKeys.length > 0 &&
                                             <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
                                                 <strong>Routing keys:</strong> {didcommStatus.routingKeys.join(', ')}
                                             </Typography>
-                                        }
-                                        <Typography variant="body2">
-                                            <strong>Key agreement:</strong> {didcommStatus.keyAgreement ? 'published' : 'missing'}
-                                        </Typography>
-                                    </>
-                                    : <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                                            }
+                                            <Typography variant="body2">
+                                                <strong>Key agreement:</strong> {didcommStatus.keyAgreement ? 'published' : 'missing'}
+                                            </Typography>
+                                        </>
+                                        : <Typography variant="body2" sx={{ opacity: 0.7 }}>
                                         Nothing published for this identity yet.
-                                    </Typography>
-                                }
-                            </Box>
+                                        </Typography>
+                                    }
+                                </Box>
 
-                            <TextField
-                                label="Endpoint URL (optional)"
-                                value={didcommEndpoint}
-                                onChange={(e) => setDidcommEndpoint(e.target.value)}
-                                disabled={didcommBusy}
-                                placeholder="https://relay.example/didcomm"
-                                helperText="Leave blank to use this node's own relay."
-                                fullWidth
-                            />
-
-                            <TextField
-                                label="Routing keys (optional, comma separated)"
-                                value={didcommRoutingKeys}
-                                onChange={(e) => setDidcommRoutingKeys(e.target.value)}
-                                disabled={didcommBusy}
-                                placeholder="did:cid:mediator#key-agreement-1"
-                                helperText="Set these when delivery goes through a mediator; senders then wrap messages in a Forward."
-                                fullWidth
-                            />
-
-                            <Box sx={{ display: 'flex', gap: 1 }}>
-                                <Button
-                                    variant="contained"
-                                    color="primary"
-                                    onClick={publishDidComm}
+                                <TextField
+                                    label="Endpoint URL (optional)"
+                                    value={didcommEndpoint}
+                                    onChange={(e) => setDidcommEndpoint(e.target.value)}
                                     disabled={didcommBusy}
-                                >
-                                    {didcommStatus ? 'Update' : 'Publish'}
-                                </Button>
-                                <Button
-                                    variant="outlined"
-                                    color="primary"
-                                    onClick={unpublishDidComm}
-                                    disabled={didcommBusy || !didcommStatus}
-                                >
+                                    placeholder="https://relay.example/didcomm"
+                                    helperText="Leave blank to use this node's own relay."
+                                    fullWidth
+                                />
+
+                                <TextField
+                                    label="Routing keys (optional, comma separated)"
+                                    value={didcommRoutingKeys}
+                                    onChange={(e) => setDidcommRoutingKeys(e.target.value)}
+                                    disabled={didcommBusy}
+                                    placeholder="did:cid:mediator#key-agreement-1"
+                                    helperText="Set these when delivery goes through a mediator; senders then wrap messages in a Forward."
+                                    fullWidth
+                                />
+
+                                <Box sx={{ display: 'flex', gap: 1 }}>
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
+                                        onClick={publishDidComm}
+                                        disabled={didcommBusy}
+                                    >
+                                        {didcommStatus ? 'Update' : 'Publish'}
+                                    </Button>
+                                    <Button
+                                        variant="outlined"
+                                        color="primary"
+                                        onClick={unpublishDidComm}
+                                        disabled={didcommBusy || !didcommStatus}
+                                    >
                                     Unpublish
-                                </Button>
-                            </Box>
+                                    </Button>
+                                </Box>
                             </Box>
                             }
                         </Box>

--- a/apps/keymaster-client/src/KeymasterUI.jsx
+++ b/apps/keymaster-client/src/KeymasterUI.jsx
@@ -4674,12 +4674,12 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload, hasLightn
             const not = (tag) => !has(tag);
             // Neither deleted nor archived, i.e. still in the working set. The
             // three live tabs share this; archive and trash each define their own.
-            const live = () => not(DmailTags.DELETED) && not(DmailTags.ARCHIVED);
+            const live = not(DmailTags.DELETED) && not(DmailTags.ARCHIVED);
 
             const matchesTab = {
-                inbox: () => has(DmailTags.INBOX) && live(),
-                outbox: () => has(DmailTags.SENT) && live(),
-                drafts: () => has(DmailTags.DRAFT) && live(),
+                inbox: () => has(DmailTags.INBOX) && live,
+                outbox: () => has(DmailTags.SENT) && live,
+                drafts: () => has(DmailTags.DRAFT) && live,
                 archive: () => has(DmailTags.ARCHIVED) && not(DmailTags.DELETED),
                 trash: () => has(DmailTags.DELETED),
             };

--- a/scripts/gatekeeper-parity.mjs
+++ b/scripts/gatekeeper-parity.mjs
@@ -196,18 +196,18 @@ async function runApiFixtures() {
             fixture.compareMode === 'jsonLoose'
                 ? normalizeJson(ts.body)
                 : fixture.compareMode === 'errorText'
-                  ? normalizeErrorText(ts.body)
-                : fixture.compareMode === 'jsonSet'
-                  ? normalizeSetLikeJson(ts.body)
-                  : ts.body;
+                    ? normalizeErrorText(ts.body)
+                    : fixture.compareMode === 'jsonSet'
+                        ? normalizeSetLikeJson(ts.body)
+                        : ts.body;
         const rightBody =
             fixture.compareMode === 'jsonLoose'
                 ? normalizeJson(rust.body)
                 : fixture.compareMode === 'errorText'
-                  ? normalizeErrorText(rust.body)
-                : fixture.compareMode === 'jsonSet'
-                  ? normalizeSetLikeJson(rust.body)
-                  : rust.body;
+                    ? normalizeErrorText(rust.body)
+                    : fixture.compareMode === 'jsonSet'
+                        ? normalizeSetLikeJson(rust.body)
+                        : rust.body;
         assertEqual(`${fixture.name} body`, leftBody, rightBody);
         console.log(`ok api ${fixture.name}`);
     }
@@ -223,8 +223,8 @@ async function runApiFlows() {
                 flow.bodyFrom.file === 'proof-vectors.json'
                     ? proofVectors
                     : flow.bodyFrom.file === 'deterministic-vectors.json'
-                      ? deterministicVectors
-                      : null;
+                        ? deterministicVectors
+                        : null;
             if (!source) {
                 throw new Error(`Unsupported bodyFrom file: ${flow.bodyFrom.file}`);
             }
@@ -258,18 +258,18 @@ async function runApiFlows() {
             compareMode === 'jsonLoose'
                 ? normalizeJson(ts.body)
                 : compareMode === 'errorText'
-                  ? normalizeErrorText(ts.body)
-                : compareMode === 'jsonSet'
-                  ? normalizeSetLikeJson(ts.body)
-                  : ts.body;
+                    ? normalizeErrorText(ts.body)
+                    : compareMode === 'jsonSet'
+                        ? normalizeSetLikeJson(ts.body)
+                        : ts.body;
         const rightBody =
             compareMode === 'jsonLoose'
                 ? normalizeJson(rust.body)
                 : compareMode === 'errorText'
-                  ? normalizeErrorText(rust.body)
-                : compareMode === 'jsonSet'
-                  ? normalizeSetLikeJson(rust.body)
-                  : rust.body;
+                    ? normalizeErrorText(rust.body)
+                    : compareMode === 'jsonSet'
+                        ? normalizeSetLikeJson(rust.body)
+                        : rust.body;
         assertEqual(`${flow.name} body`, leftBody, rightBody);
 
         if (flow.capture?.key) {
@@ -356,7 +356,11 @@ async function runMetricsChecks() {
     }
 
     for (const route of metricsFixture.requiredNormalizedRoutes) {
-        if (!rustMetrics.includes(`route=\"${route}\"`) && !rustMetrics.includes(`route="${route}"`)) {
+        // One check, not two: inside a template literal `\"` is just `"`, so the
+        // former operand was the same expression as the latter. A raw Prometheus
+        // scrape writes labels as route="value", so that is the only form there
+        // is to look for.
+        if (!rustMetrics.includes(`route="${route}"`)) {
             console.warn(`warn metrics route label not yet observed in Rust scrape: ${route}`);
         }
     }

--- a/services/drawbridge/server/src/middleware/l402-auth.ts
+++ b/services/drawbridge/server/src/middleware/l402-auth.ts
@@ -302,7 +302,10 @@ export async function handlePaymentCompletion(
     req: Request,
     res: Response
 ): Promise<void> {
-    const { paymentHash, preimage } = req.body;
+    // Only the hash comes from the client. A preimage it supplied would be
+    // worthless as proof -- the authoritative one is fetched from the mediator
+    // below and verified against this hash.
+    const { paymentHash } = req.body;
 
     if (!paymentHash) {
         res.status(400).json({ error: 'paymentHash is required' });

--- a/tests/ci/lint-scope.test.ts
+++ b/tests/ci/lint-scope.test.ts
@@ -13,25 +13,52 @@ import { join } from 'path';
 
 const CONFIG = '.eslintrc.json';
 
-// The extensions this repo actually ships source in. Anything here must be
-// reachable by `eslint .`, whether through the default, a preset, or an override.
-const REQUIRED = ['.js', '.jsx', '.ts', '.tsx'];
+// Extensions `eslint .` must reach, whether through its default, a preset, or an
+// override in the config.
+const LINTED = ['.js', '.jsx', '.mjs', '.ts', '.tsx'];
 
-function sourceExtensions(dir: string, found = new Set<string>()): Set<string> {
+// Extensions present in the source trees that are deliberately not JavaScript to
+// lint -- assets, config, docs, and the Android build. Each entry is a decision
+// someone made; an extension in neither list fails the test rather than slipping
+// in unlinted, which is the whole point.
+const NOT_LINTABLE = [
+    '.css', '.env', '.html', '.ico', '.json', '.md', '.png', '.sh', '.svg',
+    '.txt', '.webmanifest', '.webp', '.xml',
+];
+
+// Build output, dependencies, and the native project trees. The Android and iOS
+// directories are whole Gradle/Xcode projects -- their .java, .gradle and .jar
+// files are not JavaScript anyone would lint, and enumerating them would bury
+// the extensions this test is actually asking about.
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', 'android', 'ios', 'public', 'static']);
+
+// Collects whatever extensions are there, deliberately without reference to
+// LINTED. An earlier version matched only /\.(js|jsx|ts|tsx)$/ -- so it could
+// never discover a fifth extension, which is exactly what it claimed to guard
+// against, while two unlinted .mjs files sat in the tree it was scanning.
+function extensionsIn(dir: string, found = new Set<string>()): Set<string> {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'build') {
+        if (SKIP_DIRS.has(entry.name)) {
             continue;
         }
 
         const path = join(dir, entry.name);
+
         if (entry.isDirectory()) {
-            sourceExtensions(path, found);
+            extensionsIn(path, found);
+            continue;
         }
-        else {
-            const match = /\.(js|jsx|ts|tsx)$/.exec(entry.name);
-            if (match) {
-                found.add(`.${match[1]}`);
-            }
+
+        // Dotfiles are configuration, never lintable source, and their names do
+        // not decompose the same way: .env.android would otherwise be read as an
+        // ".android" extension, which is not a thing.
+        if (entry.name.startsWith('.')) {
+            continue;
+        }
+
+        const dot = entry.name.lastIndexOf('.');
+        if (dot > 0) {
+            found.add(entry.name.slice(dot));
         }
     }
 
@@ -63,11 +90,29 @@ describe('lint scope', () => {
         expect(overridesSection()).toContain('.jsx');
     });
 
-    it('covers every extension this repo has source in', () => {
-        // If a fifth extension appears -- .mjs, .cjs -- it needs the same
-        // treatment, and this fails rather than letting it in unlinted.
-        const present = [...sourceExtensions('apps'), ...sourceExtensions('packages')];
+    it('has decided about every extension in the source trees', () => {
+        // A new one -- .cjs, .vue, .svelte -- lands here as a failure asking
+        // whether it is JavaScript that needs linting. That question going
+        // unasked is how .jsx stayed invisible.
+        const present = [
+            ...extensionsIn('apps'),
+            ...extensionsIn('packages'),
+            ...extensionsIn('scripts'),
+        ];
 
-        expect([...new Set(present)].sort()).toStrictEqual(REQUIRED.slice().sort());
+        const decided = new Set([...LINTED, ...NOT_LINTABLE]);
+        const undecided = [...new Set(present)].filter(extension => !decided.has(extension)).sort();
+
+        expect(undecided).toStrictEqual([]);
+    });
+
+    it('names every lintable extension the default does not cover', () => {
+        // eslint's default is .js; eslint-config-react-app adds **/*.ts?(x).
+        // Everything else has to be named explicitly or it is silently skipped.
+        const overrides = overridesSection();
+
+        for (const extension of ['.jsx', '.mjs']) {
+            expect(overrides).toContain(extension);
+        }
     });
 });

--- a/tests/ci/lint-scope.test.ts
+++ b/tests/ci/lint-scope.test.ts
@@ -1,0 +1,73 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+// `eslint .` expands a directory only to extensions it knows about: .js by
+// default, plus any named in an `overrides.files` pattern. eslint-config-react-app
+// contributes `**/*.ts?(x)`, so .ts and .tsx were linted and .jsx silently was
+// not -- 15 files, two of them 8400-line KeymasterUI copies, outside every
+// automated check in the repo. A whole feature went missing in one of them for
+// weeks without anything going red (#919, #935).
+//
+// This asserts the extension stays in scope. It reads the config rather than
+// running eslint, which would cost minutes for a fact that is one line of JSON.
+
+const CONFIG = '.eslintrc.json';
+
+// The extensions this repo actually ships source in. Anything here must be
+// reachable by `eslint .`, whether through the default, a preset, or an override.
+const REQUIRED = ['.js', '.jsx', '.ts', '.tsx'];
+
+function sourceExtensions(dir: string, found = new Set<string>()): Set<string> {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'build') {
+            continue;
+        }
+
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            sourceExtensions(path, found);
+        }
+        else {
+            const match = /\.(js|jsx|ts|tsx)$/.exec(entry.name);
+            if (match) {
+                found.add(`.${match[1]}`);
+            }
+        }
+    }
+
+    return found;
+}
+
+// Read as text, deliberately not parsed. .eslintrc.json permits JavaScript-style
+// comments that JSON.parse rejects, and stripping them with a regex is a trap
+// here: a glob like `**\/*.ts?(x)` contains `/*`, and `"**\/*.jsx"` contains `*/`,
+// so a block-comment stripper matches from one to the other and deletes the very
+// override this file exists to check. Found the hard way, by writing it.
+function overridesSection(): string {
+    const source = readFileSync(CONFIG, 'utf-8');
+    const start = source.indexOf('"overrides"');
+
+    expect(start).toBeGreaterThan(-1);
+
+    return source.slice(start);
+}
+
+describe('lint scope', () => {
+    it('has a config to read', () => {
+        // Guard the guard: a rename to flat config (eslint.config.js) would make
+        // every check below vacuous, and is exactly when this needs re-deciding.
+        expect(statSync(CONFIG).isFile()).toBe(true);
+    });
+
+    it('names .jsx in an override, since nothing else brings it into scope', () => {
+        expect(overridesSection()).toContain('.jsx');
+    });
+
+    it('covers every extension this repo has source in', () => {
+        // If a fifth extension appears -- .mjs, .cjs -- it needs the same
+        // treatment, and this fails rather than letting it in unlinted.
+        const present = [...sourceExtensions('apps'), ...sourceExtensions('packages')];
+
+        expect([...new Set(present)].sort()).toStrictEqual(REQUIRED.slice().sort());
+    });
+});


### PR DESCRIPTION
Prerequisite for #935.

`eslint .` expands a directory only to extensions it knows about: `.js` by default, plus any named in an `overrides.files` pattern. `eslint-config-react-app` contributes `**/*.ts?(x)` — which is why `.ts` and `.tsx` were linted and **`.jsx` silently was not**.

That left 15 files unlinted, two of them the 8400-line `KeymasterUI.jsx` copies. Those are also outside the typecheck gate (#923 — they aren't TypeScript) and outside the render harness (#914 — that covers the wallets' provider trees). **Every automated check in the repo missed them**, which is how a whole feature landed in two of four UIs and went unnoticed for weeks (#919).

Coverage: **457 → 472 files**. The fix is one empty override; naming the extension is the entire point.

## Clearing the 281 errors that surfaced

In ascending order of risk:

| Count | Rule | How it was handled |
| --- | --- | --- |
| 272 | `indent` | auto-fixed |
| 8 | `sonarjs/no-duplicated-branches` | refactored |
| 1 | `sonarjs/no-collapsible-if` | collapsed |

**The `indent` fix is whitespace-only — proved, not assumed.** Both clients rebuild to byte-identical bundles:

```
before   keymaster-client d2d940963340b08e 845762   gatekeeper-client 1b14b95ef5f255da 1597889
after    keymaster-client d2d940963340b08e 845762   gatekeeper-client 1b14b95ef5f255da 1597889
```

**The `no-duplicated-branches` finding was correct.** The dmail tab filter was a dispatch table written as an if/else chain whose every branch assigned the same thing. It's now an actual dispatch table.

Byte-identity can't prove *that* one, and the file has no tests — so equivalence was proved exhaustively instead: every subset of the seven `DmailTags` crossed with six tabs, **768 cases, zero mismatches**. (Bundles shrink by exactly 56 bytes each, which is the five duplicated assignments going away.)

Both `KeymasterUI.jsx` copies remain byte-identical to each other.

## The guard

`tests/ci/lint-scope.test.ts` keeps `.jsx` named, and fails if a fifth source extension appears unlinted. Mutation-tested: removing the override, and naming `tsx` instead of `jsx`, each turn it red.

It reads the config as **text rather than parsing it**, for a reason worth recording. My first version stripped comments before `JSON.parse`, and the block-comment regex ate the override — `**/*.ts?(x)` contains `/*`, `"**/*.jsx"` contains `*/`, so it matched from one to the other and deleted exactly what the test checks. Globs and C-style comments share delimiters.

## Not included

9 warnings remain — 8 `no-unused-vars` in the KeymasterUI copies, 1 pre-existing in drawbridge. Warnings don't gate CI, and clearing them means touching more of an untested file than this change needs to.

2269 tests, typecheck 0, `eslint .` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)