### PR TITLE
ci: Build every service image, not fourteen of twenty-six

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -61,6 +61,41 @@ jobs:
             image: herald-client
           - dockerfile: docker/Dockerfile.gatekeeper-client
             image: drawbridge-client
+          # The twelve below were built by nothing until #954. Every Dockerfile
+          # in the repo is referenced by a compose file under docker/compose/,
+          # so each of these is a service somebody can bring up -- they were
+          # simply absent from the matrix, which meant a change breaking one of
+          # them passed every check. The bullseye -> bookworm -> trixie moves in
+          # #890 and #892 crossed two Debian generations without any of them
+          # being compiled once.
+          - dockerfile: docker/Dockerfile.didcomm
+            image: didcomm
+          - dockerfile: docker/Dockerfile.keymaster-py
+            image: keymaster-py
+          - dockerfile: docker/Dockerfile.gatekeeper-rust
+            image: gatekeeper-rust
+          - dockerfile: docker/Dockerfile.pinning
+            image: pinning-mediator
+          # Chain mediators and their wallet sidecars. Named for the chain
+          # rather than the network, the way satoshi/satoshi-wallet already are:
+          # compose picks the network (eth-sepolia, sol-devnet, zcash-mainnet),
+          # and one image serves all of them.
+          - dockerfile: docker/Dockerfile.ethereum
+            image: ethereum-mediator
+          - dockerfile: docker/Dockerfile.ethereum-wallet
+            image: ethereum-wallet
+          - dockerfile: docker/Dockerfile.solana
+            image: solana-mediator
+          - dockerfile: docker/Dockerfile.solana-wallet
+            image: solana-wallet
+          - dockerfile: docker/Dockerfile.zcash
+            image: zcash-mediator
+          - dockerfile: docker/Dockerfile.zcash-wallet
+            image: zcash-wallet
+          - dockerfile: docker/Dockerfile.filecoin
+            image: filecoin-mediator
+          - dockerfile: docker/Dockerfile.filecoin-wallet
+            image: filecoin-wallet
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5


### PR DESCRIPTION
Closes the build half of #954. Publishing is deliberately untouched — that is a separate decision about what belongs in the registry, and it is not what makes breakage silent.

## The gap

Twelve Dockerfiles were compiled by no workflow at all:

`didcomm` · `keymaster-py` · `gatekeeper-rust` · `pinning` · and the chain mediators and wallet sidecars for `ethereum`, `solana`, `zcash`, `filecoin`

A change breaking any of them passed all thirty checks. None are dead files — every Dockerfile in the repo is referenced by a compose file under `docker/compose/`, so each is a service somebody can bring up.

This was not academic for the release just shipped. v0.12.0 moved every image bullseye → bookworm (#890), then bookworm → trixie (#892), and upgraded Node to 22.23.2. Fourteen images proved they survived; twelve were never compiled once. #880 exists because a base-image move broke the hyperswarm mediator on glibc — caught only because hyperswarm was in the matrix.

The Rust gatekeeper was the sharpest case: its tests run in CI and #833 added a TS/Rust parity harness, so the code was covered while the image that would ship it was built by nothing.

## Result

**All 27 legs built successfully** ([run 33179120509](https://github.com/archetech/archon/actions/runs/33179120509)). The orphaned images were sound — so this adds no fixes, only the proof that was missing.

| | Before | After |
| --- | --- | --- |
| Matrix legs | 15 | 27 |
| Slowest leg | 5m | 6m |
| Wall clock | ~5m | **9m** |
| Summed CPU | — | 96m |

Legs run in parallel, so 96 minutes of work completes in 9 minutes of wall time. `build_test_images` is one of the checks branch protection requires, and 9 minutes keeps it comfortably inside the existing envelope.

## Notes

Images are named for the **chain**, not the network, matching the existing `satoshi`/`satoshi-wallet` pair: compose selects `eth-sepolia`, `sol-devnet` or `zcash-mainnet`, and one image serves all of them. Using the compose service names would have produced a `zcash-mainnet-mediator` image that could not serve testnet.

Image names remain unique across the matrix, which matters because the buildx cache scope is keyed on `matrix.image` — a duplicate would make two legs evict each other.

Two figures in #954 were wrong and are corrected here: the workflows have **15** entries, not 16 (my count also caught the metadata step's `images:` line), and adding legs does **not** double the wall clock, since the matrix is parallel.