### PR TITLE
perf(ci): Cross-compile the Rust gatekeeper instead of emulating it

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,6 +21,33 @@ jobs:
           calver=$(date +'%Y.%m.%d')
           echo "calver=$calver" >> $GITHUB_OUTPUT
 
+  # The publish workflow builds for arm64, and nothing else does -- so a change
+  # that breaks the cross-compile is invisible until a release. This leg exists
+  # because cross-compiling made it affordable: emulating a Rust build cost 59
+  # minutes, and building it natively for a foreign target does not (#957).
+  #
+  # No scan and no load: those need the image in the local daemon, which a
+  # foreign-architecture build cannot provide. Compiling is what is being
+  # checked here.
+  cross_compile_arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
+
+      - name: Cross-compile the Rust gatekeeper for arm64
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: .
+          file: docker/Dockerfile.gatekeeper-rust
+          platforms: linux/arm64
+          push: false
+          cache-from: type=gha,scope=gatekeeper-rs-arm64
+          cache-to: type=gha,mode=min,scope=gatekeeper-rs-arm64
+
   build_test_images:
     runs-on: ubuntu-latest
     needs: generate

--- a/docker/Dockerfile.gatekeeper-rust
+++ b/docker/Dockerfile.gatekeeper-rust
@@ -1,10 +1,56 @@
-FROM rust:1.90-trixie AS builder
+# The build stage runs on the builder's own architecture and cross-compiles to
+# the target, rather than running under emulation.
+#
+# Emulating it cost 59 minutes of a 63-minute publish -- a Rust release build
+# executed instruction-by-instruction through QEMU, while the other 26 images
+# finished inside that window (#957). Nothing here needs to run as the target
+# architecture; only the output has to be built for it.
+FROM --platform=$BUILDPLATFORM rust:1.90-trixie AS builder
+
+# Set by buildx from --platform, normalised to amd64 / arm64.
+ARG TARGETARCH
 
 WORKDIR /build
+
+# Several dependencies compile C as part of their build: rusqlite is used with
+# `bundled`, so SQLite comes from source, and rustls pulls in ring, which brings
+# its own C. Both need a cross-toolchain for the target.
+#
+# The libc headers are a separate package from the compiler, and
+# --no-install-recommends does not pull them in. Without them the cross gcc runs
+# but its stdint.h reaches /usr/include and fails on bits/libc-header-start.h --
+# a confusing failure, because the compiler is plainly correct and the headers
+# are plainly the host's.
+#
+# The TLS dependencies are rustls rather than OpenSSL, which is what usually
+# makes this painful; ring is C but self-contained.
+RUN set -eux; \
+    case "$TARGETARCH" in \
+        amd64) echo x86_64-unknown-linux-gnu > /target ;; \
+        arm64) echo aarch64-unknown-linux-gnu > /target; \
+               apt-get update; \
+               apt-get install -y --no-install-recommends \
+                   gcc-aarch64-linux-gnu libc6-dev-arm64-cross; \
+               rm -rf /var/lib/apt/lists/* ;; \
+        *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    rustup target add "$(cat /target)"
+
+# Which compiler and linker cargo reaches for when the target is not the host.
+# Harmless on a native build, where the target triple matches and neither is
+# consulted.
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+    CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+
 COPY rust/services/gatekeeper/Cargo.toml ./Cargo.toml
 COPY rust/services/gatekeeper/Cargo.lock ./Cargo.lock
 COPY rust/services/gatekeeper/src ./src
-RUN cargo build --release
+
+# Copied to a fixed path so the runtime stage does not need to know the triple.
+RUN set -eux; \
+    target="$(cat /target)"; \
+    cargo build --release --target "$target"; \
+    cp "target/$target/release/archon-rust-gatekeeper" /archon-rust-gatekeeper
 
 FROM debian:trixie-slim
 
@@ -14,7 +60,7 @@ RUN apt-get update \
 
 WORKDIR /app/gatekeeper
 
-COPY --from=builder /build/target/release/archon-rust-gatekeeper /usr/local/bin/archon-rust-gatekeeper
+COPY --from=builder /archon-rust-gatekeeper /usr/local/bin/archon-rust-gatekeeper
 
 ARG GIT_COMMIT=unknown
 ENV GIT_COMMIT=$GIT_COMMIT


### PR DESCRIPTION
Building this image for arm64 took **59 minutes of a 63-minute publish** — a Rust release build executed instruction by instruction through QEMU, while the other 26 images finished inside that window (#957).

Nothing in that build needs to *run* as the target architecture. Only the output does.

## Result

| | Time |
| --- | --- |
| arm64, emulated (publish run, 28 Aug) | **59m** |
| arm64, cross-compiled (this branch) | **4m** |
| amd64, native (unchanged path) | 5m |

Roughly **15x**. The arm64 build is now marginally faster than amd64, since it stops before the runtime stage's `apt-get`.

## How

The builder stage pins to `$BUILDPLATFORM`, so `cargo` runs natively and emits a foreign-architecture binary via a cross toolchain selected from `TARGETARCH`. Only the runtime stage is the target architecture, and it copies a binary rather than compiling one.

Two things made this tractable, both checked before starting:

- **TLS is rustls, not OpenSSL.** No `openssl-sys` to cross-build, which is what usually makes this painful.
- **But several dependencies compile C** — `rusqlite` is `bundled`, and rustls pulls in `ring` — so a C cross-toolchain is needed alongside the Rust target.

## A wrong turn on the way, since the diagnosis generalises

The first attempt failed inside `ring`. It compiles fine now — the run above shows `Compiling ring v0.17.14` and `Finished release profile in 3m 59s` — but the error is worth recording because it points somewhere misleading:

```
/usr/include/stdint.h:26:10: fatal error: bits/libc-header-start.h: No such file or directory
```

That reads like a missing header. It is a missing **sysroot**. The log shows the cross compiler was selected and invoked correctly — `CC_aarch64_unknown_linux_gnu = Some(aarch64-linux-gnu-gcc)` — and then its `stdint.h` falls through to the host's `/usr/include`, which is amd64-only.

On Debian the target libc headers are a separate package from the compiler, and `--no-install-recommends` does not pull them in. `libc6-dev-arm64-cross` fixes it.

## It verifies itself

A `cross_compile_arm64` job builds this image for arm64 on every push. That leg is why the numbers above exist, and it closes a real hole: **nothing else in CI builds for a foreign architecture**, which is how the QEMU omission in #956 passed 42 checks.

No scan and no load on that leg — both need the image in the local daemon, which a foreign-architecture build cannot provide. Compiling is what is being checked.

## For #957

This changes the economics of the nightly considerably. `gatekeeper-rs` was the long pole at 59 of 63 minutes; at 4 minutes it is unremarkable. The remaining slow legs are the chain mediators at ~30m each, which are Node native modules rather than Rust — a different problem, and worth measuring before assuming the same fix applies.