### PR TITLE
fix(herald): Trust the manifest key only when the credential names it

### DIFF
--- a/services/herald/server/src/routes.ts
+++ b/services/herald/server/src/routes.ts
@@ -127,27 +127,42 @@ async function checkManifestCredential(
             return { status: 'unverified', reason: 'issuer does not match the signing key' };
         }
 
+        // The manifest key says which asset holds this credential, and the key
+        // is controller data. A credential issued since #108 names its own
+        // asset as `id`, under the issuer's signature, so the two can be
+        // compared: disagreement means the entry is filed under an asset the
+        // issuer never put it in, and the revocation state of that asset says
+        // nothing about this credential.
+        //
+        // Checked before the signature because it costs nothing and because a
+        // redacted credential still carries its `id` -- redaction strips the
+        // claim values and leaves the identifier alone.
+        const bound = typeof vc.id === 'string';
+
+        if (bound && vc.id !== credentialDid) {
+            return { status: 'unverified', reason: 'filed under an asset it does not name' };
+        }
+
+        // Revocation next, and ahead of the signature, because "revoked" tells
+        // a reader more than "cannot be checked" for a credential that is both.
+        //
+        // Sound where the credential is bound. Where it is not -- anything
+        // issued before #108 -- this is best effort: an owner can re-key a
+        // revoked credential under a fresh asset and the lookup follows them
+        // there. Absence of `id` means unbound, not invalid, so those
+        // credentials keep working rather than being marked down for their age.
+        const doc = await keymaster.resolveDID(credentialDid);
+
+        if (doc?.didDocumentMetadata?.deactivated) {
+            return { status: 'unverified', reason: 'revoked by the issuer' };
+        }
+
         if (isRedactedPublication(vc)) {
             return { status: 'unverified', reason: 'published without its claims, so the signature cannot be checked' };
         }
 
         if (!await keymaster.verifyProof(vc)) {
             return { status: 'unverified', reason: 'signature does not verify' };
-        }
-
-        // The manifest holds a copy of the credential, so revoking the
-        // credential asset leaves that copy in place and looking healthy.
-        //
-        // Best effort, and worth being clear about why: nothing in the proof
-        // binds a credential to the asset DID it was stored under, and the
-        // manifest key is controller data, so an owner can re-key a revoked
-        // credential under a fresh asset and this lookup will follow them
-        // there. It catches the ordinary case and cannot be relied on against
-        // someone trying to avoid it.
-        const doc = await keymaster.resolveDID(credentialDid);
-
-        if (doc?.didDocumentMetadata?.deactivated) {
-            return { status: 'unverified', reason: 'revoked by the issuer' };
         }
 
         return { status: 'verified' };

--- a/services/herald/server/src/routes.ts
+++ b/services/herald/server/src/routes.ts
@@ -127,42 +127,47 @@ async function checkManifestCredential(
             return { status: 'unverified', reason: 'issuer does not match the signing key' };
         }
 
-        // The manifest key says which asset holds this credential, and the key
-        // is controller data. A credential issued since #108 names its own
-        // asset as `id`, under the issuer's signature, so the two can be
-        // compared: disagreement means the entry is filed under an asset the
-        // issuer never put it in, and the revocation state of that asset says
-        // nothing about this credential.
-        //
-        // Checked before the signature because it costs nothing and because a
-        // redacted credential still carries its `id` -- redaction strips the
-        // claim values and leaves the identifier alone.
-        const bound = typeof vc.id === 'string';
-
-        if (bound && vc.id !== credentialDid) {
-            return { status: 'unverified', reason: 'filed under an asset it does not name' };
-        }
-
-        // Revocation next, and ahead of the signature, because "revoked" tells
-        // a reader more than "cannot be checked" for a credential that is both.
-        //
-        // Sound where the credential is bound. Where it is not -- anything
-        // issued before #108 -- this is best effort: an owner can re-key a
-        // revoked credential under a fresh asset and the lookup follows them
-        // there. Absence of `id` means unbound, not invalid, so those
-        // credentials keep working rather than being marked down for their age.
-        const doc = await keymaster.resolveDID(credentialDid);
-
-        if (doc?.didDocumentMetadata?.deactivated) {
-            return { status: 'unverified', reason: 'revoked by the issuer' };
-        }
-
         if (isRedactedPublication(vc)) {
             return { status: 'unverified', reason: 'published without its claims, so the signature cannot be checked' };
         }
 
         if (!await keymaster.verifyProof(vc)) {
             return { status: 'unverified', reason: 'signature does not verify' };
+        }
+
+        // Everything below rests on the signature having been checked, and the
+        // order is load-bearing rather than incidental. The proof covers the
+        // whole credential except `proof` itself, so until it verifies, no
+        // field is the issuer's word for anything -- `id` included. A redacted
+        // copy can never verify, which means its `id` is an unsigned string a
+        // holder may rewrite at will, along with the key it is filed under.
+        //
+        // Reading revocation before this point looked like an improvement,
+        // since `id` textually survives redaction. It is not: a revoked
+        // redacted credential re-keyed to a fresh active asset would agree with
+        // itself and be reported as merely unreadable rather than revoked.
+        // Same verdict, misleading reason.
+
+        // The manifest key says which asset holds this credential, and the key
+        // is unsigned controller data. A credential issued since #108 names its
+        // own asset as `id`, so now that the signature has been checked the two
+        // can be compared: disagreement means the entry sits under an asset the
+        // issuer never put it in, whose revocation state says nothing about
+        // this credential.
+        if (typeof vc.id === 'string' && vc.id !== credentialDid) {
+            return { status: 'unverified', reason: 'filed under an asset it does not name' };
+        }
+
+        // Sound where the credential names its asset. Where it does not --
+        // anything issued before #108 -- this is best effort: an owner can
+        // re-key a revoked credential under a fresh asset and the lookup
+        // follows them there. Absence of `id` means unbound, not invalid, so
+        // those credentials keep working rather than being marked down for
+        // their age.
+        const doc = await keymaster.resolveDID(credentialDid);
+
+        if (doc?.didDocumentMetadata?.deactivated) {
+            return { status: 'unverified', reason: 'revoked by the issuer' };
         }
 
         return { status: 'verified' };

--- a/tests/herald/routes.test.ts
+++ b/tests/herald/routes.test.ts
@@ -1199,15 +1199,36 @@ describe('herald member lookup', () => {
             });
         });
 
-        // Revocation is reported ahead of the signature, because a credential
-        // that is both revoked and unverifiable is better described as revoked.
-        // The id survives redaction, so this answer is available even when the
-        // signature is not.
-        it('reports a redacted credential as revoked rather than unreadable', async () => {
+        // A redacted credential gets no revocation answer, and that is the
+        // honest one. Its `id` survives redaction textually, but the proof
+        // covers the whole credential except `proof` itself, so a copy that can
+        // never verify has no field the issuer stands behind -- `id` included.
+        //
+        // Reading revocation first looked like an improvement. It is not: a
+        // holder can re-key a revoked redacted credential to a fresh active
+        // asset, rewrite the matching `id`, and have it agree with itself. The
+        // verdict would still be unverified, but the reason would say
+        // unreadable when the truth is revoked.
+        it('makes no revocation claim about a credential it cannot verify', async () => {
             const redacted = issued({ id: 'did:cid:vc', credentialSubject: { id: ALICE } });
             const { app } = mountWith(redacted, { verifyProof: false, deactivated: true });
 
-            expect(await statusOf(app)).toStrictEqual({ status: 'unverified', reason: 'revoked by the issuer' });
+            expect(await statusOf(app)).toStrictEqual({
+                status: 'unverified',
+                reason: 'published without its claims, so the signature cannot be checked',
+            });
+        });
+
+        // The same order protects the binding check. A tampered `id` fails on
+        // the signature, which is the stronger statement -- reporting it as
+        // misfiled would imply the rest of the credential was sound.
+        it('catches a tampered id at the signature, not at the binding', async () => {
+            const { app } = mountWith(issued({ id: 'did:cid:vc' }), { verifyProof: false });
+
+            expect(await statusOf(app)).toStrictEqual({
+                status: 'unverified',
+                reason: 'signature does not verify',
+            });
         });
 
         // The endpoint is public and the manifest is written by the profile's

--- a/tests/herald/routes.test.ts
+++ b/tests/herald/routes.test.ts
@@ -1162,6 +1162,54 @@ describe('herald member lookup', () => {
             });
         });
 
+        // A credential issued since #108 names the asset holding it, under the
+        // issuer's signature, so the manifest key can be checked against it.
+        // Without that the key is unsigned controller data and a revoked
+        // credential can be re-keyed under a fresh, active asset.
+        describe('binding the entry to the asset it names', () => {
+            it('accepts a credential filed under the asset it names', async () => {
+                const { app } = mountWith(issued({ id: 'did:cid:vc' }));
+
+                expect(await statusOf(app)).toStrictEqual({ status: 'verified' });
+            });
+
+            it('refuses one filed under an asset it does not name', async () => {
+                // The credential is genuine and verifies; only the key lies.
+                const { app } = mountWith(issued({ id: 'did:cid:somewhere-else' }));
+
+                expect(await statusOf(app)).toStrictEqual({
+                    status: 'unverified',
+                    reason: 'filed under an asset it does not name',
+                });
+            });
+
+            it('makes the revocation lookup meaningful for a bound credential', async () => {
+                const { app } = mountWith(issued({ id: 'did:cid:vc' }), { deactivated: true });
+
+                expect(await statusOf(app)).toStrictEqual({ status: 'unverified', reason: 'revoked by the issuer' });
+            });
+
+            // Credentials issued before #108 carry no id. Absence means unbound,
+            // not invalid -- marking every older credential down for its age
+            // would be the same mistake as calling a redacted one a forgery.
+            it('still checks an unbound credential, best effort', async () => {
+                const { app } = mountWith(issued());
+
+                expect(await statusOf(app)).toStrictEqual({ status: 'verified' });
+            });
+        });
+
+        // Revocation is reported ahead of the signature, because a credential
+        // that is both revoked and unverifiable is better described as revoked.
+        // The id survives redaction, so this answer is available even when the
+        // signature is not.
+        it('reports a redacted credential as revoked rather than unreadable', async () => {
+            const redacted = issued({ id: 'did:cid:vc', credentialSubject: { id: ALICE } });
+            const { app } = mountWith(redacted, { verifyProof: false, deactivated: true });
+
+            expect(await statusOf(app)).toStrictEqual({ status: 'unverified', reason: 'revoked by the issuer' });
+        });
+
         // The endpoint is public and the manifest is written by the profile's
         // owner, so the work per request cannot be left to them.
         it('checks at most fifty entries however long the manifest is', async () => {


### PR DESCRIPTION
The follow-up left open in #946, now unblocked by #948.

## What it fixes

Herald's revocation lookup resolved whatever DID the manifest was keyed by, and that key is unsigned controller data. A holder could take a revoked credential — genuinely issued, correctly signed, still verifying — and file it under a fresh, active asset. Every check passed, because the credential was authentic. Only the pointer lied.

#948 fixed that at the source: a credential now names its own asset as `id`, covered by the issuer's signature. Once the signature verifies, `id` is the issuer's statement about where the credential lives, so a manifest key that disagrees is caught.

## Scope, stated plainly

This closes the re-keying hole **only where it is closable**, which is narrower than it first appears:

| | Covered |
| --- | --- |
| Revealed publication, credential issued since #948 | **yes** |
| Redacted publication (the `publishCredential` default) | no — never verifies, so nothing about it is the issuer's word |
| Credential issued before #948 | no — carries no `id`; unbound, and best effort as before |

So the immediate reach is small and grows as credentials are issued. The check itself costs one string comparison.

Absence of `id` means unbound, not invalid. Older credentials keep exactly the behaviour they had — marking them down for their age would repeat the mistake that made #946's first draft wrong, when redacted publications were going to be reported as forgeries.

## A claim this PR made and withdrew

The first version put revocation ahead of the signature, arguing that `id` survives redaction so a redacted credential could still be reported as revoked. It survives *textually*, which is not the same as surviving *verifiably* — `verifyProof` covers the whole credential except `proof`, so until it passes, no field is the issuer's word for anything.

A holder could therefore re-key a revoked redacted credential to a fresh active asset, rewrite `id` to match, and have it agree with itself. The verdict stayed `unverified` either way, so no green tick was at risk — but the reason would have said "published without its claims" about a credential that was revoked, which reads as benign.

Both the binding comparison and the revocation lookup now sit behind the signature. A credential that cannot be verified yields no revocation claim in either direction.

That order also protects the binding check: a tampered `id` fails on the signature rather than being reported as misfiled, and misfiled is the weaker statement — it implies the rest of the credential was sound.

## Verification

Six tests: a bound credential accepted, one filed under an asset it does not name refused, revocation meaningful for a bound credential, an unbound credential still checked best-effort, no revocation claim about a credential that cannot be verified, and a tampered `id` caught at the signature.

Mutation-checked — removing the id/key comparison fails only the mismatch test; restoring the earlier ordering fails only the test documenting the attack above.

197 herald tests pass; tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)