### PR TITLE
release: archon-keymaster 0.6.3

### DIFF
--- a/python/keymaster/pyproject.toml
+++ b/python/keymaster/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "archon-keymaster"
-version = "0.6.2"
+version = "0.6.3"
 description = "Reusable Python Keymaster core library for Archon"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/python/keymaster_service/pyproject.toml
+++ b/python/keymaster_service/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.12.0"
 description = "Native Python Keymaster service for Archon"
 readme = "README.md"
 dependencies = [
-  "archon-keymaster==0.6.2",
+  "archon-keymaster==0.6.3",
   "fastapi==0.115.12",
   "uvicorn[standard]==0.34.2",
   "prometheus-client==0.21.1",


### PR DESCRIPTION
Back-merge of the Python version bump for the 2026-08-26 release. Published to PyPI by run [33025072499](https://github.com/archetech/archon/actions/runs/33025072499).

`archon-keymaster` is kept in lockstep with `@didcid/keymaster`, which went to `0.6.3` on npm earlier today. Nothing bumps it automatically — lerna covers the JS packages only — so this is the manual half of the same release.

Two files, and the second is the one that gets missed:

| File | Change |
| --- | --- |
| `python/keymaster/pyproject.toml` | `version = "0.6.3"` |
| `python/keymaster_service/pyproject.toml` | `"archon-keymaster==0.6.3"` |

`test_service_dependency_tracks_repo_keymaster_version` asserts those two match. Bumping only the first is how the v0.11.0 back-merge broke its own checks.

## Verification

Ran the full ladder rather than going straight to production:

- **check** — build, `twine check`, wheel install, CLI smoke test
- **testpypi** — published, then downloaded `archon-keymaster-0.6.3` back from the live index and re-ran the smoke test against it, resolving all 30 dependencies
- **pypi** — production, which has no install-back step of its own

Verified afterward in a clean venv with `--no-cache-dir`, so resolution came from the real index rather than a local cache: `archon-keymaster 0.6.3`, imports fine.

## What is in it

The Python port of yesterday's keymaster work:

- credentials name the asset that holds them, `id` embedded before signing (#108)
- remote name lookups check their target on every path, with the private-address guard and redirect-checking fetch mirrored from the TypeScript side (#252)