### PR TITLE
chore: Init v0.13.0

### DIFF
--- a/apps/browser-extension/package-lock.json
+++ b/apps/browser-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "archon-browser-extension",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "archon-browser-extension",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "qrcode.react": "^4.2.0"

--- a/apps/browser-extension/package.json
+++ b/apps/browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archon-browser-extension",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Archon Browser Extension",
   "main": "index.js",
   "scripts": {

--- a/apps/browser-extension/src/static/manifest.firefox.json
+++ b/apps/browser-extension/src/static/manifest.firefox.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Archon Wallet",
     "description": "Archon Wallet",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "icons": {
         "16": "icon.png",
         "48": "icon.png",

--- a/apps/browser-extension/src/static/manifest.json
+++ b/apps/browser-extension/src/static/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Archon Wallet",
     "description": "Archon Wallet",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "icons": {
         "16": "icon.png",
         "48": "icon.png",

--- a/apps/gatekeeper-client/package-lock.json
+++ b/apps/gatekeeper-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatekeeper-client",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatekeeper-client",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/apps/gatekeeper-client/package.json
+++ b/apps/gatekeeper-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatekeeper-client",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/herald-client/package-lock.json
+++ b/apps/herald-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-client",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-client",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.14.1",

--- a/apps/herald-client/package.json
+++ b/apps/herald-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-client",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/keymaster-client/package-lock.json
+++ b/apps/keymaster-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "keymaster-client",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "keymaster-client",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/apps/keymaster-client/package.json
+++ b/apps/keymaster-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymaster-client",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/react-wallet/package-lock.json
+++ b/apps/react-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@didcid/react-wallet",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@didcid/react-wallet",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor-mlkit/barcode-scanning": "^7.3.0",

--- a/apps/react-wallet/package.json
+++ b/apps/react-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/react-wallet",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Archon Android Demo",
   "scripts": {
     "dev": "vite",

--- a/docs/gatekeeper-api.json
+++ b/docs/gatekeeper-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Gatekeeper API",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "description": "Documentation for Gatekeeper API"
   },
   "paths": {

--- a/docs/keymaster-api.json
+++ b/docs/keymaster-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Keymaster API",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "description": "Documentation for Keymaster API"
   },
   "paths": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "archon",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "archon",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "ISC",
       "workspaces": [
         "packages/*"
@@ -28076,7 +28076,7 @@
     },
     "packages/keymaster-ui": {
       "name": "@didcid/keymaster-ui",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "peerDependencies": {
         "@mui/icons-material": "^7.3.5",
@@ -28118,7 +28118,7 @@
     },
     "packages/wallet-ui": {
       "name": "@didcid/wallet-ui",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "peerDependencies": {
         "@mui/icons-material": "^7.3.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archon",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Self-sovereign identity infrastructure for the decentralized web",
   "private": true,

--- a/packages/keymaster-ui/package.json
+++ b/packages/keymaster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/keymaster-ui",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "The Keymaster demo UI shared by the standalone client apps",
   "license": "MIT",
   "type": "module",

--- a/packages/wallet-ui/package.json
+++ b/packages/wallet-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didcid/wallet-ui",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "React components and contexts shared by the Archon wallets",
   "license": "MIT",
   "type": "module",

--- a/python/keymaster_sdk/pyproject.toml
+++ b/python/keymaster_sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "keymaster-sdk"
-version = "0.12.0"
+version = "0.13.0"
 description = "Keymaster is a client library for Archon"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/python/keymaster_service/pyproject.toml
+++ b/python/keymaster_service/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "keymaster-service"
-version = "0.12.0"
+version = "0.13.0"
 description = "Native Python Keymaster service for Archon"
 readme = "README.md"
 dependencies = [

--- a/python/keymaster_service/src/keymaster_service/__init__.py
+++ b/python/keymaster_service/src/keymaster_service/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/python/keymaster_service/src/keymaster_service/config.py
+++ b/python/keymaster_service/src/keymaster_service/config.py
@@ -9,7 +9,7 @@ def _package_version() -> str:
     try:
         return metadata.version("keymaster-service")
     except metadata.PackageNotFoundError:
-        return "0.12.0"
+        return "0.13.0"
 
 
 @dataclass(slots=True)

--- a/rust/services/gatekeeper/Cargo.lock
+++ b/rust/services/gatekeeper/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "archon-rust-gatekeeper"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/rust/services/gatekeeper/Cargo.toml
+++ b/rust/services/gatekeeper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "archon-rust-gatekeeper"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT"
 description = "Native Rust Gatekeeper service for Archon"

--- a/services/didcomm/server/package-lock.json
+++ b/services/didcomm/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "didcomm-server",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "didcomm-server",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.6",

--- a/services/didcomm/server/package.json
+++ b/services/didcomm/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "didcomm-server",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon DIDComm relay (mailbox) server",
   "main": "dist/index.js",

--- a/services/drawbridge/server/package-lock.json
+++ b/services/drawbridge/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drawbridge-server",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drawbridge-server",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",

--- a/services/drawbridge/server/package.json
+++ b/services/drawbridge/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drawbridge-server",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon Drawbridge L402 API Gateway",
   "main": "dist/drawbridge-api.js",

--- a/services/explorer/package-lock.json
+++ b/services/explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "archon-explorer",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "archon-explorer",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/services/explorer/package.json
+++ b/services/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archon-explorer",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "scripts": {
     "start": "npm run build && node server.js",

--- a/services/gatekeeper/server/package-lock.json
+++ b/services/gatekeeper/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatekeeper-server",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatekeeper-server",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.6",

--- a/services/gatekeeper/server/package.json
+++ b/services/gatekeeper/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatekeeper-server",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon Gatekeeper REST API server",
   "main": "src/index.js",

--- a/services/herald/package-lock.json
+++ b/services/herald/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "herald",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "herald",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "hasInstallScript": true,
       "dependencies": {
         "jose": "^6.2.9"

--- a/services/herald/package.json
+++ b/services/herald/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herald",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "scripts": {
     "install": "npm install --prefix server",

--- a/services/herald/server/package-lock.json
+++ b/services/herald/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "herald-server",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "herald-server",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@sendgrid/mail": "^8.1.6",

--- a/services/herald/server/package.json
+++ b/services/herald/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herald-server",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon naming service",
   "main": "dist/index.js",

--- a/services/keymaster/server/package-lock.json
+++ b/services/keymaster/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "keymaster-server",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "keymaster-server",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.6",

--- a/services/keymaster/server/package.json
+++ b/services/keymaster/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymaster-server",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon Keymaster REST API server",
   "main": "src/index.js",

--- a/services/mediators/ethereum-wallet/package-lock.json
+++ b/services/mediators/ethereum-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ethereum-wallet",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ethereum-wallet",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.18.1",

--- a/services/mediators/ethereum-wallet/package.json
+++ b/services/mediators/ethereum-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-wallet",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon Ethereum Wallet Service",
   "main": "dist/wallet-api.js",

--- a/services/mediators/ethereum/package-lock.json
+++ b/services/mediators/ethereum/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ethereum-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ethereum-mediator",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.18.1",

--- a/services/mediators/ethereum/package.json
+++ b/services/mediators/ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon Ethereum blockchain mediator",
   "main": "dist/ethereum-mediator.js",

--- a/services/mediators/filecoin-wallet/package-lock.json
+++ b/services/mediators/filecoin-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filecoin-wallet",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filecoin-wallet",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^2.2.0",

--- a/services/mediators/filecoin-wallet/package.json
+++ b/services/mediators/filecoin-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filecoin-wallet",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon Filecoin Wallet Service",
   "main": "dist/wallet-api.js",

--- a/services/mediators/filecoin/package-lock.json
+++ b/services/mediators/filecoin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "filecoin-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "filecoin-mediator",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.18.0",

--- a/services/mediators/filecoin/package.json
+++ b/services/mediators/filecoin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filecoin-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon Filecoin storage mediator",
   "main": "dist/filecoin-mediator.js",

--- a/services/mediators/hyperswarm/package-lock.json
+++ b/services/mediators/hyperswarm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hyperswarm-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hyperswarm-mediator",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.3.3",

--- a/services/mediators/hyperswarm/package.json
+++ b/services/mediators/hyperswarm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswarm-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon hyperswarm network mediator",
   "main": "src/index.js",

--- a/services/mediators/lightning/package-lock.json
+++ b/services/mediators/lightning/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-mediator",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.18.0",

--- a/services/mediators/lightning/package.json
+++ b/services/mediators/lightning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon Lightning mediator",
   "main": "dist/index.js",

--- a/services/mediators/pinning/package-lock.json
+++ b/services/mediators/pinning/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pinning-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pinning-mediator",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.18.0",

--- a/services/mediators/pinning/package.json
+++ b/services/mediators/pinning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinning-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon generic IPFS pinning mediator",
   "main": "dist/pinning-mediator.js",

--- a/services/mediators/satoshi-wallet/package-lock.json
+++ b/services/mediators/satoshi-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "satoshi-wallet",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "satoshi-wallet",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/services/mediators/satoshi-wallet/package.json
+++ b/services/mediators/satoshi-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satoshi-wallet",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon Satoshi Wallet Service",
   "main": "dist/wallet-api.js",

--- a/services/mediators/satoshi/package-lock.json
+++ b/services/mediators/satoshi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "satoshi-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "satoshi-mediator",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/services/mediators/satoshi/package.json
+++ b/services/mediators/satoshi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satoshi-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon satoshi blockchain mediator",
   "main": "src/index.js",

--- a/services/mediators/solana-wallet/package-lock.json
+++ b/services/mediators/solana-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solana-wallet",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "solana-wallet",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@solana/web3.js": "^1.98.4",

--- a/services/mediators/solana-wallet/package.json
+++ b/services/mediators/solana-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solana-wallet",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon Solana Wallet Service",
   "main": "dist/wallet-api.js",

--- a/services/mediators/solana/package-lock.json
+++ b/services/mediators/solana/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solana-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "solana-mediator",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@solana/web3.js": "^1.98.4",

--- a/services/mediators/solana/package.json
+++ b/services/mediators/solana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solana-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon Solana blockchain mediator",
   "main": "dist/solana-mediator.js",

--- a/services/mediators/zcash-wallet/package-lock.json
+++ b/services/mediators/zcash-wallet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zcash-wallet",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zcash-wallet",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@bitgo/utxo-lib": "^11.22.1",

--- a/services/mediators/zcash-wallet/package.json
+++ b/services/mediators/zcash-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcash-wallet",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon Zcash Transparent Wallet Service",
   "main": "dist/wallet-api.js",

--- a/services/mediators/zcash/package-lock.json
+++ b/services/mediators/zcash/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zcash-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zcash-mediator",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/services/mediators/zcash/package.json
+++ b/services/mediators/zcash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcash-mediator",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "Archon Zcash blockchain mediator",
   "main": "dist/zcash-mediator.js",

--- a/swaggerConf.js
+++ b/swaggerConf.js
@@ -5,7 +5,7 @@ const baseDefinition = {
     openapi: '3.0.0',
     info: {
         title: 'Keymaster API',
-        version: '0.12.0',
+        version: '0.13.0',
         description: 'Documentation for Keymaster API'
     },
 };


### PR DESCRIPTION
Repo-wide sweep of the Archon app/service version after the v0.12.0 release, following #654 (v0.11.0) and #812 (v0.12.0).

Separate axis from the `@didcid/*` npm packages, which lerna versions independently, and from `archon-keymaster`, which tracks `@didcid/keymaster` by hand. `python/keymaster/pyproject.toml` is deliberately untouched.

**65 files, 93 insertions, 93 deletions.**

## Three things a blind sweep would have broken

The version string appears in places that are not the version, so the replacement is anchored to declarations rather than to `0.12.0`.

**Node engine constraints.** Eight read `">=0.12.0"`, and there are also `">=10.12.0"`, `"^10.12.0 || >=12.0.0"` and `">= 20.12.0"` nearby. Bumping those changes what a package claims to run on. A first attempt anchored only against a leading digit — which protected `10.12.0` and `20.12.0` and rewrote all eight bare ones. Reverted and redone.

**Third-party packages that are themselves at 0.12.0.** `retry`, `caseless` and `@sentry/conventions` all sit at that version, so their lockfile entries carry `"version": "0.12.0"` exactly like ours:

| Entry | Ours? |
| --- | --- |
| `node_modules/promise-retry/node_modules/retry` | no |
| `node_modules/@sentry/conventions` | no |
| `node_modules/caseless` (×2) | no |
| `node_modules/retry` | no |
| `packages/keymaster-ui` | **yes** |
| `packages/wallet-ui` | **yes** |

Matched on being under `node_modules/`, so the two workspace packages at the same version still move.

**The generated API docs.** Regenerated with `npm run generate-openapi` rather than edited. That only works because `swaggerConf.js` is in scope — it is the generator's source for the version, and #654 missing it meant regenerating stamped the old number for three weeks.

## Lockfile validation

Validated with `npm install --package-lock-only --ignore-scripts` on the pinned `npm@10.9.2`. The root lockfile and twenty service lockfiles came back byte-identical, which is the signal the sweep was right.

Five did not, and not because of this change: `apps/gatekeeper-client`, `apps/herald-client`, `apps/keymaster-client`, `apps/react-wallet` and `services/explorer` were generated by a newer npm and lose their `libc` fields when 10.9.2 rewrites them — 172 deletions of unrelated metadata. Reverted here and left for its own change.

Worth a follow-up: those five are drifting from the pinned npm, and the next person to run a lockfile command in them will produce the same churn by accident.