### PR TITLE
ci: Allow publishing a past ref with the current matrix

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,28 @@ on:
     branches: [ "pre-release" ]
     tags: [ "v*" ]
 
+  # A tag-triggered run uses the workflow file as it existed at that tag, so a
+  # release published before this workflow landed cannot be completed by
+  # re-running it -- the old file carries the old, shorter matrix. Dispatching
+  # from a branch that has this file, against a ref that has the source, is the
+  # only way to combine the two.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Ref to build (tag, branch or SHA). Defaults to the dispatching ref."
+        required: false
+        type: string
+      version:
+        description: "Version tag to publish under, e.g. v0.12.0."
+        required: true
+        type: string
+      channel:
+        description: "Second tag to apply."
+        required: true
+        default: pre-release
+        type: choice
+        options: [pre-release, latest]
+
 env:
   REGISTRY: ghcr.io
 
@@ -32,7 +54,10 @@ jobs:
       - name: Determine version and channel
         id: channel
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+          if [[ -n "${{ inputs.version }}" ]]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "channel=${{ inputs.channel }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
             echo "channel=latest" >> "$GITHUB_OUTPUT"
           else
@@ -131,6 +156,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       # arm64 RUN steps execute under emulation on an amd64 runner, so binfmt
       # has to be registered before buildx. Both workflows this replaces had


### PR DESCRIPTION
v0.12.0 published 6 of 27 images, because the unified publish workflow landed after that release. This adds the only mechanism that can finish the job.

## Why re-running does not work

A tag-triggered workflow uses the workflow file **as it existed at that tag**. `v0.12.0` predates #956, so re-running its run replays the old six-image matrix. Deleting and re-pushing the tag has the same problem, and changes what a published release points at.

What is needed is the **current workflow file** against the **v0.12.0 source** — a combination no push event produces. `workflow_dispatch` does: the file comes from the branch dispatched on, the source from the ref requested.

```
ref      what to build, defaulting to the dispatching ref
version  what to tag it
channel  latest | pre-release
```

The build job's checkout honours `inputs.ref`. The `generate` job's does not need to, since it computes the version and channel and reads no source.

Verified against the tag: all 26 Dockerfiles and `scripts/prefetch-prebuilds.mjs` exist at `v0.12.0`, so the 27-image matrix builds against it unchanged.

## What this will be used for

Dispatching `ref=v0.12.0, version=v0.12.0, channel=latest` publishes the full set for the current release, and moves `latest` onto it — nine images have no `latest` at all today.

## Worth stating plainly

**Rebuilding a released version does not reproduce its bits.** The source is identical, but the Debian and Node base images have moved since 28 August, so what gets published is that version's source built today. Six images already exist at `:v0.12.0` and would be overwritten with different bits.

The alternative — publishing only the 21 missing — avoids that but leaves a release set split across two build dates, six images from August and twenty-one from now. A coherent set built from one source at one time is the better artefact, and Docker tags are mutable by design, so this PR is written for that choice.