### PR TITLE
fix(ci): Stamp images with the commit they were built from

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -159,6 +159,17 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      # Read the commit from the checkout rather than from the event. On a
+      # dispatch, github.sha is the branch the workflow file came from, not the
+      # ref being built -- so a backfill of an older release stamped its images
+      # with the commit of whatever main happened to be, in both GIT_COMMIT and
+      # the OCI revision label. The services report that value at runtime, so
+      # the image claimed a commit it was not built from. Equal to github.sha on
+      # a push, so this is only ever more correct.
+      - name: Record the commit actually built
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       # arm64 RUN steps execute under emulation on an amd64 runner, so binfmt
       # has to be registered before buildx. Both workflows this replaces had
       # this step; the build-only workflow does not, because it is
@@ -197,6 +208,8 @@ jobs:
           tags: |
             type=raw,value=${{ needs.generate.outputs.VERSION }}
             type=raw,value=${{ needs.generate.outputs.CHANNEL }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.source.outputs.sha }}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
@@ -208,7 +221,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64
           build-args: |
-            GIT_COMMIT=${{ github.sha }}
+            GIT_COMMIT=${{ steps.source.outputs.sha }}
 
       - name: Run Anchore vulnerability scanner
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2

--- a/tests/ci/image-matrix.test.ts
+++ b/tests/ci/image-matrix.test.ts
@@ -104,6 +104,25 @@ describe('docker image matrices', () => {
         ]);
     });
 
+    it('takes the commit from the checkout, not from the event', () => {
+        // The publish workflow can be dispatched against a ref other than the
+        // branch carrying the workflow file, so `github.sha` there is the
+        // dispatching branch rather than the code being built. Using it stamped
+        // a v0.12.0 backfill with main's commit, in both GIT_COMMIT and the OCI
+        // revision label -- an image reporting a commit it was not built from,
+        // which is exactly the provenance confusion this repo has spent time
+        // untangling elsewhere.
+        const publishYaml = readFileSync(PUBLISH, 'utf-8');
+
+        // The expression, not the word: the comment explaining why this rule
+        // exists necessarily mentions github.sha.
+        const expressions = publishYaml.match(/\$\{\{[^}]*\}\}/g) ?? [];
+
+        expect(expressions.filter(e => e.includes('github.sha'))).toStrictEqual([]);
+        expect(publishYaml).toMatch(/GIT_COMMIT=\$\{\{ steps\.source\.outputs\.sha \}\}/);
+        expect(publishYaml).toMatch(/org\.opencontainers\.image\.revision=\$\{\{ steps\.source\.outputs\.sha \}\}/);
+    });
+
     it('publishes every image the compose files pull', () => {
         // The compose files under docker/compose are the consumers, so they
         // decide the names. An image published as something else cannot be


### PR DESCRIPTION
The v0.12.0 backfill published 27 images with the right source and the wrong commit.

```
org.opencontainers.image.version:  v0.12.0
org.opencontainers.image.revision: 5929fb5e…   <- main, not c9b76eff
```

Read off the published image, not inferred.

## Cause

`github.sha` on a `workflow_dispatch` is the sha of the branch carrying the workflow file, not the ref being built. #958 wired `inputs.ref` through to the checkout and stopped there — the build arg and the OCI label still came from the event.

The same value reaches `GIT_COMMIT`, which the services report at runtime. So `gatekeeper-ts:v0.12.0` answers with a commit it does not contain — the provenance problem this repo has spent time untangling from the other end, reintroduced at the source.

## Fix

The commit comes from `git rev-parse HEAD` after checkout: equal to `github.sha` on a push, correct on a dispatch. The revision label is now set explicitly rather than left to `docker/metadata-action`, which derives it from the event for the same reason.

## Guard

No expression in this workflow may reference `github.sha`, and both the build arg and the revision label must come from the recorded sha. Restoring either fails the test. The assertion matches `${{ … }}` expressions rather than the bare string, since the comment explaining the rule necessarily mentions it.

## Pattern

This is the second step in this file to assume something about its trigger and be wrong once the trigger changed. The first dropped QEMU by inheriting a single-platform template into a multi-platform workflow; all 42 checks passed with it missing, because nothing in CI builds for arm64.

Adding a trigger means auditing what the existing steps assumed about the old one. Both faults were invisible to CI and caught only by inspection.

## Republishing

The 27 images already published for v0.12.0 carry the wrong revision label. Correcting them means re-dispatching after this merges — about an hour, `gatekeeper-rs` setting the pace. Not done here; worth deciding separately, since the alternative is a released set that misreports its own provenance permanently.