### PR TITLE
feat(keymaster): Let a credential name the asset that holds it

### DIFF
--- a/packages/clients/src/keymaster-types.ts
+++ b/packages/clients/src/keymaster-types.ts
@@ -144,6 +144,12 @@ export interface CredentialSchema {
 export interface VerifiableCredential {
     "@context": string[];
     type: string[];
+    // The DID of the asset holding this credential, set by issueCredential
+    // after the asset exists and covered by the issuer's signature, so a reader
+    // can tell where the credential lives and check it for revocation (#108).
+    // Optional because credentials issued before that existed do not carry it;
+    // absent means unbound rather than invalid.
+    id?: string;
     issuer: string;
     validFrom: string;
     validUntil?: string;

--- a/packages/keymaster/src/didcomm-protocols.ts
+++ b/packages/keymaster/src/didcomm-protocols.ts
@@ -129,11 +129,17 @@ export function requestCredential(thid?: string, comment?: string): DidCommPlain
     return { type: ISSUE_CREDENTIAL_REQUEST_TYPE, ...(thid ? { thid } : {}), body: comment ? { comment } : {} };
 }
 
-// `credentialDid` is an Archon-specific hint, and it rides in the body rather
-// than inside the credential on purpose: the proof covers every field of the VC
-// except `proof` itself, so adding an `id` after signing would make the
-// credential fail verification for exactly the foreign recipient this message
-// exists to reach. The attachment must travel byte-for-byte as it was signed.
+// `credentialDid` is an Archon-specific hint carried in the body, where the
+// issue-credential protocol expects it.
+//
+// It used to be the only place the DID appeared. The proof covers every field
+// of the VC except `proof` itself, so an `id` written after signing would have
+// made the credential fail verification for exactly the foreign recipient this
+// message exists to reach. issueCredential now sets `id` *before* signing --
+// it re-signs once the asset exists and its DID is known -- so the attachment
+// carries its own identifier and still verifies (#108).
+//
+// The attachment must still travel byte-for-byte as it was signed.
 export function issueCredentialMessage(
     credential: object,
     options: { thid?: string; comment?: string; credentialDid?: string } = {}

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -3590,11 +3590,30 @@ export default class Keymaster implements KeymasterInterface {
         const signed = await this.addProof(credential);
         const subjectId = credential.credentialSubject!.id;
 
-        if (this.isManagedDID(subjectId)) {
-            return this.encryptJSON(signed, subjectId, { ...options, includeHash: true });
-        }
+        const did = this.isManagedDID(subjectId)
+            ? await this.encryptJSON(signed, subjectId, { ...options, includeHash: true })
+            : await this.encryptJSON(signed, id.did, { ...options, includeHash: true, encryptForSender: false });
 
-        return this.encryptJSON(signed, id.did, { ...options, includeHash: true, encryptForSender: false });
+        // Bind the credential to the asset holding it, under the issuer's own
+        // signature. Without this a credential says nothing about where it
+        // lives, so a holder can copy a revoked one -- genuinely issued,
+        // correctly signed, and still verifying -- under a fresh asset DID and
+        // present it as current. Signature, issuer and subject all check out,
+        // because the credential is authentic; only the pointer lies, and the
+        // pointer was the one part nobody signed (#108).
+        //
+        // Two steps rather than one because the DID is the CID of the operation
+        // that creates the asset, so it cannot be known before the asset
+        // exists. That is only true of the create operation: updateDID appends
+        // to the same chain and leaves the identifier alone, so re-signing the
+        // credential with its own DID does not move it.
+        //
+        // `id` is a standard optional property of a W3C Verifiable Credential,
+        // so a verifier that knows nothing about Archon still reads it as the
+        // credential's identifier.
+        await this.updateCredential(did, { ...credential, id: did } as VerifiableCredential);
+
+        return did;
     }
 
     async sendCredential(

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -3649,10 +3649,11 @@ export default class Keymaster implements KeymasterInterface {
     // DID nor decrypt what it points at -- issueCredential encrypts to the ISSUER
     // when the subject is not managed. So this carries the credential itself.
     //
-    // The attachment is the signed VC exactly as issued, and the credential's own
-    // DID rides in the body instead: the proof covers every field but `proof`, so
-    // an `id` added afterwards would make the credential fail verification for the
-    // very recipient this exists to reach. The recipient verifies `proof` by
+    // The attachment is the signed VC exactly as issued, and it names its own
+    // asset DID: issueCredential embeds `id` before signing, so the identifier is
+    // covered by the proof rather than added after it (#108). `credential_did`
+    // stays in the body, which is where the protocol expects the hint and what an
+    // Archon holder reads to acceptCredential. The recipient verifies `proof` by
     // resolving the issuer's did:cid, which any Universal Resolver carrying the
     // did:cid driver can do; an Archon holder reads the body to acceptCredential.
     async sendCredentialDidComm(
@@ -3692,11 +3693,16 @@ export default class Keymaster implements KeymasterInterface {
             return false;
         }
 
-        // The DID rides outside the signed credential, so nothing on the wire
-        // binds the two together: a sender could attach one credential and name
-        // another. Both would have to be genuinely issued to this holder for
+        // A sender could attach one credential and name another in the body.
+        // Both would have to be genuinely issued to this holder for
         // acceptCredential to take them, so this is not forgery -- but storing
         // something other than what the user was shown is still wrong.
+        //
+        // The credential now names its own asset under the issuer's signature
+        // (#108), so `attached.id` would disagree with `credentialDid` on a
+        // mismatch. Comparing the full content still catches strictly more:
+        // it also rejects an attachment that names the right DID but differs
+        // from what that DID actually holds.
         const attached = attachedJson(message as DidCommPlaintext);
         const resolved = await this.getCredential(credentialDid);
 

--- a/python/keymaster/src/keymaster/core.py
+++ b/python/keymaster/src/keymaster/core.py
@@ -3358,10 +3358,11 @@ class Keymaster:
         # that DID nor decrypt what it points at (issue_credential encrypts to the
         # ISSUER when the subject is not managed). So this carries the credential.
         #
-        # The attachment is the signed VC exactly as issued, and the credential's
-        # own DID travels in the body: the proof covers every field but `proof`,
-        # so an `id` added after signing would make the credential fail
-        # verification for the very recipient this message exists to reach.
+        # The attachment is the signed VC exactly as issued, and it names its own
+        # asset DID: issue_credential embeds `id` before signing, so the
+        # identifier is covered by the proof rather than added after it (#108).
+        # `credential_did` stays in the body, which is where the protocol expects
+        # the hint and what an Archon holder reads to accept_credential.
         options = options or {}
         credential_did = await self.lookup_did(did)
         vc = await self.get_credential(credential_did)
@@ -3392,11 +3393,16 @@ class Keymaster:
             # there is nothing for this wallet to hold.
             return False
 
-        # The DID rides outside the signed credential, so nothing on the wire
-        # binds the two together: a sender could attach one credential and name
-        # another. Both would have to be genuinely issued to this holder for
+        # A sender could attach one credential and name another in the body.
+        # Both would have to be genuinely issued to this holder for
         # accept_credential to take them, so this is not forgery -- but storing
         # something other than what the user was shown is still wrong.
+        #
+        # The credential now names its own asset under the issuer's signature
+        # (#108), so `attached["id"]` would disagree with `credential_did` on a
+        # mismatch. Comparing the full content still catches strictly more: it
+        # also rejects an attachment that names the right DID but differs from
+        # what that DID actually holds.
         attached = dc_protocols.attached_json(message)
         resolved = await self.get_credential(credential_did)
 

--- a/python/keymaster/src/keymaster/core.py
+++ b/python/keymaster/src/keymaster/core.py
@@ -2866,8 +2866,26 @@ class Keymaster:
         signed = await self.add_proof(credential)
         subject_id = credential.get("credentialSubject", {}).get("id")
         if self.is_managed_did(subject_id):
-            return await self.encrypt_json(signed, subject_id, {**options, "includeHash": True})
-        return await self.encrypt_json(signed, id_info["did"], {**options, "includeHash": True, "encryptForSender": False})
+            did = await self.encrypt_json(signed, subject_id, {**options, "includeHash": True})
+        else:
+            did = await self.encrypt_json(
+                signed, id_info["did"], {**options, "includeHash": True, "encryptForSender": False}
+            )
+
+        # Bind the credential to the asset holding it, under the issuer's own
+        # signature. Without this a credential says nothing about where it
+        # lives, so a holder can copy a revoked one -- genuinely issued,
+        # correctly signed, still verifying -- under a fresh asset DID and
+        # present it as current. Only the pointer lies, and the pointer was the
+        # one part nobody signed (#108).
+        #
+        # Two steps rather than one because the DID is the CID of the operation
+        # that creates the asset, so it cannot be known before the asset exists.
+        # That is only true of the create operation: updating appends to the
+        # same chain and leaves the identifier alone.
+        await self.update_credential(did, {**credential, "id": did})
+
+        return did
 
     def verify_tag_list(self, tags: list[str]) -> list[str]:
         if not isinstance(tags, list):

--- a/python/keymaster/src/keymaster/didcomm_protocols.py
+++ b/python/keymaster/src/keymaster/didcomm_protocols.py
@@ -108,11 +108,17 @@ def request_credential(thid: str | None = None, comment: str | None = None) -> d
     return _with_thid({"type": ISSUE_CREDENTIAL_REQUEST_TYPE, "body": {"comment": comment} if comment else {}}, thid)
 
 
-# `credential_did` is an Archon-specific hint, and it rides in the body rather
-# than inside the credential on purpose: the proof covers every field of the VC
-# except `proof` itself, so adding an `id` after signing would make the
-# credential fail verification for exactly the foreign recipient this message
-# exists to reach. The attachment must travel byte-for-byte as it was signed.
+# `credential_did` is an Archon-specific hint carried in the body, where the
+# issue-credential protocol expects it.
+#
+# It used to be the only place the DID appeared. The proof covers every field of
+# the VC except `proof` itself, so an `id` written after signing would have made
+# the credential fail verification for exactly the foreign recipient this
+# message exists to reach. issue_credential now sets `id` *before* signing -- it
+# re-signs once the asset exists and its DID is known -- so the attachment
+# carries its own identifier and still verifies (#108).
+#
+# The attachment must still travel byte-for-byte as it was signed.
 def issue_credential_message(
     credential: dict[str, Any],
     thid: str | None = None,

--- a/python/keymaster/tests/test_credential.py
+++ b/python/keymaster/tests/test_credential.py
@@ -38,6 +38,27 @@ def test_issue_get_and_list_issued_credential(testbed):
     assert run(testbed.keymaster.list_issued()) == [did]
 
 
+def test_issued_credential_names_its_own_did(testbed):
+    """A credential must say which asset holds it, under the issuer's signature.
+
+    Otherwise nothing binds the two: a holder can copy a revoked credential --
+    genuinely issued and still verifying -- under a fresh asset DID and present
+    it as current, because only the pointer lies and the pointer is the part
+    nobody signed (#108).
+    """
+    subject = run(testbed.keymaster.create_id("Bob"))
+    schema_did = run(testbed.keymaster.create_schema(MOCK_SCHEMA))
+    bound = run(testbed.keymaster.bind_credential(subject, {"schema": schema_did}))
+
+    did = run(testbed.keymaster.issue_credential(bound))
+    vc = run(testbed.keymaster.get_credential(did))
+
+    assert vc["id"] == did
+    # Embedded before signing rather than bolted on after, so the binding is
+    # the issuer's statement and not something a later holder could have added.
+    assert run(testbed.keymaster.verify_proof(vc)) is True
+
+
 def test_accept_and_list_held_credential(testbed):
     run(testbed.keymaster.create_id("Alice"))
     bob = run(testbed.keymaster.create_id("Bob"))

--- a/python/keymaster/tests/test_didcomm.py
+++ b/python/keymaster/tests/test_didcomm.py
@@ -589,9 +589,11 @@ def test_send_credential_didcomm_carries_the_credential_not_a_reference(monkeypa
         km.send_credential_didcomm("did:cid:credential", "did:web:example.com")
     ) == ["msg-1"]
 
-    # The DID is named in the body, and the credential travels byte-for-byte as
-    # it was signed: the proof covers every field but `proof`, so an `id` added
-    # afterwards would break verification for the recipient this exists to reach.
+    # The DID is named in the body, where the protocol expects the hint, and the
+    # credential travels byte-for-byte as it was signed. It also names its own
+    # asset DID: issue_credential embeds `id` before signing, so the identifier
+    # is covered by the proof rather than added after it (#108). This test hands
+    # in its own VC, so what arrives is whatever was passed.
     assert sent["message"]["body"]["credential_did"] == "did:cid:credential"
 
     attached = sent["message"]["attachments"][0]["data"]["json"]
@@ -599,8 +601,11 @@ def test_send_credential_didcomm_carries_the_credential_not_a_reference(monkeypa
 
 
 def test_accept_credential_didcomm_refuses_a_credential_it_did_not_show(monkeypatch):
-    # Nothing on the wire binds the body's DID to the attachment, so a sender can
-    # name one credential and display another.
+    # A sender can name one credential in the body and attach another. The
+    # credential now names its own asset under the issuer's signature (#108), so
+    # the two would disagree -- but comparing the full content catches strictly
+    # more, including an attachment that names the right DID and differs from
+    # what that DID holds.
     import asyncio
     from keymaster.core import Keymaster
 

--- a/tests/keymaster/credential.test.ts
+++ b/tests/keymaster/credential.test.ts
@@ -176,6 +176,48 @@ describe('publishCredential', () => {
         expect(manifest[did]).toStrictEqual(vc);
     });
 
+    // A credential must say which asset holds it, under the issuer's signature.
+    // Otherwise nothing binds the two, and a holder can copy a revoked
+    // credential -- genuinely issued, correctly signed, still verifying --
+    // under a fresh asset DID and present it as current. Signature, issuer and
+    // subject all check out, because the credential is authentic; only the
+    // pointer lies, and the pointer was the part nobody signed (#108).
+    it('names its own DID, under the issuer\'s signature', async () => {
+        const bob = await keymaster.createId('Bob');
+        const schemaDid = await keymaster.createSchema(mockSchema);
+        const bound = await keymaster.bindCredential(bob, { schema: schemaDid });
+
+        const did = await keymaster.issueCredential(bound);
+        const vc = await keymaster.getCredential(did) as VerifiableCredential;
+
+        expect(vc.id).toBe(did);
+        // Embedded before signing rather than bolted on afterwards, so the
+        // binding is the issuer's statement and not something a later holder
+        // could have added. Asserting the id alone would pass either way.
+        expect(await keymaster.verifyProof(vc)).toBe(true);
+    });
+
+    // The binding has to survive publication, since a manifest entry is where
+    // a reader actually encounters it.
+    it('keeps its DID through publication, revealed or not', async () => {
+        const bob = await keymaster.createId('Bob');
+        const schemaDid = await keymaster.createSchema(mockSchema);
+        const bound = await keymaster.bindCredential(bob, { schema: schemaDid });
+        const did = await keymaster.issueCredential(bound);
+
+        await keymaster.publishCredential(did, { reveal: true });
+        const revealed = (((await keymaster.resolveDID(bob)).didDocumentData as any).manifest)[did];
+        expect(revealed.id).toBe(did);
+
+        // Redaction strips the claim values, so this copy cannot have its
+        // signature checked -- but it still names the asset it came from,
+        // which is what a revocation lookup needs.
+        await keymaster.publishCredential(did);
+        const redacted = (((await keymaster.resolveDID(bob)).didDocumentData as any).manifest)[did];
+        expect(redacted.id).toBe(did);
+        expect(Object.keys(redacted.credentialSubject!)).toStrictEqual(['id']);
+    });
+
     // Herald's public profile depends on this exact shape. A non-revealed
     // publication cannot verify -- the proof covers claims that were stripped
     // after signing -- so the profile recognises the redaction and says so,
@@ -534,7 +576,11 @@ describe('updateCredential', () => {
         expect(updated.validUntil).toBe(vc.validUntil);
 
         const doc = await keymaster.resolveDID(did);
-        expect(doc.didDocumentMetadata!.versionSequence).toBe("2");
+        // Three, not two: issuing a credential now takes two operations. The
+        // asset is created, and then updated with its own DID embedded and
+        // re-signed, because a DID derived from the create operation cannot be
+        // known before that operation exists (#108). This update is the third.
+        expect(doc.didDocumentMetadata!.versionSequence).toBe("3");
     });
 
     it('should throw exception on invalid parameters', async () => {

--- a/tests/keymaster/didcomm.test.ts
+++ b/tests/keymaster/didcomm.test.ts
@@ -1001,14 +1001,20 @@ describe('credential exchange over DIDComm', () => {
         const { message } = await keymaster.unpackDidComm(packed, { name: 'Bob' });
         expect(message.type).toBe('https://didcomm.org/issue-credential/3.0/issue-credential');
 
-        // The DID is named in the body, NOT inside the credential: the proof
-        // covers every field but `proof`, so an `id` added after signing would
-        // make the credential fail verification for the very recipient this
-        // message exists to reach.
+        // The DID is named in the body, where the issue-credential protocol puts
+        // it, and again inside the credential as its `id`. Those used to be
+        // alternatives: an `id` written after signing would have broken the
+        // proof, which covers every field but `proof` itself. issueCredential
+        // now sets it before signing -- it re-signs once the asset exists and
+        // its DID is known -- so the credential carries its own identifier and
+        // still verifies (#108). The assertion below proves the second half.
         expect(message.body.credential_did).toBe(credentialDid);
 
         const attached = message.attachments[0].data.json;
-        expect(attached.id).toBeUndefined();
+        // Self-describing on the wire: a recipient holding only the attachment
+        // knows which asset it came from, without trusting whoever handed it
+        // over to have named it honestly.
+        expect(attached.id).toBe(credentialDid);
         expect(attached.credentialSubject.id).toBe(bob);
         expect(attached.issuer).toBeDefined();
         // The signature travels with it, so a foreign holder can verify against

--- a/tests/keymaster/didcomm.test.ts
+++ b/tests/keymaster/didcomm.test.ts
@@ -1045,11 +1045,15 @@ describe('credential exchange over DIDComm', () => {
     });
 
     it('refuses a credential that is not the one it showed', async () => {
-        // Nothing on the wire binds the body's DID to the attachment, so a
-        // sender can name one credential and display another. Both must be
-        // genuinely issued to this holder for acceptCredential to take them, so
-        // this is not forgery -- but storing something other than what the user
-        // was shown is still wrong.
+        // A sender can name one credential in the body and attach another. Both
+        // must be genuinely issued to this holder for acceptCredential to take
+        // them, so this is not forgery -- but storing something other than what
+        // the user was shown is still wrong.
+        //
+        // The credential now names its own asset under the issuer's signature
+        // (#108), so the two would disagree on a mismatch. Comparing the full
+        // content catches strictly more: an attachment naming the right DID but
+        // differing from what that DID holds is also refused.
         await keymaster.createId('Alice');
         const bob = await keymaster.createId('Bob');
         await keymaster.setCurrentId('Alice');


### PR DESCRIPTION
Closes #108, which asked for exactly this in February: *"update the credential with a custom DID field so it can be checked for revocation."*

## The gap

A published credential lives in `didDocumentData.manifest` as `{ [assetDID]: VC }`. The **value** is signed; the **key** is not, and `bindCredential` built no `id`, so nothing in the credential referred to the asset holding it.

A holder whose credential has been revoked could therefore write the same signed VC — untouched, genuinely issued, still verifying — under a fresh and still-active asset DID. Signature, issuer and subject all pass, because the credential is authentic. Only the pointer lies, and the pointer was the one part nobody signed.

This surfaced from the other end in #946, where Herald began verifying published credentials and could not soundly check revocation.

## The fix

`issueCredential` creates the asset, then re-signs the credential with `id: <did>` embedded. The binding is the issuer's statement rather than something a later holder could have added.

The obvious objection is circularity — the DID is the CID of the operation that creates the asset. That is only true of the **create** operation: `updateDID` appends to the same chain and leaves the identifier alone, and `updateCredential` already does the required work (strip proof, re-sign, re-encrypt, same DID).

`id` is a standard optional property of a W3C Verifiable Credential, so this is not an Archon extension — a foreign verifier reads it as the credential's identifier.

## Two consequences, both real

**Issuance costs two operations.** Free on the default registry; batched on blockchain registries. Unavoidable, for the reason above.

**A credential now starts at version 2.** One test asserted this directly and now records why.

## The DIDComm comment

That test carried a deliberate note:

> The DID is named in the body, NOT inside the credential: the proof covers every field but `proof`, so an `id` added after signing would make the credential fail verification.

Correct about the approach it was warning against, and not true of re-signing — the same test still asserts `verifyProof(attached)` passes. The body keeps `credential_did`, which the issue-credential protocol asks for; the credential now also carries its own. The comment is rewritten rather than deleted, since the reasoning is worth keeping alongside why it no longer applies.

## Why not the cipher_hash alternative

`issueCredential` stores `cipher_hash` publicly on the asset, so a verifier can bind key to value today by hashing the published copy. I confirmed that works, and it needs no issuance change at all. It loses on three counts:

- The binding is incidental rather than asserted by the issuer.
- It depends on `JSON.stringify` reproducing byte-identical output across a parse round trip.
- It cannot work for **redacted** publications, whose copy no longer hashes to the original — and `publishCredential` redacts by default, so it would fail for most credentials.

A signed `id` survives redaction. A test pins that: a redacted copy keeps only `{ id }` in `credentialSubject` and still names its asset, which is exactly what a revocation lookup needs.

## Verification

Tests in both ports, each mutation-checked — removing the binding fails "names its own DID" and "keeps its DID through publication", and the Python equivalent.

1472 tests pass across `tests/keymaster`, `tests/herald`, `tests/clients` and `tests/mcp-server`; 254 in Python; eslint clean.

The Python port has the same change. Its issuance is a behaviour rather than a route, so `python-service-parity` would not have caught a divergence.

## Follow-up

Herald's revocation check in #946 is documented as best-effort. Once this lands it can compare `vc.id` against the manifest key and become sound. Not done here, to keep this to the credential format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)